### PR TITLE
RPE-57: feat(ui): UiMode type + INPUT_TIER/RESULT_TIER tiering config

### DIFF
--- a/packages/ui/src/state/uiMode.ts
+++ b/packages/ui/src/state/uiMode.ts
@@ -19,8 +19,14 @@ import type { DealExpenses, DealInputs, ScreenerResults } from '@rpe/engine';
 /** Controls form and results complexity. Orthogonal to the screener/pro-forma eval mode. */
 export type UiMode = 'simple' | 'complex';
 
-/** Tier a field or metric belongs to. */
-export type InputTier = 'simple' | 'complex';
+/**
+ * Tier that a field or metric belongs to.
+ * Used for both input fields (INPUT_TIER) and result metrics (RESULT_TIER).
+ */
+export type ComplexityTier = 'simple' | 'complex';
+
+/** @deprecated Use ComplexityTier. */
+export type InputTier = ComplexityTier;
 
 // ─── Input tiering ────────────────────────────────────────────────────────────
 
@@ -38,7 +44,7 @@ export type InputTier = 'simple' | 'complex';
  */
 export type InputFieldKey = Exclude<keyof DealInputs, 'expenses'> | keyof DealExpenses;
 
-export const INPUT_TIER: Readonly<Record<InputFieldKey, InputTier>> = {
+export const INPUT_TIER: Readonly<Record<InputFieldKey, ComplexityTier>> = {
   // ── Shown in simple mode ──────────────────────────────────────────────────
   purchasePrice: 'simple',
   grossRent: 'simple',
@@ -88,7 +94,7 @@ export const INPUT_TIER: Readonly<Record<InputFieldKey, InputTier>> = {
  * Simple set answers "is this deal worth pursuing?" without overwhelming a beginner:
  * cash flow, returns, loan safety, deal-quality rule-of-thumb, and capital required.
  */
-export const RESULT_TIER: Readonly<Record<keyof ScreenerResults, InputTier>> = {
+export const RESULT_TIER: Readonly<Record<keyof ScreenerResults, ComplexityTier>> = {
   // ── Shown in simple mode ──────────────────────────────────────────────────
   cashFlowMonthly: 'simple',
   cashFlowAnnual: 'simple',
@@ -124,7 +130,7 @@ export const RESULT_TIER: Readonly<Record<keyof ScreenerResults, InputTier>> = {
 
 /** Ordered list of result keys displayed in simple mode. */
 export const SIMPLE_RESULT_KEYS: ReadonlyArray<keyof ScreenerResults> = (
-  Object.entries(RESULT_TIER) as [keyof ScreenerResults, InputTier][]
+  Object.entries(RESULT_TIER) as [keyof ScreenerResults, ComplexityTier][]
 )
   .filter(([, tier]) => tier === 'simple')
   .map(([key]) => key);

--- a/packages/ui/src/state/uiMode.ts
+++ b/packages/ui/src/state/uiMode.ts
@@ -1,0 +1,124 @@
+/**
+ * E8 — UI complexity mode (RPE-57)
+ *
+ * UiMode governs which DealInputs fields are shown in the form and which
+ * ScreenerResults metrics are shown in the results panel.
+ *
+ * - 'simple'  — beginner-friendly: 4 visible inputs, 8 key metrics; hidden fields
+ *               are filled from the baseline-assumptions module (RPE-58).
+ * - 'complex' — full experience (default): all inputs and all metrics.
+ *
+ * The engine always receives a fully-populated DealInputs; UiMode is a UI concern only.
+ * Pro-forma mode is disabled when UiMode is 'simple' (it requires complex inputs).
+ */
+
+import type { ScreenerResults } from '@rpe/engine';
+
+// ─── Mode type ────────────────────────────────────────────────────────────────
+
+/** Controls form and results complexity. Orthogonal to the screener/pro-forma eval mode. */
+export type UiMode = 'simple' | 'complex';
+
+/** Tier a field or metric belongs to. */
+export type InputTier = 'simple' | 'complex';
+
+// ─── Input tiering ────────────────────────────────────────────────────────────
+
+/**
+ * Tier for every field in the input form.
+ *
+ * Top-level DealInputs fields use their DealInputs key.
+ * DealExpenses sub-fields (capExPct, maintPct, taxes, etc.) use their DealExpenses key.
+ * Pro-forma-only fields are always 'complex' (they're also gated by pro-forma mode).
+ *
+ * 'simple'  → shown in both simple and complex mode.
+ * 'complex' → shown only in complex mode; in simple mode the value comes from baselines.
+ */
+export const INPUT_TIER: Readonly<Record<string, InputTier>> = {
+  // ── Shown in simple mode ──────────────────────────────────────────────────
+  purchasePrice: 'simple',
+  grossRent: 'simple',
+  percentDown: 'simple',
+  vacancyPct: 'simple',
+
+  // ── Hidden in simple mode (filled from baselines) ─────────────────────────
+  interestRate: 'complex',
+  loanTermYears: 'complex',
+  closingCosts: 'complex',
+  rollClosingCostsIntoLoan: 'complex',
+  rehab: 'complex',
+  otherIncome: 'complex',
+  // DealExpenses sub-fields:
+  capExPct: 'complex',
+  maintPct: 'complex',
+  mgmtPct: 'complex',
+  miscPct: 'complex',
+  capExInNOI: 'complex',
+  taxes: 'complex',
+  insurance: 'complex',
+  hoa: 'complex',
+  // Optional property metadata:
+  units: 'complex',
+  sqft: 'complex',
+  // Pro-forma inputs (gated by pro-forma mode; always complex):
+  holdYears: 'complex',
+  rentGrowthPct: 'complex',
+  expenseGrowthPct: 'complex',
+  appreciationPct: 'complex',
+  sellingCostsPct: 'complex',
+  landValue: 'complex',
+  marginalTaxPct: 'complex',
+  discountRatePct: 'complex',
+} as const;
+
+// ─── Result tiering ───────────────────────────────────────────────────────────
+
+/**
+ * Tier for every ScreenerResults metric.
+ *
+ * In simple mode only 'simple'-tier metrics are shown and included in the deal score.
+ * The full set is available in complex mode (current behaviour).
+ *
+ * Simple set answers "is this deal worth pursuing?" without overwhelming a beginner:
+ * cash flow, returns, loan safety, deal-quality rule-of-thumb, and capital required.
+ */
+export const RESULT_TIER: Readonly<Record<keyof ScreenerResults, InputTier>> = {
+  // ── Shown in simple mode ──────────────────────────────────────────────────
+  cashFlowMonthly: 'simple',
+  cashFlowAnnual: 'simple',
+  cocRoi: 'simple',
+  capRate: 'simple',
+  dscr: 'simple',
+  onePercentRule: 'simple',
+  totalCashInvested: 'simple',
+  breakEvenOccupancy: 'simple',
+
+  // ── Complex only ──────────────────────────────────────────────────────────
+  loanAmount: 'complex',
+  mortgagePayment: 'complex',
+  totalInterest: 'complex',
+  egi: 'complex',
+  egiAnnual: 'complex',
+  opExMonthly: 'complex',
+  opExAnnual: 'complex',
+  piti: 'complex',
+  noiMonthly: 'complex',
+  noiAnnual: 'complex',
+  grm: 'complex',
+  grossYield: 'complex',
+  expenseRatio: 'complex',
+  ltv: 'complex',
+  debtYield: 'complex',
+  pricePerUnit: 'complex',
+  pricePerSqft: 'complex',
+  fiftyPctRuleDeviation: 'complex',
+} as const;
+
+// ─── Derived helpers ──────────────────────────────────────────────────────────
+
+/** Ordered list of result keys displayed in simple mode. */
+export const SIMPLE_RESULT_KEYS: ReadonlyArray<keyof ScreenerResults> = (
+  Object.entries(RESULT_TIER) as [keyof ScreenerResults, InputTier][]
+)
+  .filter(([, tier]) => tier === 'simple')
+  .map(([key]) => key);

--- a/packages/ui/src/state/uiMode.ts
+++ b/packages/ui/src/state/uiMode.ts
@@ -9,10 +9,10 @@
  * - 'complex' — full experience (default): all inputs and all metrics.
  *
  * The engine always receives a fully-populated DealInputs; UiMode is a UI concern only.
- * Pro-forma mode is disabled when UiMode is 'simple' (it requires complex inputs).
+ * Disabling pro-forma mode in simple mode (it requires complex inputs) is wired in RPE-61.
  */
 
-import type { ScreenerResults } from '@rpe/engine';
+import type { DealExpenses, DealInputs, ScreenerResults } from '@rpe/engine';
 
 // ─── Mode type ────────────────────────────────────────────────────────────────
 
@@ -27,14 +27,18 @@ export type InputTier = 'simple' | 'complex';
 /**
  * Tier for every field in the input form.
  *
- * Top-level DealInputs fields use their DealInputs key.
- * DealExpenses sub-fields (capExPct, maintPct, taxes, etc.) use their DealExpenses key.
- * Pro-forma-only fields are always 'complex' (they're also gated by pro-forma mode).
+ * The key union covers:
+ *   - Every top-level DealInputs field except the `expenses` container itself.
+ *   - Every DealExpenses sub-field (including the optional `other` fixed-expense row).
+ *
+ * TypeScript enforces exhaustiveness — a missing key is a compile error.
  *
  * 'simple'  → shown in both simple and complex mode.
  * 'complex' → shown only in complex mode; in simple mode the value comes from baselines.
  */
-export const INPUT_TIER: Readonly<Record<string, InputTier>> = {
+export type InputFieldKey = Exclude<keyof DealInputs, 'expenses'> | keyof DealExpenses;
+
+export const INPUT_TIER: Readonly<Record<InputFieldKey, InputTier>> = {
   // ── Shown in simple mode ──────────────────────────────────────────────────
   purchasePrice: 'simple',
   grossRent: 'simple',
@@ -48,15 +52,16 @@ export const INPUT_TIER: Readonly<Record<string, InputTier>> = {
   rollClosingCostsIntoLoan: 'complex',
   rehab: 'complex',
   otherIncome: 'complex',
+  capExInNOI: 'complex',
   // DealExpenses sub-fields:
   capExPct: 'complex',
   maintPct: 'complex',
   mgmtPct: 'complex',
   miscPct: 'complex',
-  capExInNOI: 'complex',
   taxes: 'complex',
   insurance: 'complex',
   hoa: 'complex',
+  other: 'complex',
   // Optional property metadata:
   units: 'complex',
   sqft: 'complex',
@@ -76,8 +81,9 @@ export const INPUT_TIER: Readonly<Record<string, InputTier>> = {
 /**
  * Tier for every ScreenerResults metric.
  *
- * In simple mode only 'simple'-tier metrics are shown and included in the deal score.
- * The full set is available in complex mode (current behaviour).
+ * In simple mode only 'simple'-tier metrics are displayed. Restricting the deal
+ * score to simple-tier metrics (so it reflects only the visible metrics) is wired
+ * in RPE-60/RPE-61. The full set is available in complex mode (current behaviour).
  *
  * Simple set answers "is this deal worth pursuing?" without overwhelming a beginner:
  * cash flow, returns, loan safety, deal-quality rule-of-thumb, and capital required.


### PR DESCRIPTION
## Summary
- Adds `UiMode` type (`'simple' | 'complex'`) — E8's core mode concept, orthogonal to screener/pro-forma eval mode
- Adds `InputFieldKey` type alias (`Exclude<keyof DealInputs, 'expenses'> | keyof DealExpenses`) — TypeScript enforces exhaustiveness on `INPUT_TIER`
- Adds `INPUT_TIER` config tagging every `DealInputs` + `DealExpenses` field to its tier; simple mode shows only 4 fields (purchase price, gross rent, down %, vacancy %)
- Adds `RESULT_TIER` config tagging all 26 `ScreenerResults` keys; simple mode exposes 8 focused metrics
- `SIMPLE_RESULT_KEYS` derived from `RESULT_TIER` so the two never drift
- No runtime behavior changes — config + types only; downstream stories (RPE-58–61) consume this

## Test plan
- [ ] `pnpm typecheck` passes (all 5 workspace packages)
- [ ] `pnpm lint` passes
- [ ] `pnpm test` — 461 tests, 14 files, all passing
- [ ] `RESULT_TIER` covers all 26 `ScreenerResults` keys (TypeScript enforces this via `Record<keyof ScreenerResults, InputTier>`)
- [ ] `INPUT_TIER` covers all `InputFieldKey` members (TypeScript enforces exhaustiveness via `Record<InputFieldKey, InputTier>`)
- [ ] `SIMPLE_RESULT_KEYS` is derived at module init from `RESULT_TIER`, never manually listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)