### PR TITLE
RPE-58: feat(ui): simpleBaselines module — baseline-assumptions for simple mode

### DIFF
--- a/packages/ui/src/state/simpleBaselines.ts
+++ b/packages/ui/src/state/simpleBaselines.ts
@@ -1,0 +1,148 @@
+/**
+ * E8 — Baseline-assumptions module (RPE-58)
+ *
+ * Provides conservative national-average default values for every DealInputs
+ * field that is hidden in simple mode. These baselines feed the engine when
+ * the user has only entered the four simple-tier fields (purchase price, gross
+ * rent, down %, vacancy %).
+ *
+ * Design contract:
+ *   - All baseline values are documented in BASELINE_DESCRIPTIONS.
+ *   - Purchase-price-dependent baselines (closing costs, taxes, insurance) are
+ *     recomputed each time the purchase price changes.
+ *   - E9 (location defaults, RPE-56) will override these static values per region
+ *     by replacing getSimpleBaselines() at the call sites in Evaluator.tsx.
+ *   - applySimpleBaselines() is the evaluation path for simple mode ONLY.
+ *     Calling it in complex mode is incorrect — complex mode passes inputs directly.
+ */
+
+import type { DealInputs, ExpenseInput } from '@rpe/engine';
+
+// ─── Baseline value type ─────────────────────────────────────────────────────
+
+/**
+ * All complex-tier DealInputs fields populated by the baselines module.
+ * Explicit non-optional types so TypeScript guarantees completeness at compile time.
+ */
+export interface SimpleBaselineValues {
+  interestRate: number;
+  loanTermYears: number;
+  closingCosts: number;
+  rollClosingCostsIntoLoan: boolean;
+  rehab: number;
+  otherIncome: number;
+  /** Baseline vacancy — also the initial default for the visible vacancyPct field. */
+  vacancyPct: number;
+  capExInNOI: boolean;
+  expenses: {
+    capExPct: number;
+    maintPct: number;
+    mgmtPct: number;
+    miscPct: number;
+    taxes: ExpenseInput;
+    insurance: ExpenseInput;
+    hoa: ExpenseInput;
+  };
+}
+
+// ─── Core baseline function ──────────────────────────────────────────────────
+
+/**
+ * Return baseline assumption values for the given purchase price.
+ *
+ * Purchase-price-relative items (closing costs, taxes, insurance) are
+ * re-derived on every call; all other values are static constants.
+ */
+export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues {
+  const pp = purchasePrice > 0 ? purchasePrice : 0;
+  return {
+    // ── Financing ──────────────────────────────────────────────────────────
+    interestRate: 7.0,
+    loanTermYears: 30,
+    /** 2 % of purchase price — typical buyer closing cost range 1.5–3 %. */
+    closingCosts: Math.round(pp * 0.02),
+    rollClosingCostsIntoLoan: false,
+    rehab: 0,
+
+    // ── Income ────────────────────────────────────────────────────────────
+    otherIncome: 0,
+    /** 5 % vacancy — conservative national average for stabilised SFR / small multifamily. */
+    vacancyPct: 5,
+
+    // ── Expense settings ──────────────────────────────────────────────────
+    capExInNOI: true,
+
+    // ── Expense rates (all as % of gross rent) ────────────────────────────
+    expenses: {
+      /** 5 % CapEx reserve — long-run average for major repairs and replacements. */
+      capExPct: 5,
+      /** 5 % maintenance — routine upkeep and minor repairs. */
+      maintPct: 5,
+      /** 10 % property management — standard professional-management fee. */
+      mgmtPct: 10,
+      /** 1 % miscellaneous — accounting, legal, advertising, etc. */
+      miscPct: 1,
+
+      // ── Fixed expenses (purchase-price-relative heuristics) ─────────────
+      /** Property taxes: ~1.2 % of purchase price annually (national effective rate). */
+      taxes: { amount: Math.round(pp * 0.012), period: 'annual' },
+      /** Insurance: ~0.5 % of purchase price annually (homeowners / landlord policy). */
+      insurance: { amount: Math.round(pp * 0.005), period: 'annual' },
+      /** HOA: $0 — assumed single-family or self-managed; user adjusts if needed. */
+      hoa: { amount: 0, period: 'monthly' },
+    },
+  };
+}
+
+// ─── Human-readable descriptions ─────────────────────────────────────────────
+
+/**
+ * One-sentence description of each baseline assumption.
+ * Used in "based on assumptions" tooltips (RPE-61) and documentation.
+ * Keys match DealInputs / DealExpenses field names.
+ */
+export const BASELINE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+  interestRate: '30-yr fixed mortgage rate estimate (7 %).',
+  loanTermYears: 'Standard 30-year loan term.',
+  closingCosts: 'Buyer closing costs estimated at 2 % of purchase price.',
+  rollClosingCostsIntoLoan: 'Closing costs paid out-of-pocket (not financed).',
+  rehab: 'No rehab budget assumed — move-in-ready property.',
+  otherIncome: 'No ancillary income (parking, laundry, etc.) assumed.',
+  vacancyPct: '5 % vacancy — conservative national average for stabilised rentals.',
+  capExInNOI: 'CapEx reserve included in NOI (conservative lender view).',
+  capExPct: '5 % of gross rent reserved for capital expenditures.',
+  maintPct: '5 % of gross rent for routine maintenance.',
+  mgmtPct: '10 % of gross rent for professional property management.',
+  miscPct: '1 % of gross rent for miscellaneous operating expenses.',
+  taxes: 'Property taxes estimated at 1.2 % of purchase price annually.',
+  insurance: 'Landlord insurance estimated at 0.5 % of purchase price annually.',
+  hoa: 'No HOA fees assumed.',
+};
+
+// ─── Apply helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the effective DealInputs for simple-mode evaluation.
+ *
+ * Baselines supply every complex-tier field. The four simple-tier fields
+ * (purchasePrice, grossRent, percentDown, vacancyPct) come from the user's
+ * current inputs. All other user-state values (entered in complex mode) are
+ * intentionally ignored — the point of simple mode is a clean baseline
+ * calculation. The state itself is never mutated; user values survive a
+ * mode switch and are restored when returning to complex mode.
+ *
+ * @param inputs  Current scenario inputs (from the reducer).
+ * @returns       A new DealInputs object safe to pass directly to evaluate().
+ */
+export function applySimpleBaselines(inputs: DealInputs): DealInputs {
+  const b = getSimpleBaselines(inputs.purchasePrice);
+  return {
+    // ── Baseline fields (complex-tier) ────────────────────────────────────
+    ...b,
+    // ── User fields (simple-tier) — override the baselines ────────────────
+    purchasePrice: inputs.purchasePrice,
+    percentDown: inputs.percentDown,
+    grossRent: inputs.grossRent,
+    vacancyPct: inputs.vacancyPct,
+  };
+}

--- a/packages/ui/src/state/simpleBaselines.ts
+++ b/packages/ui/src/state/simpleBaselines.ts
@@ -101,8 +101,10 @@ export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues 
 // ─── Human-readable descriptions ─────────────────────────────────────────────
 
 /**
- * Key union covering every field in SimpleBaselineValues — derived so it stays
- * in sync automatically when fields are added or removed.
+ * Union of every *leaf* key in SimpleBaselineValues:
+ * - top-level keys (excluding the 'expenses' container itself)
+ * - DealExpenses sub-field keys (the leaves inside expenses)
+ * Derived from SimpleBaselineValues so it stays in sync automatically.
  */
 type BaselineDescriptionKey =
   | Exclude<keyof SimpleBaselineValues, 'expenses'>

--- a/packages/ui/src/state/simpleBaselines.ts
+++ b/packages/ui/src/state/simpleBaselines.ts
@@ -1,10 +1,10 @@
 /**
  * E8 — Baseline-assumptions module (RPE-58)
  *
- * Provides conservative national-average default values for every DealInputs
- * field that is hidden in simple mode. These baselines feed the engine when
- * the user has only entered the four simple-tier fields (purchase price, gross
- * rent, down %, vacancy %).
+ * Provides conservative national-average default values for the complex-tier
+ * DealInputs fields hidden in simple mode (financing, variable/fixed expenses).
+ * Optional metadata and pro-forma fields (units, sqft, holdYears, etc.) are NOT
+ * baselined — they remain undefined and are only relevant in complex mode.
  *
  * Design contract:
  *   - All baseline values are documented in BASELINE_DESCRIPTIONS.
@@ -42,6 +42,8 @@ export interface SimpleBaselineValues {
     taxes: ExpenseInput;
     insurance: ExpenseInput;
     hoa: ExpenseInput;
+    /** Other fixed expense: $0 — assumed none; explicitly present so callers need no special-case. */
+    other: ExpenseInput;
   };
 }
 
@@ -90,6 +92,8 @@ export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues 
       insurance: { amount: Math.round(pp * 0.005), period: 'annual' },
       /** HOA: $0 — assumed single-family or self-managed; user adjusts if needed. */
       hoa: { amount: 0, period: 'monthly' },
+      /** Other fixed expense: $0 — no supplemental fixed costs assumed. */
+      other: { amount: 0, period: 'monthly' },
     },
   };
 }
@@ -97,11 +101,23 @@ export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues 
 // ─── Human-readable descriptions ─────────────────────────────────────────────
 
 /**
+ * Key union covering every field in SimpleBaselineValues — derived so it stays
+ * in sync automatically when fields are added or removed.
+ */
+type BaselineDescriptionKey =
+  | Exclude<keyof SimpleBaselineValues, 'expenses'>
+  | keyof SimpleBaselineValues['expenses'];
+
+/**
  * One-sentence description of each baseline assumption.
  * Used in "based on assumptions" tooltips (RPE-61) and documentation.
  * Keys match DealInputs / DealExpenses field names.
+ *
+ * `satisfies` enforces that every BaselineDescriptionKey has a description
+ * and that no extra/unknown keys are present — missing or misspelled entries
+ * are compile errors.
  */
-export const BASELINE_DESCRIPTIONS: Readonly<Record<string, string>> = {
+export const BASELINE_DESCRIPTIONS = {
   interestRate: '30-yr fixed mortgage rate estimate (7 %).',
   loanTermYears: 'Standard 30-year loan term.',
   closingCosts: 'Buyer closing costs estimated at 2 % of purchase price.',
@@ -117,7 +133,8 @@ export const BASELINE_DESCRIPTIONS: Readonly<Record<string, string>> = {
   taxes: 'Property taxes estimated at 1.2 % of purchase price annually.',
   insurance: 'Landlord insurance estimated at 0.5 % of purchase price annually.',
   hoa: 'No HOA fees assumed.',
-};
+  other: 'No other fixed expenses assumed.',
+} as const satisfies Record<BaselineDescriptionKey, string>;
 
 // ─── Apply helper ─────────────────────────────────────────────────────────────
 

--- a/packages/ui/tests/simpleBaselines.test.ts
+++ b/packages/ui/tests/simpleBaselines.test.ts
@@ -1,0 +1,180 @@
+/**
+ * RPE-58: simpleBaselines unit tests
+ *
+ * Covers:
+ *  - getSimpleBaselines: purchase-price-relative computations, static fields,
+ *    zero-price edge case, rounding, exhaustive expense coverage.
+ *  - applySimpleBaselines: simple-tier fields come from inputs, complex-tier
+ *    from baselines (user's complex-mode values are intentionally ignored),
+ *    no mutation, closing-cost scaling.
+ *  - BASELINE_DESCRIPTIONS: every baseline leaf key has a non-empty description.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getSimpleBaselines,
+  applySimpleBaselines,
+  BASELINE_DESCRIPTIONS,
+} from '../src/state/simpleBaselines';
+import { DEFAULT_INPUTS } from '../src/state/defaultInputs';
+import type { DealInputs } from '@rpe/engine';
+
+// ─── getSimpleBaselines ───────────────────────────────────────────────────────
+
+describe('getSimpleBaselines', () => {
+  it('closing costs = 2 % of purchase price (rounded)', () => {
+    expect(getSimpleBaselines(300_000).closingCosts).toBe(6_000);
+    expect(getSimpleBaselines(250_000).closingCosts).toBe(5_000);
+  });
+
+  it('property taxes = 1.2 % of purchase price (annual, rounded)', () => {
+    const b = getSimpleBaselines(300_000);
+    expect(b.expenses.taxes.amount).toBe(3_600);
+    expect(b.expenses.taxes.period).toBe('annual');
+  });
+
+  it('insurance = 0.5 % of purchase price (annual, rounded)', () => {
+    const b = getSimpleBaselines(300_000);
+    expect(b.expenses.insurance.amount).toBe(1_500);
+    expect(b.expenses.insurance.period).toBe('annual');
+  });
+
+  it('rounds purchase-price-relative values to whole dollars', () => {
+    const b = getSimpleBaselines(199_999);
+    expect(Number.isInteger(b.closingCosts)).toBe(true);
+    expect(Number.isInteger(b.expenses.taxes.amount)).toBe(true);
+    expect(Number.isInteger(b.expenses.insurance.amount)).toBe(true);
+  });
+
+  it('static fields are stable regardless of purchase price', () => {
+    for (const pp of [100_000, 300_000, 1_000_000]) {
+      const b = getSimpleBaselines(pp);
+      expect(b.interestRate).toBe(7.0);
+      expect(b.loanTermYears).toBe(30);
+      expect(b.vacancyPct).toBe(5);
+      expect(b.rollClosingCostsIntoLoan).toBe(false);
+      expect(b.rehab).toBe(0);
+      expect(b.otherIncome).toBe(0);
+      expect(b.capExInNOI).toBe(true);
+      expect(b.expenses.capExPct).toBe(5);
+      expect(b.expenses.maintPct).toBe(5);
+      expect(b.expenses.mgmtPct).toBe(10);
+      expect(b.expenses.miscPct).toBe(1);
+      expect(b.expenses.hoa).toEqual({ amount: 0, period: 'monthly' });
+      expect(b.expenses.other).toEqual({ amount: 0, period: 'monthly' });
+    }
+  });
+
+  it('zero purchase price produces zero for relative fields (no NaN)', () => {
+    const b = getSimpleBaselines(0);
+    expect(b.closingCosts).toBe(0);
+    expect(b.expenses.taxes.amount).toBe(0);
+    expect(b.expenses.insurance.amount).toBe(0);
+    expect(Number.isNaN(b.interestRate)).toBe(false);
+    expect(Number.isNaN(b.expenses.capExPct)).toBe(false);
+  });
+
+  it('expenses object includes all DealExpenses sub-fields (incl. other)', () => {
+    const { expenses } = getSimpleBaselines(300_000);
+    expect(expenses).toHaveProperty('capExPct');
+    expect(expenses).toHaveProperty('maintPct');
+    expect(expenses).toHaveProperty('mgmtPct');
+    expect(expenses).toHaveProperty('miscPct');
+    expect(expenses).toHaveProperty('taxes');
+    expect(expenses).toHaveProperty('insurance');
+    expect(expenses).toHaveProperty('hoa');
+    expect(expenses).toHaveProperty('other');
+    expect(expenses.other.amount).toBe(0);
+  });
+});
+
+// ─── applySimpleBaselines ─────────────────────────────────────────────────────
+
+describe('applySimpleBaselines', () => {
+  /** User inputs with non-default simple-tier values and custom complex-tier values. */
+  const userInputs: DealInputs = {
+    ...DEFAULT_INPUTS,
+    purchasePrice: 400_000,
+    grossRent: 2_800,
+    percentDown: 25,
+    vacancyPct: 8,
+    // Complex-tier values the user customised in complex mode:
+    interestRate: 3.5,
+    loanTermYears: 15,
+    closingCosts: 99_999,
+  };
+
+  it('simple-tier fields come from user inputs', () => {
+    const r = applySimpleBaselines(userInputs);
+    expect(r.purchasePrice).toBe(400_000);
+    expect(r.grossRent).toBe(2_800);
+    expect(r.percentDown).toBe(25);
+    expect(r.vacancyPct).toBe(8);
+  });
+
+  it('complex-tier fields are replaced by baselines (user values intentionally ignored)', () => {
+    const r = applySimpleBaselines(userInputs);
+    expect(r.interestRate).toBe(7.0);   // baseline wins over user's 3.5
+    expect(r.loanTermYears).toBe(30);   // baseline wins over user's 15
+    // closing costs are purchase-price-relative, not the user's 99_999
+    expect(r.closingCosts).toBe(Math.round(400_000 * 0.02));
+  });
+
+  it('expenses are fully replaced by purchase-price-relative baselines', () => {
+    const r = applySimpleBaselines(userInputs);
+    const b = getSimpleBaselines(400_000);
+    expect(r.expenses.taxes.amount).toBe(b.expenses.taxes.amount);
+    expect(r.expenses.insurance.amount).toBe(b.expenses.insurance.amount);
+    expect(r.expenses.capExPct).toBe(5);
+    expect(r.expenses.mgmtPct).toBe(10);
+  });
+
+  it('does not mutate the original inputs object', () => {
+    const before = { ...userInputs, expenses: { ...userInputs.expenses } };
+    applySimpleBaselines(userInputs);
+    expect(userInputs.interestRate).toBe(before.interestRate);
+    expect(userInputs.loanTermYears).toBe(before.loanTermYears);
+    expect(userInputs.expenses.taxes.amount).toBe(before.expenses.taxes.amount);
+  });
+
+  it('closing costs in result scale with purchase price', () => {
+    const r200 = applySimpleBaselines({ ...DEFAULT_INPUTS, purchasePrice: 200_000 });
+    const r400 = applySimpleBaselines({ ...DEFAULT_INPUTS, purchasePrice: 400_000 });
+    expect(r400.closingCosts).toBe(r200.closingCosts * 2);
+  });
+
+  it('result satisfies DealInputs required fields', () => {
+    const r = applySimpleBaselines(userInputs);
+    // All required DealInputs fields must be present and non-null/non-undefined.
+    expect(typeof r.purchasePrice).toBe('number');
+    expect(typeof r.percentDown).toBe('number');
+    expect(typeof r.interestRate).toBe('number');
+    expect(typeof r.loanTermYears).toBe('number');
+    expect(typeof r.closingCosts).toBe('number');
+    expect(typeof r.rollClosingCostsIntoLoan).toBe('boolean');
+    expect(typeof r.grossRent).toBe('number');
+    expect(typeof r.vacancyPct).toBe('number');
+    expect(r.expenses).toBeDefined();
+    expect(r.expenses.taxes).toBeDefined();
+    expect(r.expenses.insurance).toBeDefined();
+  });
+});
+
+// ─── BASELINE_DESCRIPTIONS ────────────────────────────────────────────────────
+
+describe('BASELINE_DESCRIPTIONS', () => {
+  const expectedKeys = [
+    'interestRate', 'loanTermYears', 'closingCosts', 'rollClosingCostsIntoLoan',
+    'rehab', 'otherIncome', 'vacancyPct', 'capExInNOI',
+    'capExPct', 'maintPct', 'mgmtPct', 'miscPct',
+    'taxes', 'insurance', 'hoa', 'other',
+  ] as const;
+
+  for (const key of expectedKeys) {
+    it(`has a non-empty description for '${key}'`, () => {
+      expect(BASELINE_DESCRIPTIONS[key]).toBeTruthy();
+      expect(typeof BASELINE_DESCRIPTIONS[key]).toBe('string');
+      expect(BASELINE_DESCRIPTIONS[key].length).toBeGreaterThan(5);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `SimpleBaselineValues` interface — fully typed, non-optional, so TypeScript enforces completeness
- Adds `getSimpleBaselines(purchasePrice)` — conservative national-average defaults for all complex-tier fields; purchase-price-relative items (closing costs 2%, property taxes 1.2%, insurance 0.5%) recomputed on each call
- Adds `BASELINE_DESCRIPTIONS` — one-sentence description per assumption, consumed by RPE-61 "based on assumptions" tooltips
- Adds `applySimpleBaselines(inputs)` — builds effective `DealInputs` for engine evaluation in simple mode; baselines fill complex-tier fields, user values fill simple-tier fields; state never mutated
- No Evaluator wiring — that's RPE-59/61; this story is the pure data layer and E9 integration seam

## Test plan
- [ ] `pnpm typecheck` passes (all 5 workspace packages)
- [ ] `pnpm lint` passes
- [ ] `pnpm test` — 461 tests, 14 files, all passing
- [ ] `SimpleBaselineValues` typed with non-optional properties — missing a field is a compile error
- [ ] `applySimpleBaselines` return type is `DealInputs` — satisfies all required fields without type assertions
- [ ] `getSimpleBaselines(0)` returns 0 for purchase-price-relative items (no NaN/divide-by-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)