### PR TITLE
RPE-30: feat(ui): amortization numbers + SVG stacked bar chart

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback } from 'react';
-import { evaluate, SCREENER_METRIC_CONFIG } from '@rpe/engine';
+import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount } from '@rpe/engine';
 import type { DealInputs, ScreenerResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
 import { useScenarios } from './hooks/useScenarios';
@@ -9,6 +9,7 @@ import { DealInputsForm } from './components/inputs/DealInputsForm';
 import { SavedDealsPanel } from './components/SavedDealsPanel';
 import { ScenarioTabs } from './components/ScenarioTabs';
 import { ComparisonPanel } from './components/ComparisonPanel';
+import { AmortizationPanel } from './components/AmortizationPanel';
 import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from './utils/format';
 import type { SavedDeal } from './state/savedDealsSchema';
 
@@ -371,7 +372,14 @@ export function Evaluator() {
           {isComparing ? (
             <ComparisonPanel scenarios={scenarios} resultsList={resultsList} />
           ) : (
-            <ResultsPanel results={activeResults} />
+            <div className="flex flex-col gap-4">
+              <ResultsPanel results={activeResults} />
+              <AmortizationPanel
+                loanAmount={calcLoanAmount(activeInputs)}
+                interestRate={activeInputs.interestRate}
+                loanTermYears={activeInputs.loanTermYears}
+              />
+            </div>
           )}
         </section>
       </main>

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback } from 'react';
-import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount } from '@rpe/engine';
+import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount, normalizeInputs } from '@rpe/engine';
 import type { DealInputs, ScreenerResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
 import { useScenarios } from './hooks/useScenarios';
@@ -268,6 +268,9 @@ export function Evaluator() {
   const activeResults = resultsList[activeIdx] ?? (evaluate(activeInputs) as ScreenerResults);
   const isComparing = scenarios.length > 1;
 
+  /** Normalize active inputs once; used by AmortizationPanel to avoid triple-calling normalizeInputs. */
+  const activeNormalized = useMemo(() => normalizeInputs(activeInputs), [activeInputs]);
+
   const handleLoadDeal = (deal: SavedDeal) => {
     replaceScenarioInputs(activeIdx, deal.inputs);
   };
@@ -375,9 +378,9 @@ export function Evaluator() {
             <div className="flex flex-col gap-4">
               <ResultsPanel results={activeResults} />
               <AmortizationPanel
-                loanAmount={calcLoanAmount(activeInputs)}
-                interestRate={activeInputs.interestRate}
-                loanTermYears={activeInputs.loanTermYears}
+                loanAmount={calcLoanAmount(activeNormalized)}
+                interestRate={activeNormalized.interestRate}
+                loanTermYears={activeNormalized.loanTermYears}
               />
             </div>
           )}

--- a/packages/ui/src/components/AmortizationPanel.tsx
+++ b/packages/ui/src/components/AmortizationPanel.tsx
@@ -1,0 +1,250 @@
+/**
+ * AmortizationPanel — year-by-year loan breakdown + SVG stacked bar chart (RPE-30).
+ *
+ * Props: the three loan primitives needed to run the schedule.
+ * The panel hides itself when loanAmount ≤ 0 (cash purchase).
+ */
+
+import { useMemo, useState } from 'react';
+import { amortize } from '@rpe/engine';
+import { buildAmortizationYears, findCrossoverYear } from '../utils/amortization';
+import { fmtCurrency } from '../utils/format';
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface AmortizationPanelProps {
+  loanAmount: number;
+  interestRate: number;
+  loanTermYears: number;
+}
+
+// ─── SVG chart ────────────────────────────────────────────────────────────────
+
+const CHART_W = 1000;
+const CHART_H = 160;
+const BAR_GAP = 2;
+
+interface ChartProps {
+  years: ReturnType<typeof buildAmortizationYears>;
+  crossoverIdx: number;
+}
+
+function AmortizationChart({ years, crossoverIdx }: ChartProps) {
+  if (years.length === 0) return null;
+
+  const n = years.length;
+  const barW = (CHART_W - BAR_GAP * (n - 1)) / n;
+  // All bars share the same total height (fixed-rate payment is constant).
+  const annualPayment = years[0]!.annualPayment;
+
+  return (
+    <div className="w-full">
+      <svg
+        viewBox={`0 0 ${CHART_W} ${CHART_H + 24}`}
+        className="w-full"
+        aria-label="Amortization chart — principal vs interest per year"
+        role="img"
+      >
+        {years.map((y, i) => {
+          const x = i * (barW + BAR_GAP);
+          const interestH = (y.interestPaid / annualPayment) * CHART_H;
+          const principalH = (y.principalPaid / annualPayment) * CHART_H;
+          const isEven = i % 2 === 0;
+
+          return (
+            <g key={y.year} aria-label={`Year ${y.year}`}>
+              {/* Interest (top — amber) */}
+              <rect
+                x={x}
+                y={0}
+                width={barW}
+                height={interestH}
+                fill="var(--color-accent-dim)"
+                opacity={isEven ? 1 : 0.85}
+              />
+              {/* Principal (bottom — green) */}
+              <rect
+                x={x}
+                y={interestH}
+                width={barW}
+                height={principalH}
+                fill="var(--color-pass)"
+                opacity={isEven ? 1 : 0.85}
+              />
+              {/* Crossover marker */}
+              {i === crossoverIdx && (
+                <rect
+                  x={x - 1}
+                  y={0}
+                  width={barW + 2}
+                  height={CHART_H}
+                  fill="none"
+                  stroke="var(--color-hi)"
+                  strokeWidth={1.5}
+                  opacity={0.4}
+                />
+              )}
+              {/* X-axis label every 5 years (or every year for short terms) */}
+              {(n <= 15 || y.year % 5 === 0 || y.year === 1) && (
+                <text
+                  x={x + barW / 2}
+                  y={CHART_H + 16}
+                  textAnchor="middle"
+                  fontSize={n > 20 ? 28 : 22}
+                  fill="var(--color-lo)"
+                >
+                  {y.year}
+                </text>
+              )}
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-1 text-[10px] text-lo">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ background: 'var(--color-pass)' }} />
+          Principal
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 rounded-sm" style={{ background: 'var(--color-accent-dim)' }} />
+          Interest
+        </span>
+        {crossoverIdx >= 0 && (
+          <span className="text-hi/50">
+            crossover: year {crossoverIdx + 1}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Year table ───────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 10;
+
+interface TableProps {
+  years: ReturnType<typeof buildAmortizationYears>;
+}
+
+function AmortizationTable({ years }: TableProps) {
+  const [page, setPage] = useState(0);
+  const totalPages = Math.ceil(years.length / PAGE_SIZE);
+  const slice = years.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  return (
+    <div>
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-lo text-right border-b border-border">
+            <th className="py-1.5 text-left font-normal">Yr</th>
+            <th className="py-1.5 font-normal">Payment</th>
+            <th className="py-1.5 font-normal">Principal</th>
+            <th className="py-1.5 font-normal">Interest</th>
+            <th className="py-1.5 font-normal">Balance</th>
+          </tr>
+        </thead>
+        <tbody>
+          {slice.map((y) => (
+            <tr
+              key={y.year}
+              className="text-right border-b border-border/50 last:border-b-0 hover:bg-raised/40 transition-colors"
+            >
+              <td className="py-1.5 text-left text-lo">{y.year}</td>
+              <td className="py-1.5 num tabular-nums text-mid">{fmtCurrency(y.annualPayment)}</td>
+              <td className="py-1.5 num tabular-nums text-pass">{fmtCurrency(y.principalPaid)}</td>
+              <td className="py-1.5 num tabular-nums" style={{ color: 'var(--color-accent)' }}>{fmtCurrency(y.interestPaid)}</td>
+              <td className="py-1.5 num tabular-nums text-hi">{fmtCurrency(y.endingBalance)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-2 text-[10px] text-lo">
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+            className="px-2 py-0.5 rounded border border-border disabled:opacity-30 hover:border-accent hover:text-accent transition-colors"
+          >
+            ← prev
+          </button>
+          <span>years {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, years.length)} of {years.length}</span>
+          <button
+            type="button"
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page === totalPages - 1}
+            className="px-2 py-0.5 rounded border border-border disabled:opacity-30 hover:border-accent hover:text-accent transition-colors"
+          >
+            next →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main panel ───────────────────────────────────────────────────────────────
+
+export function AmortizationPanel({ loanAmount, interestRate, loanTermYears }: AmortizationPanelProps) {
+  const data = useMemo(() => {
+    if (loanAmount <= 0) return null;
+    const schedule = amortize(loanAmount, interestRate, loanTermYears);
+    if (!schedule) return null;
+    const years = buildAmortizationYears(schedule);
+    const crossoverIdx = findCrossoverYear(years);
+    const totalInterest = schedule.totalInterest;
+    return { years, crossoverIdx, totalInterest };
+  }, [loanAmount, interestRate, loanTermYears]);
+
+  if (!data || data.years.length === 0) return null;
+
+  const { years, crossoverIdx, totalInterest } = data;
+  const firstYear = years[0]!;
+  const lastYear = years[years.length - 1]!;
+
+  return (
+    <details className="group rounded border border-border bg-surface overflow-hidden">
+      <summary className="flex items-center justify-between px-4 py-2 cursor-pointer bg-raised border-b border-border hover:bg-raised/80 transition-colors select-none list-none">
+        <h3 className="section-title text-xs">Amortization Schedule</h3>
+        <span className="text-[10px] text-lo group-open:hidden">
+          {loanTermYears}yr · {fmtCurrency(totalInterest, false)} total interest
+        </span>
+        <span className="text-[10px] text-lo hidden group-open:inline">▲ collapse</span>
+      </summary>
+
+      <div className="px-4 py-4 flex flex-col gap-5">
+
+        {/* Summary stats */}
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <p className="text-[10px] text-lo mb-0.5">Annual payment</p>
+            <p className="num text-sm tabular-nums text-hi">{fmtCurrency(firstYear.annualPayment)}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-lo mb-0.5">Total interest</p>
+            <p className="num text-sm tabular-nums" style={{ color: 'var(--color-accent)' }}>
+              {fmtCurrency(totalInterest, false)}
+            </p>
+          </div>
+          <div>
+            <p className="text-[10px] text-lo mb-0.5">Final balance</p>
+            <p className="num text-sm tabular-nums text-pass">
+              {fmtCurrency(lastYear.endingBalance, false)}
+            </p>
+          </div>
+        </div>
+
+        {/* Chart */}
+        <AmortizationChart years={years} crossoverIdx={crossoverIdx} />
+
+        {/* Table */}
+        <AmortizationTable years={years} />
+
+      </div>
+    </details>
+  );
+}

--- a/packages/ui/src/components/AmortizationPanel.tsx
+++ b/packages/ui/src/components/AmortizationPanel.tsx
@@ -34,8 +34,10 @@ function AmortizationChart({ years, crossoverIdx }: ChartProps) {
 
   const n = years.length;
   const barW = (CHART_W - BAR_GAP * (n - 1)) / n;
-  // All bars share the same total height (fixed-rate payment is constant).
-  const annualPayment = years[0]!.annualPayment;
+  // Scale against the maximum annual payment so each bar fills the chart height
+  // proportionally. Using per-bar max (rather than years[0]) correctly handles
+  // partial final years or any floating-point rounding in the amortization schedule.
+  const maxPayment = Math.max(...years.map((y) => y.annualPayment));
 
   return (
     <div className="w-full">
@@ -47,8 +49,9 @@ function AmortizationChart({ years, crossoverIdx }: ChartProps) {
       >
         {years.map((y, i) => {
           const x = i * (barW + BAR_GAP);
-          const interestH = (y.interestPaid / annualPayment) * CHART_H;
-          const principalH = (y.principalPaid / annualPayment) * CHART_H;
+          const denom = maxPayment > 0 ? maxPayment : 1;
+          const interestH = (y.interestPaid / denom) * CHART_H;
+          const principalH = (y.principalPaid / denom) * CHART_H;
           const isEven = i % 2 === 0;
 
           return (

--- a/packages/ui/src/components/AmortizationPanel.tsx
+++ b/packages/ui/src/components/AmortizationPanel.tsx
@@ -5,7 +5,7 @@
  * The panel hides itself when loanAmount ≤ 0 (cash purchase).
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { amortize } from '@rpe/engine';
 import { buildAmortizationYears, findCrossoverYear } from '../utils/amortization';
 import { fmtCurrency } from '../utils/format';
@@ -131,6 +131,8 @@ interface TableProps {
 
 function AmortizationTable({ years }: TableProps) {
   const [page, setPage] = useState(0);
+  // Reset to first page whenever the schedule length changes (e.g. loan term edited).
+  useEffect(() => { setPage(0); }, [years.length]);
   const totalPages = Math.ceil(years.length / PAGE_SIZE);
   const slice = years.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 

--- a/packages/ui/src/components/AmortizationPanel.tsx
+++ b/packages/ui/src/components/AmortizationPanel.tsx
@@ -56,28 +56,28 @@ function AmortizationChart({ years, crossoverIdx }: ChartProps) {
 
           return (
             <g key={y.year} aria-label={`Year ${y.year}`}>
-              {/* Interest (top — amber) */}
+              {/* Interest (top segment — amber); bars are bottom-aligned, growing up from CHART_H. */}
               <rect
                 x={x}
-                y={0}
+                y={CHART_H - principalH - interestH}
                 width={barW}
                 height={interestH}
                 fill="var(--color-accent-dim)"
                 opacity={isEven ? 1 : 0.85}
               />
-              {/* Principal (bottom — green) */}
+              {/* Principal (bottom segment — green) */}
               <rect
                 x={x}
-                y={interestH}
+                y={CHART_H - principalH}
                 width={barW}
                 height={principalH}
                 fill="var(--color-pass)"
                 opacity={isEven ? 1 : 0.85}
               />
-              {/* Crossover marker */}
+              {/* Crossover marker — x clamped to 0 so the year-1 outline stays in-bounds. */}
               {i === crossoverIdx && (
                 <rect
-                  x={x - 1}
+                  x={Math.max(0, x - 1)}
                   y={0}
                   width={barW + 2}
                   height={CHART_H}

--- a/packages/ui/src/utils/amortization.ts
+++ b/packages/ui/src/utils/amortization.ts
@@ -70,8 +70,9 @@ export function buildAmortizationYears(schedule: AmortizationSchedule): Amortiza
 }
 
 /**
- * Returns the year index (0-based) where principal paid first exceeds interest paid
- * within a single year. Returns -1 if the crossover never occurs (e.g. interest-only).
+ * Returns the year index (0-based) where principal paid first meets or exceeds
+ * interest paid within a single year. Returns -1 if the crossover never occurs
+ * (e.g. interest-only loans where principal never catches up).
  */
 export function findCrossoverYear(years: AmortizationYear[]): number {
   return years.findIndex((y) => y.principalPaid >= y.interestPaid);

--- a/packages/ui/src/utils/amortization.ts
+++ b/packages/ui/src/utils/amortization.ts
@@ -1,0 +1,78 @@
+/**
+ * Amortization schedule utilities (RPE-30).
+ *
+ * Pure functions — no React, no DOM.
+ */
+
+import type { AmortizationSchedule } from '@rpe/engine';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AmortizationYear {
+  /** 1-indexed. */
+  year: number;
+  /** Total payments made during the year. */
+  annualPayment: number;
+  /** Principal repaid during the year. */
+  principalPaid: number;
+  /** Interest paid during the year. */
+  interestPaid: number;
+  /** Remaining balance at end of year. */
+  endingBalance: number;
+  /** Running total principal repaid through this year. */
+  cumulativePrincipal: number;
+  /** Running total interest paid through this year. */
+  cumulativeInterest: number;
+}
+
+// ─── Aggregator ───────────────────────────────────────────────────────────────
+
+/**
+ * Aggregate a monthly amortization schedule into year-by-year summaries.
+ *
+ * Returns an array of length `ceil(rows.length / 12)` — one entry per year of the
+ * loan term, including any partial final year (e.g. a 10-month loan → 1 year entry).
+ */
+export function buildAmortizationYears(schedule: AmortizationSchedule): AmortizationYear[] {
+  const { rows } = schedule;
+  if (rows.length === 0) return [];
+
+  const termYears = Math.ceil(rows.length / 12);
+  const years: AmortizationYear[] = [];
+  let cumulativePrincipal = 0;
+  let cumulativeInterest = 0;
+
+  for (let y = 1; y <= termYears; y++) {
+    const start = (y - 1) * 12;
+    const end = Math.min(y * 12, rows.length);
+    const slice = rows.slice(start, end);
+
+    const annualPayment = slice.reduce((s, r) => s + r.payment, 0);
+    const principalPaid = slice.reduce((s, r) => s + r.principal, 0);
+    const interestPaid = slice.reduce((s, r) => s + r.interest, 0);
+    const endingBalance = slice[slice.length - 1]?.balance ?? 0;
+
+    cumulativePrincipal += principalPaid;
+    cumulativeInterest += interestPaid;
+
+    years.push({
+      year: y,
+      annualPayment,
+      principalPaid,
+      interestPaid,
+      endingBalance,
+      cumulativePrincipal,
+      cumulativeInterest,
+    });
+  }
+
+  return years;
+}
+
+/**
+ * Returns the year index (0-based) where principal paid first exceeds interest paid
+ * within a single year. Returns -1 if the crossover never occurs (e.g. interest-only).
+ */
+export function findCrossoverYear(years: AmortizationYear[]): number {
+  return years.findIndex((y) => y.principalPaid >= y.interestPaid);
+}

--- a/packages/ui/tests/amortization.test.ts
+++ b/packages/ui/tests/amortization.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { amortize } from '@rpe/engine';
+import { buildAmortizationYears, findCrossoverYear } from '../src/utils/amortization';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/** 30-year, $240,000 @ 7% loan */
+function schedule30() {
+  const s = amortize(240_000, 7, 30);
+  if (!s) throw new Error('amortize returned null');
+  return s;
+}
+
+/** 5-year, $50,000 @ 6% loan — short term for edge cases */
+function schedule5() {
+  const s = amortize(50_000, 6, 5);
+  if (!s) throw new Error('amortize returned null');
+  return s;
+}
+
+// ─── buildAmortizationYears ───────────────────────────────────────────────────
+
+describe('buildAmortizationYears', () => {
+  it('returns 30 entries for a 30-year schedule', () => {
+    expect(buildAmortizationYears(schedule30()).length).toBe(30);
+  });
+
+  it('returns 5 entries for a 5-year schedule', () => {
+    expect(buildAmortizationYears(schedule5()).length).toBe(5);
+  });
+
+  it('year numbers are 1-indexed and sequential', () => {
+    const years = buildAmortizationYears(schedule5());
+    expect(years.map((y) => y.year)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('annualPayment ≈ monthly payment × 12', () => {
+    const s = schedule30();
+    const monthlyPayment = s.rows[0]!.payment;
+    const years = buildAmortizationYears(s);
+    expect(years[0]!.annualPayment).toBeCloseTo(monthlyPayment * 12, 2);
+  });
+
+  it('annualPayment = principalPaid + interestPaid for each year', () => {
+    const years = buildAmortizationYears(schedule30());
+    for (const y of years) {
+      expect(y.annualPayment).toBeCloseTo(y.principalPaid + y.interestPaid, 6);
+    }
+  });
+
+  it('endingBalance at final year is ≈ 0 (fully amortized)', () => {
+    const years = buildAmortizationYears(schedule30());
+    expect(years[29]!.endingBalance).toBeCloseTo(0, 0);
+  });
+
+  it('endingBalance decreases each year', () => {
+    const years = buildAmortizationYears(schedule30());
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]!.endingBalance).toBeLessThan(years[i - 1]!.endingBalance);
+    }
+  });
+
+  it('principalPaid increases each year (more goes to principal as balance falls)', () => {
+    const years = buildAmortizationYears(schedule30());
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]!.principalPaid).toBeGreaterThan(years[i - 1]!.principalPaid);
+    }
+  });
+
+  it('interestPaid decreases each year', () => {
+    const years = buildAmortizationYears(schedule30());
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]!.interestPaid).toBeLessThan(years[i - 1]!.interestPaid);
+    }
+  });
+
+  it('cumulativePrincipal is the running sum of principalPaid', () => {
+    const years = buildAmortizationYears(schedule30());
+    let running = 0;
+    for (const y of years) {
+      running += y.principalPaid;
+      expect(y.cumulativePrincipal).toBeCloseTo(running, 6);
+    }
+  });
+
+  it('cumulativeInterest is the running sum of interestPaid', () => {
+    const years = buildAmortizationYears(schedule30());
+    let running = 0;
+    for (const y of years) {
+      running += y.interestPaid;
+      expect(y.cumulativeInterest).toBeCloseTo(running, 6);
+    }
+  });
+
+  it('total cumulative interest matches schedule.totalInterest', () => {
+    const s = schedule30();
+    const years = buildAmortizationYears(s);
+    const totalInterest = years[years.length - 1]!.cumulativeInterest;
+    expect(totalInterest).toBeCloseTo(s.totalInterest, 2);
+  });
+
+  it('total cumulative principal ≈ original loan amount', () => {
+    const s = schedule30();
+    const years = buildAmortizationYears(s);
+    const totalPrincipal = years[years.length - 1]!.cumulativePrincipal;
+    expect(totalPrincipal).toBeCloseTo(240_000, 0);
+  });
+
+  it('returns empty array for schedule with 0 rows', () => {
+    expect(buildAmortizationYears({ rows: [], totalInterest: 0 })).toEqual([]);
+  });
+});
+
+// ─── findCrossoverYear ────────────────────────────────────────────────────────
+
+describe('findCrossoverYear', () => {
+  it('returns -1 for empty years array', () => {
+    expect(findCrossoverYear([])).toBe(-1);
+  });
+
+  it('returns a valid index for a standard 30-year loan at 7%', () => {
+    const years = buildAmortizationYears(schedule30());
+    const idx = findCrossoverYear(years);
+    // At 7%, crossover happens somewhere in the second half of the term
+    expect(idx).toBeGreaterThan(0);
+    expect(idx).toBeLessThan(years.length);
+  });
+
+  it('at the crossover year, principalPaid >= interestPaid', () => {
+    const years = buildAmortizationYears(schedule30());
+    const idx = findCrossoverYear(years);
+    if (idx >= 0) {
+      expect(years[idx]!.principalPaid).toBeGreaterThanOrEqual(years[idx]!.interestPaid);
+    }
+  });
+
+  it('before crossover year, principalPaid < interestPaid', () => {
+    const years = buildAmortizationYears(schedule30());
+    const idx = findCrossoverYear(years);
+    if (idx > 0) {
+      expect(years[idx - 1]!.principalPaid).toBeLessThan(years[idx - 1]!.interestPaid);
+    }
+  });
+
+  it('returns index 0 for a 0% interest loan (principal always ≥ interest)', () => {
+    const s = amortize(10_000, 0, 5);
+    if (!s) return; // guard
+    const years = buildAmortizationYears(s);
+    expect(findCrossoverYear(years)).toBe(0);
+  });
+});

--- a/packages/ui/tests/amortization.test.ts
+++ b/packages/ui/tests/amortization.test.ts
@@ -144,7 +144,8 @@ describe('findCrossoverYear', () => {
 
   it('returns index 0 for a 0% interest loan (principal always ≥ interest)', () => {
     const s = amortize(10_000, 0, 5);
-    if (!s) return; // guard
+    expect(s).not.toBeNull();
+    if (!s) return; // narrow type for TS
     const years = buildAmortizationYears(s);
     expect(findCrossoverYear(years)).toBe(0);
   });


### PR DESCRIPTION
## Summary

- New `buildAmortizationYears()` pure util aggregates the monthly engine schedule into annual summaries (payment / principal / interest / balance / cumulative totals)
- New `AmortizationPanel` collapsible component rendered below `ResultsPanel` in single-scenario view — hidden automatically for cash purchases
- Pure SVG stacked bar chart: principal (green) bottom, interest (amber) top, crossover-year marker, responsive `viewBox`
- Paginated 10-row/year table with color-coded principal/interest columns
- No new dependencies — built entirely with SVG + Tailwind

## Test plan

- [ ] 19 new tests in `amortization.test.ts` — all passing (340 total)
- [ ] TypeScript typecheck clean across all 4 packages
- [ ] Verify panel renders collapsed by default below screener results
- [ ] Verify panel hides when `percentDown = 100` (cash purchase)
- [ ] Verify chart shows interest-heavy bars early → principal-heavy late for 30yr loan
- [ ] Verify pagination works for 30-year (3 pages of 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)