### PR TITLE
RPE-59: feat(ui): simple-mode input form

### DIFF
--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -16,8 +16,11 @@ export interface DealInputsFormProps {
   proFormaMode?: boolean;
   /**
    * Controls which input sections are shown.
-   * - 'simple'  — shows only Purchase Price, Down Payment, Gross Rent, and Vacancy;
-   *               all other fields are hidden and filled from baseline assumptions.
+   * - 'simple'  — shows only Purchase Price, Down Payment, Gross Rent, and Vacancy.
+   *               All other input sections are hidden. Complex-tier fields (financing,
+   *               acquisition costs, expenses) are supplied by national-average baseline
+   *               assumptions. Optional metadata (units, sqft) and pro-forma fields are
+   *               hidden and not evaluated in simple mode — they are not baselined.
    * - 'complex' — shows all sections (default, current behaviour).
    */
   uiMode?: UiMode;
@@ -142,7 +145,7 @@ export function DealInputsForm({
       {/* ── Simple-mode assumptions note ─────────────────────────────────── */}
       {simple && (
         <div className="px-4 py-3 border-b border-border text-xs text-lo italic">
-          Financing and expenses use national-average assumptions.
+          All hidden inputs use national-average assumptions.
           Switch to Complex mode to customise.
         </div>
       )}

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -1,6 +1,7 @@
 import type { Dispatch } from 'react';
 import type { DealInputs, ExpenseInput } from '@rpe/engine';
 import type { DealAction } from '../../state/dealReducer';
+import type { UiMode } from '../../state/uiMode';
 import { InputSection } from './InputSection';
 import { CurrencyInput } from './CurrencyInput';
 import { PercentInput } from './PercentInput';
@@ -8,21 +9,40 @@ import { NumberInput } from './NumberInput';
 import { ToggleInput } from './ToggleInput';
 import { FixedExpenseRow } from './FixedExpenseRow';
 
-interface DealInputsFormProps {
+export interface DealInputsFormProps {
   state: DealInputs;
   dispatch: Dispatch<DealAction>;
-  /** When true, the Pro-Forma Settings section is rendered. */
+  /** When true, the Pro-Forma Settings section is rendered (complex mode only). */
   proFormaMode?: boolean;
+  /**
+   * Controls which input sections are shown.
+   * - 'simple'  — shows only Purchase Price, Down Payment, Gross Rent, and Vacancy;
+   *               all other fields are hidden and filled from baseline assumptions.
+   * - 'complex' — shows all sections (default, current behaviour).
+   */
+  uiMode?: UiMode;
 }
 
 /**
- * Full deal-input form, grouped into labelled sections.
+ * Deal-input form, grouped into labelled sections.
  * Each input dispatches a typed action to the parent reducer.
+ *
+ * In simple mode only the four core fields are shown; complex-tier sections
+ * are replaced by a brief note describing the active baseline assumptions.
+ * User values entered in complex mode are preserved in state and restored on
+ * return to complex mode — no data is discarded on mode switch.
  */
-export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealInputsFormProps) {
+export function DealInputsForm({
+  state,
+  dispatch,
+  proFormaMode = false,
+  uiMode = 'complex',
+}: DealInputsFormProps) {
   const { expenses } = state;
+  const simple = uiMode === 'simple';
 
-  // ── Taxes helper — always present ──────────────────────────────────────────
+  // Fixed-expense refs (only used in complex mode, declared here to avoid
+  // repeated optional-chaining and keep JSX clean).
   const taxes = expenses.taxes as ExpenseInput;
   const insurance = expenses.insurance as ExpenseInput;
   const hoa = expenses.hoa ?? { amount: 0, period: 'monthly' as const };
@@ -44,45 +64,53 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
           max={100}
           hint="100 = cash purchase (no loan)"
         />
-        <CurrencyInput
-          label="Closing Costs"
-          value={state.closingCosts}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'closingCosts', value: v })}
-          emptyZero
-        />
-        <ToggleInput
-          label="Roll Closing Costs Into Loan"
-          value={state.rollClosingCostsIntoLoan}
-          onChange={(v) => dispatch({ type: 'SET_BOOL', field: 'rollClosingCostsIntoLoan', value: v })}
-        />
-        <CurrencyInput
-          label="Rehab Budget"
-          value={state.rehab ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'rehab', value: v })}
-          emptyZero
-          hint="Added to total cash invested; not financed"
-        />
+        {!simple && (
+          <>
+            <CurrencyInput
+              label="Closing Costs"
+              value={state.closingCosts}
+              onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'closingCosts', value: v })}
+              emptyZero
+            />
+            <ToggleInput
+              label="Roll Closing Costs Into Loan"
+              value={state.rollClosingCostsIntoLoan}
+              onChange={(v) =>
+                dispatch({ type: 'SET_BOOL', field: 'rollClosingCostsIntoLoan', value: v })
+              }
+            />
+            <CurrencyInput
+              label="Rehab Budget"
+              value={state.rehab ?? 0}
+              onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'rehab', value: v })}
+              emptyZero
+              hint="Added to total cash invested; not financed"
+            />
+          </>
+        )}
       </InputSection>
 
-      {/* ── Financing ────────────────────────────────────────────────────── */}
-      <InputSection title="Financing">
-        <PercentInput
-          label="Interest Rate"
-          value={state.interestRate}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'interestRate', value: v })}
-          min={0}
-          max={30}
-          hint="Annual rate — set to 0 for interest-free"
-        />
-        <NumberInput
-          label="Loan Term"
-          value={state.loanTermYears}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'loanTermYears', value: v })}
-          min={1}
-          max={50}
-          unit="yrs"
-        />
-      </InputSection>
+      {/* ── Financing (complex mode only) ────────────────────────────────── */}
+      {!simple && (
+        <InputSection title="Financing">
+          <PercentInput
+            label="Interest Rate"
+            value={state.interestRate}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'interestRate', value: v })}
+            min={0}
+            max={30}
+            hint="Annual rate — set to 0 for interest-free"
+          />
+          <NumberInput
+            label="Loan Term"
+            value={state.loanTermYears}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'loanTermYears', value: v })}
+            min={1}
+            max={50}
+            unit="yrs"
+          />
+        </InputSection>
+      )}
 
       {/* ── Income ───────────────────────────────────────────────────────── */}
       <InputSection title="Income">
@@ -92,13 +120,15 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
           onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'grossRent', value: v })}
           hint="Monthly gross potential rent"
         />
-        <CurrencyInput
-          label="Other Income"
-          value={state.otherIncome ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'otherIncome', value: v })}
-          emptyZero
-          hint="Parking, laundry, storage, pet rent, etc."
-        />
+        {!simple && (
+          <CurrencyInput
+            label="Other Income"
+            value={state.otherIncome ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'otherIncome', value: v })}
+            emptyZero
+            hint="Parking, laundry, storage, pet rent, etc."
+          />
+        )}
         <PercentInput
           label="Vacancy"
           value={state.vacancyPct}
@@ -109,116 +139,130 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
         />
       </InputSection>
 
-      {/* ── Fixed Expenses ───────────────────────────────────────────────── */}
-      <InputSection title="Fixed Expenses">
-        <FixedExpenseRow
-          label="Property Taxes"
-          amount={taxes.amount}
-          period={taxes.period}
-          onAmountChange={(amount) =>
-            dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount, period: taxes.period })
-          }
-          onPeriodChange={(period) =>
-            dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: taxes.amount, period })
-          }
-        />
-        <FixedExpenseRow
-          label="Insurance"
-          amount={insurance.amount}
-          period={insurance.period}
-          onAmountChange={(amount) =>
-            dispatch({
-              type: 'SET_EXPENSE_FIXED',
-              field: 'insurance',
-              amount,
-              period: insurance.period,
-            })
-          }
-          onPeriodChange={(period) =>
-            dispatch({
-              type: 'SET_EXPENSE_FIXED',
-              field: 'insurance',
-              amount: insurance.amount,
-              period,
-            })
-          }
-        />
-        <FixedExpenseRow
-          label="HOA"
-          amount={hoa.amount}
-          period={hoa.period}
-          onAmountChange={(amount) =>
-            dispatch({ type: 'SET_EXPENSE_FIXED', field: 'hoa', amount, period: hoa.period })
-          }
-          onPeriodChange={(period) =>
-            dispatch({ type: 'SET_EXPENSE_FIXED', field: 'hoa', amount: hoa.amount, period })
-          }
-        />
-      </InputSection>
+      {/* ── Simple-mode assumptions note ─────────────────────────────────── */}
+      {simple && (
+        <div className="px-4 py-3 border-b border-border text-xs text-lo italic">
+          Financing, expenses, and property details use national-average assumptions.
+          Switch to Complex mode to customise.
+        </div>
+      )}
 
-      {/* ── Variable Expenses ────────────────────────────────────────────── */}
-      <InputSection title="Variable Expenses">
-        <PercentInput
-          label="CapEx Reserve"
-          value={expenses.capExPct ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'capExPct', value: v })}
-          min={0}
-          max={50}
-          hint="% of gross rent set aside for capital expenses"
-        />
-        <PercentInput
-          label="Maintenance"
-          value={expenses.maintPct ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'maintPct', value: v })}
-          min={0}
-          max={50}
-        />
-        <PercentInput
-          label="Property Management"
-          value={expenses.mgmtPct ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'mgmtPct', value: v })}
-          min={0}
-          max={50}
-        />
-        <PercentInput
-          label="Miscellaneous"
-          value={expenses.miscPct ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'miscPct', value: v })}
-          min={0}
-          max={50}
-        />
-        <ToggleInput
-          label="Include CapEx in NOI"
-          value={state.capExInNOI ?? true}
-          onChange={(v) => dispatch({ type: 'SET_BOOL', field: 'capExInNOI', value: v })}
-          hint="Conservative (on) vs. lender convention (off)"
-        />
-      </InputSection>
+      {/* ── Fixed Expenses (complex mode only) ───────────────────────────── */}
+      {!simple && (
+        <InputSection title="Fixed Expenses">
+          <FixedExpenseRow
+            label="Property Taxes"
+            amount={taxes.amount}
+            period={taxes.period}
+            onAmountChange={(amount) =>
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount, period: taxes.period })
+            }
+            onPeriodChange={(period) =>
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: taxes.amount, period })
+            }
+          />
+          <FixedExpenseRow
+            label="Insurance"
+            amount={insurance.amount}
+            period={insurance.period}
+            onAmountChange={(amount) =>
+              dispatch({
+                type: 'SET_EXPENSE_FIXED',
+                field: 'insurance',
+                amount,
+                period: insurance.period,
+              })
+            }
+            onPeriodChange={(period) =>
+              dispatch({
+                type: 'SET_EXPENSE_FIXED',
+                field: 'insurance',
+                amount: insurance.amount,
+                period,
+              })
+            }
+          />
+          <FixedExpenseRow
+            label="HOA"
+            amount={hoa.amount}
+            period={hoa.period}
+            onAmountChange={(amount) =>
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'hoa', amount, period: hoa.period })
+            }
+            onPeriodChange={(period) =>
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'hoa', amount: hoa.amount, period })
+            }
+          />
+        </InputSection>
+      )}
 
-      {/* ── Property Details (optional metrics) ──────────────────────────── */}
-      <InputSection title="Property Details">
-        <NumberInput
-          label="Units"
-          value={state.units ?? 0}
-          onChange={(v) =>
-            dispatch({ type: 'SET_NUMBER', field: 'units', value: v === 0 ? 0 : v })
-          }
-          min={0}
-          unit="units"
-          hint="Leave 0 to hide price-per-unit metric"
-        />
-        <NumberInput
-          label="Square Footage"
-          value={state.sqft ?? 0}
-          onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'sqft', value: v })}
-          min={0}
-          unit="sqft"
-          hint="Leave 0 to hide price-per-sqft metric"
-        />
-      </InputSection>
+      {/* ── Variable Expenses (complex mode only) ────────────────────────── */}
+      {!simple && (
+        <InputSection title="Variable Expenses">
+          <PercentInput
+            label="CapEx Reserve"
+            value={expenses.capExPct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'capExPct', value: v })}
+            min={0}
+            max={50}
+            hint="% of gross rent set aside for capital expenses"
+          />
+          <PercentInput
+            label="Maintenance"
+            value={expenses.maintPct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'maintPct', value: v })}
+            min={0}
+            max={50}
+          />
+          <PercentInput
+            label="Property Management"
+            value={expenses.mgmtPct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'mgmtPct', value: v })}
+            min={0}
+            max={50}
+          />
+          <PercentInput
+            label="Miscellaneous"
+            value={expenses.miscPct ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_EXPENSE_PCT', field: 'miscPct', value: v })}
+            min={0}
+            max={50}
+          />
+          <ToggleInput
+            label="Include CapEx in NOI"
+            value={state.capExInNOI ?? true}
+            onChange={(v) => dispatch({ type: 'SET_BOOL', field: 'capExInNOI', value: v })}
+            hint="Conservative (on) vs. lender convention (off)"
+          />
+        </InputSection>
+      )}
 
-      {/* ── Pro-Forma Settings (shown in pro-forma mode only) ─────────────── */}
-      {proFormaMode && (
+      {/* ── Property Details (complex mode only) ─────────────────────────── */}
+      {!simple && (
+        <InputSection title="Property Details">
+          <NumberInput
+            label="Units"
+            value={state.units ?? 0}
+            onChange={(v) =>
+              dispatch({ type: 'SET_NUMBER', field: 'units', value: v === 0 ? 0 : v })
+            }
+            min={0}
+            unit="units"
+            hint="Leave 0 to hide price-per-unit metric"
+          />
+          <NumberInput
+            label="Square Footage"
+            value={state.sqft ?? 0}
+            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'sqft', value: v })}
+            min={0}
+            unit="sqft"
+            hint="Leave 0 to hide price-per-sqft metric"
+          />
+        </InputSection>
+      )}
+
+      {/* ── Pro-Forma Settings (complex + pro-forma mode only) ───────────── */}
+      {!simple && proFormaMode && (
         <InputSection title="Pro-Forma Settings">
           <NumberInput
             label="Hold Period"
@@ -240,7 +284,9 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
           <PercentInput
             label="Expense Growth"
             value={state.expenseGrowthPct ?? 2}
-            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'expenseGrowthPct', value: v })}
+            onChange={(v) =>
+              dispatch({ type: 'SET_NUMBER', field: 'expenseGrowthPct', value: v })
+            }
             min={-20}
             max={20}
             hint="Annual growth for fixed expenses"
@@ -256,7 +302,9 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
           <PercentInput
             label="Selling Costs"
             value={state.sellingCostsPct ?? 6}
-            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'sellingCostsPct', value: v })}
+            onChange={(v) =>
+              dispatch({ type: 'SET_NUMBER', field: 'sellingCostsPct', value: v })
+            }
             min={0}
             max={20}
             hint="Agent commission + closing costs at sale"
@@ -279,7 +327,9 @@ export function DealInputsForm({ state, dispatch, proFormaMode = false }: DealIn
           <PercentInput
             label="Discount Rate (NPV)"
             value={state.discountRatePct ?? 0}
-            onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'discountRatePct', value: v })}
+            onChange={(v) =>
+              dispatch({ type: 'SET_NUMBER', field: 'discountRatePct', value: v })
+            }
             min={0}
             max={50}
             hint="Hurdle rate — leave 0 to skip NPV"

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -138,7 +138,7 @@ export function DealInputsForm({
           onChange={(v) => dispatch({ type: 'SET_NUMBER', field: 'vacancyPct', value: v })}
           min={0}
           max={100}
-          hint="Applied to gross rent + other income"
+          hint={simple ? 'Applied to gross rent' : 'Applied to gross rent + other income'}
         />
       </InputSection>
 

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -142,7 +142,7 @@ export function DealInputsForm({
       {/* ── Simple-mode assumptions note ─────────────────────────────────── */}
       {simple && (
         <div className="px-4 py-3 border-b border-border text-xs text-lo italic">
-          Financing, expenses, and property details use national-average assumptions.
+          Financing and expenses use national-average assumptions.
           Switch to Complex mode to customise.
         </div>
       )}

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -144,8 +144,8 @@ export function DealInputsForm({
 
       {/* ── Simple-mode assumptions note ─────────────────────────────────── */}
       {simple && (
-        <div className="px-4 py-3 border-b border-border text-xs text-lo italic">
-          All hidden inputs use national-average assumptions.
+        <div className="px-4 py-3 border-b border-border last:border-b-0 text-xs text-lo italic">
+          Financing, acquisition costs, and expenses use national-average assumptions.
           Switch to Complex mode to customise.
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds `uiMode?: UiMode` prop to `DealInputsForm` (defaults to `'complex'` — zero behaviour change for existing callers).
- Exports `DealInputsFormProps` interface so callers (RPE-61 toggle wiring) can reference the type.
- In **simple mode**: Acquisition shows only Purchase Price + Down Payment; Income shows only Gross Rent + Vacancy; a one-line note replaces the hidden sections.
- In **complex mode**: rendering is byte-for-byte identical to the pre-PR behaviour.
- Financing, Other Income, Fixed/Variable Expenses, Property Details, and Pro-Forma Settings are all gated on `!simple`.
- User values entered in complex mode are preserved in reducer state and restored on return to complex mode — no data discarded on switch.

## Part of E8 (Simple/Complex mode switch)

Dependency order: RPE-57 (state model ✅) → RPE-58 (baselines ✅) → **RPE-59** → RPE-60 (results panel) → RPE-61 (toggle UI + wiring) → RPE-62 (integration tests)

## Test plan

- [ ] Gate passes: `pnpm lint && pnpm typecheck && pnpm test` — 490 tests, 15 files ✅
- [ ] Storybook / local dev: pass `uiMode="simple"` — only 4 inputs visible + assumptions note
- [ ] Pass `uiMode="complex"` or omit — all sections render exactly as before
- [ ] Pro-forma section still hidden when `proFormaMode={false}` and `uiMode="complex"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)