### PR TITLE
RPE-43a: feat(rentcast): typed RentCast HTTP client + tests

### DIFF
--- a/packages/rentcast/package.json
+++ b/packages/rentcast/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@rpe/rentcast",
+  "version": "1.3.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/rentcast/package.json
+++ b/packages/rentcast/package.json
@@ -6,7 +6,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -19,6 +19,12 @@ async function rcGet(path: string, apiKey: string): Promise<unknown> {
   return res.json() as Promise<unknown>;
 }
 
+function ensureRentCastError(reason: unknown): RentCastError {
+  if (reason instanceof RentCastError) return reason;
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  return new RentCastError('unknown', `Network error: ${msg}`);
+}
+
 /**
  * Fetch property data from RentCast for the given address.
  *
@@ -47,8 +53,8 @@ export async function fetchPropertyData(
   ]);
 
   // AVM failures are fatal
-  if (avm.status === 'rejected') throw avm.reason as RentCastError;
-  if (rent.status === 'rejected') throw rent.reason as RentCastError;
+  if (avm.status === 'rejected') throw ensureRentCastError(avm.reason);
+  if (rent.status === 'rejected') throw ensureRentCastError(rent.reason);
 
   const avmData  = avm.value  as { price: number };
   const rentData = rent.value as { rent: number };

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -1,0 +1,82 @@
+import { RentCastError, type PropertyData, type RentCastErrorCode } from './types';
+
+const BASE = 'https://api.rentcast.io/v1';
+
+function statusToCode(status: number): RentCastErrorCode {
+  if (status === 401 || status === 403) return 'bad_key';
+  if (status === 404) return 'not_found';
+  if (status === 429) return 'rate_limit';
+  return 'unknown';
+}
+
+async function rcGet(path: string, apiKey: string): Promise<unknown> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path}`);
+  }
+  return res.json() as Promise<unknown>;
+}
+
+/**
+ * Fetch property data from RentCast for the given address.
+ *
+ * Makes three API calls in parallel:
+ *   /avm/value            → purchasePrice
+ *   /avm/rent/long-term   → grossRent
+ *   /properties           → sqft, units, annualTaxes (best-effort; null on 404)
+ *
+ * Throws RentCastError if either AVM call fails.
+ * /properties failure is soft — nullable fields return null.
+ *
+ * FIELD NAME VERIFICATION: Before shipping, confirm these field names against
+ * https://developers.rentcast.io/reference by running a live API call:
+ *   curl -H "X-Api-Key: $KEY" 'https://api.rentcast.io/v1/properties?address=123+Main+St&limit=1'
+ */
+export async function fetchPropertyData(
+  address: string,
+  apiKey: string,
+): Promise<PropertyData> {
+  const encoded = encodeURIComponent(address);
+
+  const [avm, rent, props] = await Promise.allSettled([
+    rcGet(`/avm/value?address=${encoded}`, apiKey),
+    rcGet(`/avm/rent/long-term?address=${encoded}`, apiKey),
+    rcGet(`/properties?address=${encoded}&limit=1`, apiKey),
+  ]);
+
+  // AVM failures are fatal
+  if (avm.status === 'rejected') throw avm.reason as RentCastError;
+  if (rent.status === 'rejected') throw rent.reason as RentCastError;
+
+  const avmData  = avm.value  as { price: number };
+  const rentData = rent.value as { rent: number };
+
+  let sqft: number | null        = null;
+  let units: number | null       = null;
+  let annualTaxes: number | null = null;
+
+  if (props.status === 'fulfilled') {
+    // /properties returns an array; we requested limit=1
+    const list = props.value as Array<{
+      squareFootage?: number;
+      units?: number;
+      // propertyTaxes is keyed by tax year: { "2023": { total: number } }
+      propertyTaxes?: Record<string, { total: number }>;
+    }>;
+    const p = list[0];
+    if (p) {
+      sqft  = typeof p.squareFootage === 'number' ? p.squareFootage : null;
+      units = typeof p.units         === 'number' ? p.units         : null;
+      if (p.propertyTaxes) {
+        const years      = Object.keys(p.propertyTaxes).sort().reverse();
+        const latestYear = years[0];
+        const latestTax  = latestYear ? p.propertyTaxes[latestYear] : undefined;
+        annualTaxes      = latestTax?.total ?? null;
+      }
+    }
+  }
+
+  return { purchasePrice: avmData.price, grossRent: rentData.rent, sqft, units, annualTaxes };
+}

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -34,7 +34,8 @@ function ensureRentCastError(reason: unknown): RentCastError {
  *   /properties           → sqft, units, annualTaxes (best-effort; null on 404)
  *
  * Throws RentCastError if either AVM call fails.
- * /properties failure is soft — nullable fields return null.
+ * /properties 404 is soft — nullable fields return null.
+ * Any other /properties error (401, 429, 5xx) is treated as fatal.
  *
  * FIELD NAME VERIFICATION: Before shipping, confirm these field names against
  * https://developers.rentcast.io/reference by running a live API call:
@@ -58,12 +59,23 @@ export async function fetchPropertyData(
 
   const avmData  = avm.value  as { price: number };
   const rentData = rent.value as { rent: number };
+  if (typeof avmData.price !== 'number') {
+    throw new RentCastError('unknown', 'RentCast: unexpected AVM value shape (price missing)');
+  }
+  if (typeof rentData.rent !== 'number') {
+    throw new RentCastError('unknown', 'RentCast: unexpected AVM rent shape (rent missing)');
+  }
 
   let sqft: number | null        = null;
   let units: number | null       = null;
   let annualTaxes: number | null = null;
 
-  if (props.status === 'fulfilled') {
+  // /properties 404 is soft (property not in database); other failures are fatal
+  if (props.status === 'rejected') {
+    const err = ensureRentCastError(props.reason);
+    if (err.code !== 'not_found') throw err;
+    // 404 → fall through with nulls
+  } else {
     // /properties returns an array; we requested limit=1
     const list = props.value as Array<{
       squareFootage?: number;

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -22,7 +22,7 @@ async function rcGet(path: string, apiKey: string): Promise<unknown> {
 function ensureRentCastError(reason: unknown): RentCastError {
   if (reason instanceof RentCastError) return reason;
   const msg = reason instanceof Error ? reason.message : String(reason);
-  return new RentCastError('unknown', `Network error: ${msg}`);
+  return new RentCastError('unknown', `RentCast fetch failed: ${msg}`);
 }
 
 /**
@@ -91,7 +91,7 @@ export async function fetchPropertyData(
         const years      = Object.keys(p.propertyTaxes).sort().reverse();
         const latestYear = years[0];
         const latestTax  = latestYear ? p.propertyTaxes[latestYear] : undefined;
-        annualTaxes      = latestTax?.total ?? null;
+        annualTaxes      = latestTax && typeof latestTax.total === 'number' ? latestTax.total : null;
       }
     }
   }

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -57,14 +57,15 @@ export async function fetchPropertyData(
   if (avm.status === 'rejected') throw ensureRentCastError(avm.reason);
   if (rent.status === 'rejected') throw ensureRentCastError(rent.reason);
 
-  const avmData  = avm.value  as { price: number };
-  const rentData = rent.value as { rent: number };
-  if (typeof avmData.price !== 'number') {
-    throw new RentCastError('unknown', 'RentCast: unexpected AVM value shape (price missing)');
-  }
-  if (typeof rentData.rent !== 'number') {
-    throw new RentCastError('unknown', 'RentCast: unexpected AVM rent shape (rent missing)');
-  }
+  const extractNumber = (data: unknown, field: string, label: string): number => {
+    if (data == null || typeof data !== 'object' || typeof (data as Record<string, unknown>)[field] !== 'number') {
+      throw new RentCastError('unknown', `RentCast: unexpected ${label} shape (${field} missing)`);
+    }
+    return (data as Record<string, unknown>)[field] as number;
+  };
+
+  const purchasePrice = extractNumber(avm.value, 'price', 'AVM value');
+  const grossRent     = extractNumber(rent.value, 'rent',  'AVM rent');
 
   let sqft: number | null        = null;
   let units: number | null       = null;
@@ -99,5 +100,5 @@ export async function fetchPropertyData(
     }
   }
 
-  return { purchasePrice: avmData.price, grossRent: rentData.rent, sqft, units, annualTaxes };
+  return { purchasePrice, grossRent, sqft, units, annualTaxes };
 }

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -14,7 +14,7 @@ async function rcGet(path: string, apiKey: string): Promise<unknown> {
     headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
   });
   if (!res.ok) {
-    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path}`);
+    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path.split('?')[0]}`);
   }
   return res.json() as Promise<unknown>;
 }

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -77,6 +77,9 @@ export async function fetchPropertyData(
     // 404 → fall through with nulls
   } else {
     // /properties returns an array; we requested limit=1
+    if (!Array.isArray(props.value)) {
+      throw new RentCastError('unknown', 'RentCast: unexpected /properties response shape');
+    }
     const list = props.value as Array<{
       squareFootage?: number;
       units?: number;

--- a/packages/rentcast/src/index.ts
+++ b/packages/rentcast/src/index.ts
@@ -1,0 +1,3 @@
+export { fetchPropertyData } from './client';
+export { RentCastError } from './types';
+export type { PropertyData, RentCastErrorCode } from './types';

--- a/packages/rentcast/src/types.ts
+++ b/packages/rentcast/src/types.ts
@@ -1,0 +1,30 @@
+/** Codes that identify why a RentCast request failed. */
+export type RentCastErrorCode = 'not_found' | 'bad_key' | 'rate_limit' | 'unknown';
+
+/** Thrown by fetchPropertyData on any RentCast API error. */
+export class RentCastError extends Error {
+  constructor(
+    public readonly code: RentCastErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RentCastError';
+  }
+}
+
+/**
+ * Property data returned after a successful autofill lookup.
+ * Fields sourced from /properties are null when RentCast returns no record.
+ */
+export interface PropertyData {
+  /** AVM mid-point estimate from /avm/value */
+  purchasePrice: number;
+  /** Monthly rent estimate from /avm/rent/long-term */
+  grossRent: number;
+  /** Square footage from /properties — null if not found */
+  sqft: number | null;
+  /** Unit count from /properties — null if not found */
+  units: number | null;
+  /** Annual property taxes from /properties — null if not found */
+  annualTaxes: number | null;
+}

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -143,5 +143,13 @@ describe('fetchPropertyData', () => {
         (e: unknown) => e instanceof RentCastError && e.code === 'rate_limit',
       );
     });
+
+    it('throws RentCastError unknown when fetch rejects with a network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'unknown',
+      );
+    });
   });
 });

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -1,0 +1,147 @@
+/**
+ * RPE-43a: fetchPropertyData unit tests
+ *
+ * All RentCast HTTP calls are mocked via vi.mock on globalThis.fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchPropertyData } from '../src/client';
+import { RentCastError } from '../src/types';
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function mockOk(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function mockFail(status: number): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message: `HTTP ${status}` }),
+  } as unknown as Response;
+}
+
+// RentCast response shapes
+// Verify field names against https://developers.rentcast.io/reference before shipping.
+const AVM_VALUE_RESPONSE   = { price: 342_000, priceRangeLow: 315_000, priceRangeHigh: 369_000 };
+const AVM_RENT_RESPONSE    = { rent: 2_150, rentRangeLow: 1_950, rentRangeHigh: 2_350 };
+const PROPERTIES_RESPONSE  = [
+  {
+    squareFootage: 1_480,
+    units: 1,
+    // propertyTaxes is a record keyed by tax year: { "2023": { total: 4210 } }
+    // If the field name or shape differs in the live API, adjust here + in client.ts
+    propertyTaxes: { '2023': { total: 4_210 } },
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('fetchPropertyData', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('returns all five fields when all three calls succeed', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      const result = await fetchPropertyData('123 Main St, Austin TX', 'rc_test_key');
+
+      expect(result.purchasePrice).toBe(342_000);
+      expect(result.grossRent).toBe(2_150);
+      expect(result.sqft).toBe(1_480);
+      expect(result.units).toBe(1);
+      expect(result.annualTaxes).toBe(4_210);
+    });
+
+    it('makes all three RentCast calls in parallel', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValue(mockOk(AVM_VALUE_RESPONSE));
+
+      // Override later calls to return appropriate shapes
+      fetchSpy
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      await fetchPropertyData('123 Main St', 'key');
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('partial success', () => {
+    it('returns null sqft/units/annualTaxes when /properties returns 404', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockFail(404));
+
+      const result = await fetchPropertyData('123 Main St', 'key');
+
+      expect(result.purchasePrice).toBe(342_000);
+      expect(result.grossRent).toBe(2_150);
+      expect(result.sqft).toBeNull();
+      expect(result.units).toBeNull();
+      expect(result.annualTaxes).toBeNull();
+    });
+
+    it('returns null for nullable fields when properties response is empty array', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk([]));
+
+      const result = await fetchPropertyData('123 Main St', 'key');
+
+      expect(result.sqft).toBeNull();
+      expect(result.units).toBeNull();
+      expect(result.annualTaxes).toBeNull();
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws RentCastError bad_key on 401', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(401));
+
+      await expect(fetchPropertyData('123 Main St', 'bad')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'bad_key',
+      );
+    });
+
+    it('throws RentCastError bad_key on 403', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(403));
+
+      await expect(fetchPropertyData('123 Main St', 'bad')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'bad_key',
+      );
+    });
+
+    it('throws RentCastError not_found on 404 from AVM call', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFail(404))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      await expect(fetchPropertyData('unknown address', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'not_found',
+      );
+    });
+
+    it('throws RentCastError rate_limit on 429', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(429));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'rate_limit',
+      );
+    });
+  });
+});

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -190,5 +190,23 @@ describe('fetchPropertyData', () => {
         message: expect.stringContaining('unexpected AVM value shape'),
       });
     });
+
+    it('throws RentCastError unknown when /properties returns a non-array body', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+        const u = String(url);
+        if (u.includes('/avm/value')) {
+          return Promise.resolve(new Response(JSON.stringify(AVM_VALUE_RESPONSE), { status: 200 }));
+        }
+        if (u.includes('/avm/rent')) {
+          return Promise.resolve(new Response(JSON.stringify(AVM_RENT_RESPONSE), { status: 200 }));
+        }
+        // /properties returns a plain object instead of an array
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }));
+      });
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toMatchObject({
+        code: 'unknown',
+        message: expect.stringContaining('unexpected /properties response shape'),
+      });
+    });
   });
 });

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -1,7 +1,7 @@
 /**
  * RPE-43a: fetchPropertyData unit tests
  *
- * All RentCast HTTP calls are mocked via vi.mock on globalThis.fetch.
+ * All RentCast HTTP calls are intercepted via vi.spyOn(globalThis, 'fetch').
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -63,7 +63,7 @@ describe('fetchPropertyData', () => {
       expect(result.annualTaxes).toBe(4_210);
     });
 
-    it('makes all three RentCast calls in parallel', async () => {
+    it('calls fetch exactly three times (once per endpoint)', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValue(mockOk(AVM_VALUE_RESPONSE));
 

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -173,5 +173,22 @@ describe('fetchPropertyData', () => {
         (e: unknown) => e instanceof RentCastError && e.code === 'unknown',
       );
     });
+
+    it('throws RentCastError unknown when AVM value response has unexpected shape', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+        const u = String(url);
+        if (u.includes('/avm/value')) {
+          return Promise.resolve(new Response(JSON.stringify({ notPrice: 999 }), { status: 200 }));
+        }
+        if (u.includes('/avm/rent')) {
+          return Promise.resolve(new Response(JSON.stringify({ rent: 2000 }), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+      });
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toMatchObject({
+        code: 'unknown',
+        message: expect.stringContaining('unexpected AVM value shape'),
+      });
+    });
   });
 });

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -151,5 +151,27 @@ describe('fetchPropertyData', () => {
         (e: unknown) => e instanceof RentCastError && e.code === 'unknown',
       );
     });
+
+    it('throws RentCastError bad_key when /properties returns 401', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockFail(401));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'bad_key',
+      );
+    });
+
+    it('throws RentCastError unknown when /properties returns 500', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockFail(500));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'unknown',
+      );
+    });
   });
 });

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -191,6 +191,23 @@ describe('fetchPropertyData', () => {
       });
     });
 
+    it('throws RentCastError unknown when /avm/value returns null body (HTTP 200)', async () => {
+      vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
+        const u = String(url);
+        if (u.includes('/avm/value')) {
+          return Promise.resolve(new Response(JSON.stringify(null), { status: 200 }));
+        }
+        if (u.includes('/avm/rent')) {
+          return Promise.resolve(new Response(JSON.stringify(AVM_RENT_RESPONSE), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify([]), { status: 200 }));
+      });
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toMatchObject({
+        code: 'unknown',
+        message: expect.stringContaining('AVM value shape'),
+      });
+    });
+
     it('throws RentCastError unknown when /properties returns a non-array body', async () => {
       vi.spyOn(globalThis, 'fetch').mockImplementation((url) => {
         const u = String(url);

--- a/packages/rentcast/tsconfig.json
+++ b/packages/rentcast/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}


### PR DESCRIPTION
## Summary

- New `packages/rentcast` workspace package (`@rpe/rentcast`) — pure TypeScript RentCast HTTP client
- `fetchPropertyData(address, apiKey)` calls three endpoints in parallel via `Promise.allSettled`: `/avm/value` (purchasePrice), `/avm/rent/long-term` (grossRent), `/properties` (sqft/units/annualTaxes)
- AVM failures throw `RentCastError`; `/properties` 404 is soft (nullable fields return null)
- Full error code hierarchy: `not_found | bad_key | rate_limit | unknown`; network errors wrapped via `ensureRentCastError`

## Test Plan
- [ ] `pnpm test packages/rentcast` — 9 tests pass (happy path, partial success, all error codes, network error)
- [ ] `pnpm lint && pnpm typecheck` — clean
- [ ] Field names (`price`, `rent`, `squareFootage`, `propertyTaxes`) verified against live RentCast API before production use

## Notes
Part of E7 RentCast autofill (RPE-43). Cherry-pick order: RPE-43a → RPE-43b → RPE-43c → RPE-43d.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)