### PR TITLE
RPE-35: feat(ui): screener↔pro-forma toggle with projection panel

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -359,7 +359,7 @@ export function Evaluator() {
           <h1 className="font-display text-xl tracking-wide text-hi">
             Rental Property Evaluator
           </h1>
-          <span className="hidden text-xs text-lo sm:inline">Screener</span>
+          <span className="hidden text-xs text-lo sm:inline">{proFormaMode ? 'Pro-Forma' : 'Screener'}</span>
         </div>
         <div className="no-print flex items-center gap-2">
           <ModeToggle proFormaMode={proFormaMode} onChange={handleSetProFormaMode} />

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -336,7 +336,14 @@ export function Evaluator() {
   const activeNormalized = useMemo(() => normalizeInputs(activeInputs), [activeInputs]);
   const proFormaResults = useMemo<ProFormaResults | null>(() => {
     if (!proFormaMode) return null;
-    return evaluate(activeNormalized, { mode: 'proforma' }) as ProFormaResults;
+    // Strip zero-valued optional rate fields so the engine treats them as "unset"
+    // (0 !== undefined in engine checks, but 0% tax/hurdle has no practical meaning).
+    const pfInputs: DealInputs = {
+      ...activeNormalized,
+      marginalTaxPct: activeNormalized.marginalTaxPct || undefined,
+      discountRatePct: activeNormalized.discountRatePct || undefined,
+    };
+    return evaluate(pfInputs, { mode: 'proforma' }) as ProFormaResults;
   }, [proFormaMode, activeNormalized]);
 
   const handleLoadDeal = (deal: SavedDeal) => {

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useCallback } from 'react';
 import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount, normalizeInputs } from '@rpe/engine';
-import type { DealInputs, ScreenerResults } from '@rpe/engine';
+import type { DealInputs, ScreenerResults, ProFormaResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
 import { useScenarios } from './hooks/useScenarios';
 import { buildShareUrl } from './utils/shareUrl';
@@ -10,6 +10,7 @@ import { SavedDealsPanel } from './components/SavedDealsPanel';
 import { ScenarioTabs } from './components/ScenarioTabs';
 import { ComparisonPanel } from './components/ComparisonPanel';
 import { AmortizationPanel } from './components/AmortizationPanel';
+import { ProFormaPanel } from './components/ProFormaPanel';
 import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from './utils/format';
 import type { SavedDeal } from './state/savedDealsSchema';
 
@@ -201,6 +202,48 @@ function ResultsPanel({ results }: { results: ScreenerResults }) {
   );
 }
 
+// ─── Mode toggle ─────────────────────────────────────────────────────────────
+
+interface ModeToggleProps {
+  proFormaMode: boolean;
+  onChange: (pf: boolean) => void;
+}
+
+function ModeToggle({ proFormaMode, onChange }: ModeToggleProps) {
+  return (
+    <div
+      className="flex rounded border border-border text-xs overflow-hidden"
+      role="group"
+      aria-label="Evaluation mode"
+    >
+      <button
+        type="button"
+        onClick={() => onChange(false)}
+        className={`px-3 py-1.5 uppercase tracking-widest transition-colors ${
+          !proFormaMode
+            ? 'bg-accent text-base font-semibold'
+            : 'text-lo hover:text-mid hover:bg-raised'
+        }`}
+        aria-pressed={!proFormaMode}
+      >
+        Screener
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange(true)}
+        className={`px-3 py-1.5 uppercase tracking-widest transition-colors border-l border-border ${
+          proFormaMode
+            ? 'bg-accent text-base font-semibold'
+            : 'text-lo hover:text-mid hover:bg-raised'
+        }`}
+        aria-pressed={proFormaMode}
+      >
+        Pro-Forma
+      </button>
+    </div>
+  );
+}
+
 // ─── Share button ─────────────────────────────────────────────────────────────
 
 function ShareButton({ inputs }: { inputs: DealInputs }) {
@@ -259,6 +302,27 @@ export function Evaluator() {
 
   const { deals, save, rename, remove } = useSavedDeals();
 
+  const [proFormaMode, setProFormaMode] = useState(false);
+
+  /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
+  const handleSetProFormaMode = useCallback((pf: boolean) => {
+    setProFormaMode(pf);
+    if (pf) {
+      // Only dispatch defaults for fields that are currently undefined/absent so we
+      // don't overwrite values the user has already entered.
+      if (activeInputs.holdYears === undefined)
+        dispatchToActive({ type: 'SET_NUMBER', field: 'holdYears', value: 5 });
+      if (activeInputs.rentGrowthPct === undefined)
+        dispatchToActive({ type: 'SET_NUMBER', field: 'rentGrowthPct', value: 2 });
+      if (activeInputs.expenseGrowthPct === undefined)
+        dispatchToActive({ type: 'SET_NUMBER', field: 'expenseGrowthPct', value: 2 });
+      if (activeInputs.appreciationPct === undefined)
+        dispatchToActive({ type: 'SET_NUMBER', field: 'appreciationPct', value: 3 });
+      if (activeInputs.sellingCostsPct === undefined)
+        dispatchToActive({ type: 'SET_NUMBER', field: 'sellingCostsPct', value: 6 });
+    }
+  }, [activeInputs, dispatchToActive]);
+
   /** Evaluate all scenarios; recomputes only when scenario inputs change. */
   const resultsList = useMemo(
     () => scenarios.map((s) => evaluate(s.inputs) as ScreenerResults),
@@ -268,8 +332,12 @@ export function Evaluator() {
   const activeResults = resultsList[activeIdx] ?? (evaluate(activeInputs) as ScreenerResults);
   const isComparing = scenarios.length > 1;
 
-  /** Normalize active inputs once; used by AmortizationPanel to avoid triple-calling normalizeInputs. */
+  /** Normalize active inputs once; used by AmortizationPanel and pro-forma mode. */
   const activeNormalized = useMemo(() => normalizeInputs(activeInputs), [activeInputs]);
+  const proFormaResults = useMemo<ProFormaResults | null>(() => {
+    if (!proFormaMode) return null;
+    return evaluate(activeNormalized, { mode: 'proforma' }) as ProFormaResults;
+  }, [proFormaMode, activeNormalized]);
 
   const handleLoadDeal = (deal: SavedDeal) => {
     replaceScenarioInputs(activeIdx, deal.inputs);
@@ -294,6 +362,7 @@ export function Evaluator() {
           <span className="hidden text-xs text-lo sm:inline">Screener</span>
         </div>
         <div className="no-print flex items-center gap-2">
+          <ModeToggle proFormaMode={proFormaMode} onChange={handleSetProFormaMode} />
           <SavedDealsPanel
             currentInputs={activeInputs}
             deals={deals}
@@ -360,7 +429,11 @@ export function Evaluator() {
             onRename={renameScenario}
           />
           <div className="flex-1 overflow-y-auto">
-            <DealInputsForm state={activeInputs} dispatch={dispatchToActive} />
+            <DealInputsForm
+              state={activeInputs}
+              dispatch={dispatchToActive}
+              proFormaMode={proFormaMode}
+            />
           </div>
         </aside>
 
@@ -372,7 +445,9 @@ export function Evaluator() {
           aria-atomic="false"
           className="overflow-y-auto p-5"
         >
-          {isComparing ? (
+          {proFormaMode && proFormaResults ? (
+            <ProFormaPanel results={proFormaResults} />
+          ) : isComparing ? (
             <ComparisonPanel scenarios={scenarios} resultsList={resultsList} />
           ) : (
             <div className="flex flex-col gap-4">

--- a/packages/ui/src/components/ProFormaPanel.tsx
+++ b/packages/ui/src/components/ProFormaPanel.tsx
@@ -14,13 +14,14 @@ interface KpiCardProps {
   label: string;
   value: string;
   sub?: string;
-  tone?: 'pass' | 'warn' | 'hi' | 'lo';
+  tone?: 'pass' | 'warn' | 'fail' | 'hi' | 'lo';
 }
 
 function KpiCard({ label, value, sub, tone = 'hi' }: KpiCardProps) {
   const valueClass =
     tone === 'pass' ? 'text-pass' :
     tone === 'warn' ? 'text-warn' :
+    tone === 'fail' ? 'text-fail' :
     tone === 'lo'   ? 'text-lo'   : 'text-hi';
 
   return (
@@ -168,7 +169,7 @@ export function ProFormaPanel({ results }: ProFormaPanelProps) {
   const isEmpty = projection.length === 0;
 
   // IRR signal
-  const irrTone = irr === null ? 'lo' : irr >= 15 ? 'pass' : irr >= 8 ? 'warn' : 'hi';
+  const irrTone = irr === null ? 'lo' : irr >= 15 ? 'pass' : irr >= 8 ? 'warn' : 'fail';
   // Total profit tone
   const profitTone = totalProfit === null ? 'lo' : totalProfit >= 0 ? 'pass' : 'warn';
 

--- a/packages/ui/src/components/ProFormaPanel.tsx
+++ b/packages/ui/src/components/ProFormaPanel.tsx
@@ -1,0 +1,232 @@
+/**
+ * ProFormaPanel — hold-period analysis display (RPE-35).
+ *
+ * Shows: summary KPI cards (IRR, equity multiple, net sale proceeds, total profit, NPV)
+ * followed by a year-by-year projection table.
+ */
+
+import type { ProFormaResults, ProjectionYear } from '@rpe/engine';
+import { fmtCurrency, fmtPercent, fmtMultiplier, NULL_DISPLAY } from '../utils/format';
+
+// ─── KPI card ─────────────────────────────────────────────────────────────────
+
+interface KpiCardProps {
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: 'pass' | 'warn' | 'hi' | 'lo';
+}
+
+function KpiCard({ label, value, sub, tone = 'hi' }: KpiCardProps) {
+  const valueClass =
+    tone === 'pass' ? 'text-pass' :
+    tone === 'warn' ? 'text-warn' :
+    tone === 'lo'   ? 'text-lo'   : 'text-hi';
+
+  return (
+    <div className="rounded border border-border bg-surface px-4 py-3 flex flex-col gap-0.5 min-w-0">
+      <span className="text-[10px] text-lo uppercase tracking-widest truncate">{label}</span>
+      <span className={`num text-base font-mono tabular-nums font-semibold ${valueClass}`}>
+        {value}
+      </span>
+      {sub && <span className="text-[10px] text-lo">{sub}</span>}
+    </div>
+  );
+}
+
+// ─── Projection table ─────────────────────────────────────────────────────────
+
+interface ProjectionTableProps {
+  rows: ProjectionYear[];
+}
+
+function ProjectionTable({ rows }: ProjectionTableProps) {
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto rounded border border-border bg-surface">
+      <table className="w-full text-xs whitespace-nowrap">
+        <thead>
+          <tr className="text-right text-lo border-b border-border bg-raised">
+            <th className="px-3 py-2 text-left font-normal sticky left-0 bg-raised z-10">Yr</th>
+            <th className="px-3 py-2 font-normal">NOI / yr</th>
+            <th className="px-3 py-2 font-normal">Debt Svc</th>
+            <th className="px-3 py-2 font-normal">Cash Flow</th>
+            <th className="px-3 py-2 font-normal">Cum. CF</th>
+            <th className="px-3 py-2 font-normal">After-Tax CF</th>
+            <th className="px-3 py-2 font-normal">Prop. Value</th>
+            <th className="px-3 py-2 font-normal">Loan Bal.</th>
+            <th className="px-3 py-2 font-normal">Equity</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((y) => {
+            const cfColor = y.cashFlowAnnual >= 0 ? 'text-pass' : 'text-fail';
+            const cumColor = y.cumulativeCashFlow >= 0 ? 'text-pass' : 'text-fail';
+            return (
+              <tr
+                key={y.year}
+                className="text-right border-b border-border/50 last:border-b-0 hover:bg-raised/40 transition-colors"
+              >
+                <td className="px-3 py-1.5 text-left text-lo font-mono sticky left-0 bg-surface z-10">
+                  {y.year}
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-mid">
+                  {fmtCurrency(y.noiAnnual)}
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-lo">
+                  {fmtCurrency(y.annualDebtService)}
+                </td>
+                <td className={`px-3 py-1.5 num tabular-nums font-semibold ${cfColor}`}>
+                  {fmtCurrency(y.cashFlowAnnual)}
+                </td>
+                <td className={`px-3 py-1.5 num tabular-nums ${cumColor}`}>
+                  {fmtCurrency(y.cumulativeCashFlow)}
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-mid">
+                  {y.taxSavings > 0
+                    ? fmtCurrency(y.cashFlowAfterTax)
+                    : <span className="text-lo">{fmtCurrency(y.cashFlowAfterTax)}</span>
+                  }
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-mid">
+                  {fmtCurrency(y.propertyValue)}
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-lo">
+                  {fmtCurrency(y.loanBalance)}
+                </td>
+                <td className="px-3 py-1.5 num tabular-nums text-hi font-semibold">
+                  {fmtCurrency(y.equity)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ─── Exit summary row ─────────────────────────────────────────────────────────
+
+interface ExitSummaryProps {
+  salePrice: number | null;
+  sellingCosts: number | null;
+  netSaleProceeds: number | null;
+}
+
+function ExitSummary({ salePrice, sellingCosts, netSaleProceeds }: ExitSummaryProps) {
+  if (salePrice === null) return null;
+  return (
+    <div className="rounded border border-border bg-surface px-4 py-3">
+      <p className="text-[10px] text-lo uppercase tracking-widest mb-2">Exit at Sale</p>
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs">
+        <span className="text-mid">
+          Gross sale price:{' '}
+          <span className="num tabular-nums text-hi">{fmtCurrency(salePrice)}</span>
+        </span>
+        <span className="text-mid">
+          Selling costs:{' '}
+          <span className="num tabular-nums text-fail">
+            {sellingCosts !== null ? `(${fmtCurrency(sellingCosts)})` : NULL_DISPLAY}
+          </span>
+        </span>
+        <span className="text-mid">
+          Net proceeds:{' '}
+          <span className="num tabular-nums text-pass font-semibold">
+            {netSaleProceeds !== null ? fmtCurrency(netSaleProceeds) : NULL_DISPLAY}
+          </span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyProForma() {
+  return (
+    <div className="rounded border border-border bg-surface px-6 py-8 text-center text-sm text-lo">
+      Set a <span className="text-mid">Hold Period</span> in the Pro-Forma Settings to generate
+      the projection.
+    </div>
+  );
+}
+
+// ─── Main panel ───────────────────────────────────────────────────────────────
+
+export interface ProFormaPanelProps {
+  results: ProFormaResults;
+}
+
+export function ProFormaPanel({ results }: ProFormaPanelProps) {
+  const { projection, irr, npv, equityMultiple, netSaleProceeds, totalProfit,
+          salePrice, sellingCosts } = results;
+
+  const isEmpty = projection.length === 0;
+
+  // IRR signal
+  const irrTone = irr === null ? 'lo' : irr >= 15 ? 'pass' : irr >= 8 ? 'warn' : 'hi';
+  // Total profit tone
+  const profitTone = totalProfit === null ? 'lo' : totalProfit >= 0 ? 'pass' : 'warn';
+
+  return (
+    <div className="flex flex-col gap-4">
+
+      {/* ── KPI summary ──────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <KpiCard
+          label="Total Profit"
+          value={totalProfit !== null ? fmtCurrency(totalProfit, false) : NULL_DISPLAY}
+          sub="cumulative incl. sale"
+          tone={profitTone}
+        />
+        <KpiCard
+          label="IRR"
+          value={irr !== null ? fmtPercent(irr, 1) : NULL_DISPLAY}
+          sub="annualised return"
+          tone={irrTone}
+        />
+        <KpiCard
+          label="Equity Multiple"
+          value={equityMultiple !== null ? fmtMultiplier(equityMultiple, 2) : NULL_DISPLAY}
+          sub="total capital returned"
+          tone={equityMultiple !== null && equityMultiple >= 1.5 ? 'pass' : 'hi'}
+        />
+        <KpiCard
+          label="Net Sale Proceeds"
+          value={netSaleProceeds !== null ? fmtCurrency(netSaleProceeds, false) : NULL_DISPLAY}
+          sub="after mortgage + selling costs"
+        />
+        <KpiCard
+          label="NPV"
+          value={npv !== null ? fmtCurrency(npv, false) : NULL_DISPLAY}
+          sub={npv !== null ? (npv >= 0 ? 'positive — deal beats hurdle' : 'negative — below hurdle') : 'set discount rate to compute'}
+          tone={npv === null ? 'lo' : npv >= 0 ? 'pass' : 'warn'}
+        />
+      </div>
+
+      {/* ── Exit summary ─────────────────────────────────────────────────── */}
+      {!isEmpty && (
+        <ExitSummary
+          salePrice={salePrice}
+          sellingCosts={sellingCosts}
+          netSaleProceeds={netSaleProceeds}
+        />
+      )}
+
+      {/* ── Projection table ─────────────────────────────────────────────── */}
+      {isEmpty ? (
+        <EmptyProForma />
+      ) : (
+        <>
+          <div className="flex items-center justify-between">
+            <h3 className="section-title text-xs">Year-by-Year Projection</h3>
+            <span className="text-[10px] text-lo">{projection.length}-year hold</span>
+          </div>
+          <ProjectionTable rows={projection} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/ProFormaPanel.tsx
+++ b/packages/ui/src/components/ProFormaPanel.tsx
@@ -84,9 +84,11 @@ function ProjectionTable({ rows }: ProjectionTableProps) {
                   {fmtCurrency(y.cumulativeCashFlow)}
                 </td>
                 <td className="px-3 py-1.5 num tabular-nums text-mid">
-                  {y.taxSavings > 0
-                    ? fmtCurrency(y.cashFlowAfterTax)
-                    : <span className="text-lo">{fmtCurrency(y.cashFlowAfterTax)}</span>
+                  {y.cashFlowAfterTax === null
+                    ? <span className="text-lo">{NULL_DISPLAY}</span>
+                    : (y.taxSavings ?? 0) > 0
+                      ? fmtCurrency(y.cashFlowAfterTax)
+                      : <span className="text-lo">{fmtCurrency(y.cashFlowAfterTax)}</span>
                   }
                 </td>
                 <td className="px-3 py-1.5 num tabular-nums text-mid">

--- a/packages/ui/src/components/ProFormaPanel.tsx
+++ b/packages/ui/src/components/ProFormaPanel.tsx
@@ -204,7 +204,7 @@ export function ProFormaPanel({ results }: ProFormaPanelProps) {
         <KpiCard
           label="NPV"
           value={npv !== null ? fmtCurrency(npv, false) : NULL_DISPLAY}
-          sub={npv !== null ? (npv >= 0 ? 'positive — deal beats hurdle' : 'negative — below hurdle') : 'set discount rate to compute'}
+          sub={npv !== null ? (npv >= 0 ? 'positive — deal beats hurdle' : 'negative — below hurdle') : 'set discount rate > 0 to compute'}
           tone={npv === null ? 'lo' : npv >= 0 ? 'pass' : 'warn'}
         />
       </div>

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -11,13 +11,15 @@ import { FixedExpenseRow } from './FixedExpenseRow';
 interface DealInputsFormProps {
   state: DealInputs;
   dispatch: Dispatch<DealAction>;
+  /** When true, the Pro-Forma Settings section is rendered. */
+  proFormaMode?: boolean;
 }
 
 /**
  * Full deal-input form, grouped into labelled sections.
  * Each input dispatches a typed action to the parent reducer.
  */
-export function DealInputsForm({ state, dispatch }: DealInputsFormProps) {
+export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealInputsFormProps) {
   const { expenses } = state;
 
   // ── Taxes helper — always present ──────────────────────────────────────────
@@ -214,6 +216,76 @@ export function DealInputsForm({ state, dispatch }: DealInputsFormProps) {
           hint="Leave 0 to hide price-per-sqft metric"
         />
       </InputSection>
+
+      {/* ── Pro-Forma Settings (shown in pro-forma mode only) ─────────────── */}
+      {proFormaMode && (
+        <InputSection title="Pro-Forma Settings">
+          <NumberInput
+            label="Hold Period"
+            value={state.holdYears ?? 5}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'holdYears', value: v })}
+            min={1}
+            max={50}
+            unit="yrs"
+            hint="Number of years to project"
+          />
+          <PercentInput
+            label="Rent Growth"
+            value={state.rentGrowthPct ?? 2}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'rentGrowthPct', value: v })}
+            min={-20}
+            max={20}
+            hint="Annual rent growth rate"
+          />
+          <PercentInput
+            label="Expense Growth"
+            value={state.expenseGrowthPct ?? 2}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'expenseGrowthPct', value: v })}
+            min={-20}
+            max={20}
+            hint="Annual growth for fixed expenses"
+          />
+          <PercentInput
+            label="Appreciation"
+            value={state.appreciationPct ?? 3}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'appreciationPct', value: v })}
+            min={-20}
+            max={20}
+            hint="Annual property value growth"
+          />
+          <PercentInput
+            label="Selling Costs"
+            value={state.sellingCostsPct ?? 6}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'sellingCostsPct', value: v })}
+            min={0}
+            max={20}
+            hint="Agent commission + closing costs at sale"
+          />
+          <CurrencyInput
+            label="Land Value"
+            value={state.landValue ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'landValue', value: v })}
+            emptyZero
+            hint="Non-depreciable portion of purchase price"
+          />
+          <PercentInput
+            label="Marginal Tax Rate"
+            value={state.marginalTaxPct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'marginalTaxPct', value: v })}
+            min={0}
+            max={60}
+            hint="For after-tax cash flow (leave 0 to skip)"
+          />
+          <PercentInput
+            label="Discount Rate (NPV)"
+            value={state.discountRatePct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'discountRatePct', value: v })}
+            min={0}
+            max={50}
+            hint="Hurdle rate — leave 0 to skip NPV"
+          />
+        </InputSection>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/state/dealReducer.ts
+++ b/packages/ui/src/state/dealReducer.ts
@@ -22,7 +22,8 @@ type NumericDealKey =
   | 'expenseGrowthPct'
   | 'appreciationPct'
   | 'sellingCostsPct'
-  | 'marginalTaxPct';
+  | 'marginalTaxPct'
+  | 'discountRatePct';
 
 /** All top-level DealInputs keys that hold a boolean (or undefined boolean). */
 type BooleanDealKey = 'rollClosingCostsIntoLoan' | 'capExInNOI';


### PR DESCRIPTION
## Summary

- Adds `SCREENER / PRO-FORMA` mode toggle to the header (pill button group)
- Pro-forma mode seeds default assumptions on first activation: hold=5yr, rent/expense growth=2%, appreciation=3%, selling costs=6%
- New `ProFormaPanel` component: KPI cards (Total Profit, IRR, Equity Multiple, Net Sale Proceeds, NPV) + exit summary + scrollable projection table
- Projection table columns: Year | NOI/yr | Debt Svc | Cash Flow | Cum. CF | After-Tax CF | Prop. Value | Loan Bal. | Equity
- `DealInputsForm` gains a conditional "Pro-Forma Settings" section (8 inputs: hold years, growth rates, selling costs, marginal tax, discount rate) shown only in pro-forma mode
- `dealReducer` adds `discountRatePct` to `NumericDealKey`
- Null-guard fix: `cashFlowAfterTax` renders `—` when `marginalTaxPct` not provided (aligns with RPE-32 nullable contract)
- Screener mode unchanged; comparison mode still available in screener mode

## Test plan

- [ ] 440 tests pass (`pnpm test`)
- [ ] `pnpm lint && pnpm typecheck && pnpm build` all clean
- [ ] Toggle between SCREENER and PRO-FORMA modes; inputs panel adapts
- [ ] Pro-forma settings seeded with defaults on first toggle; not overwritten if already set
- [ ] Projection table renders all years with correct formatting
- [ ] After-Tax CF column shows "—" when marginal tax rate is unset; numeric when set
- [ ] Exit summary (gross sale, selling costs, net proceeds) matches last projection year

🤖 Generated with [Claude Code](https://claude.com/claude-code)