### PR TITLE
RPE-43c: feat(ui): connector storage, Settings modal, Settings button

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -447,8 +447,8 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     }
   }, [proFormaMode]);
 
-  const [showSettings, setShowSettings]   = useState(false);
-  const [apiKey, setApiKey]               = useState<string | null>(() => getRentCastKey());
+  const [showSettings, setShowSettings] = useState(false);
+  const [apiKey, setApiKey] = useState<string | null>(() => getRentCastKey());
 
   // Refresh apiKey after the modal closes (user may have saved or removed)
   const handleCloseSettings = useCallback(() => {

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -16,6 +16,8 @@ import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from 
 import type { SavedDeal } from './state/savedDealsSchema';
 import { SIMPLE_RESULT_KEYS, type UiMode } from './state/uiMode';
 import { applySimpleBaselines } from './state/simpleBaselines';
+import { ConnectorSettingsModal } from './components/ConnectorSettingsModal';
+import { getRentCastKey } from './state/connectorStorage';
 
 // ─── Metric helpers ───────────────────────────────────────────────────────────
 
@@ -445,6 +447,15 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     }
   }, [proFormaMode]);
 
+  const [showSettings, setShowSettings]   = useState(false);
+  const [apiKey, setApiKey]               = useState<string | null>(() => getRentCastKey());
+
+  // Refresh apiKey after the modal closes (user may have saved or removed)
+  const handleCloseSettings = useCallback(() => {
+    setShowSettings(false);
+    setApiKey(getRentCastKey());
+  }, []);
+
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {
     setProFormaMode(pf);
@@ -533,6 +544,20 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
           <span className="hidden text-xs text-lo sm:inline">{proFormaMode ? 'Pro-Forma' : 'Screener'}</span>
         </div>
         <div className="no-print flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowSettings(true)}
+            className="
+              rounded border border-border px-3 py-1.5
+              text-xs text-mid uppercase tracking-widest
+              hover:border-accent hover:text-accent
+              transition-colors
+            "
+            aria-label="Open settings"
+            title="Settings"
+          >
+            ⚙
+          </button>
           <UiModeToggle uiMode={uiMode} onChange={handleSetUiMode} />
           <ModeToggle
             proFormaMode={proFormaMode}
@@ -610,6 +635,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               dispatch={dispatchToActive}
               proFormaMode={proFormaMode}
               uiMode={uiMode}
+              apiKey={apiKey}
             />
           </div>
         </aside>
@@ -647,6 +673,8 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
           )}
         </section>
       </main>
+
+      {showSettings && <ConnectorSettingsModal onClose={handleCloseSettings} />}
     </div>
   );
 }

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -138,7 +138,10 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
               </div>
             ) : (
               <div className="flex gap-2 items-center">
-                <code className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono overflow-hidden break-all">
+                <code
+                  className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono overflow-hidden break-all"
+                  aria-label={storedKey ? `API key ending in ${storedKey.slice(-4)}` : undefined}
+                >
                   {maskedKey}
                 </code>
                 <button

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../state/connectorStorage';
+
+interface ConnectorSettingsModalProps {
+  onClose: () => void;
+}
+
+/**
+ * Settings modal — Data Connectors section.
+ *
+ * Opened by the ⚙ Settings button in the Evaluator header.
+ * Manages the RentCast API key (read/write/clear to localStorage).
+ * Designed to grow: additional settings (dark mode, etc.) slot in below.
+ */
+export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps) {
+  const [storedKey, setStoredKey] = useState<string | null>(() => getRentCastKey());
+  const [inputValue, setInputValue]   = useState('');
+  const [isEditing, setIsEditing]     = useState(storedKey === null);
+
+  const handleSave = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    setRentCastKey(trimmed);
+    setStoredKey(trimmed);
+    setInputValue('');
+    setIsEditing(false);
+  };
+
+  const handleRemove = () => {
+    clearRentCastKey();
+    setStoredKey(null);
+    setInputValue('');
+    setIsEditing(true);
+  };
+
+  const handleChange = () => {
+    setInputValue('');
+    setIsEditing(true);
+  };
+
+  // Mask key: show last 4 chars, mask the rest
+  const maskedKey = storedKey
+    ? `rc_live_${'•'.repeat(Math.max(0, storedKey.length - 12))}${storedKey.slice(-4)}`
+    : null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h2 className="text-sm font-semibold text-hi">Settings</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-lo hover:text-hi transition-colors"
+            aria-label="Close settings"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-4">
+          {/* Section label */}
+          <p className="text-xs uppercase tracking-widest text-lo">Data Connectors</p>
+
+          {/* RentCast row */}
+          <div className="rounded border border-border bg-raised p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-hi">RentCast</span>
+                {storedKey && (
+                  <span className="rounded-full bg-green-900/50 px-2 py-0.5 text-xs text-green-400">
+                    ● Connected
+                  </span>
+                )}
+              </div>
+              {storedKey && !isEditing && (
+                <button
+                  type="button"
+                  onClick={handleRemove}
+                  className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+
+            {isEditing ? (
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+                  placeholder="rc_live_…"
+                  className="
+                    flex-1 rounded border border-border bg-base px-3 py-1.5
+                    text-xs text-hi placeholder:text-lo
+                    focus:border-accent focus:outline-none
+                  "
+                  autoFocus
+                  aria-label="RentCast API key"
+                />
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!inputValue.trim()}
+                  className="
+                    rounded border border-accent px-3 py-1.5 text-xs text-accent
+                    hover:bg-accent hover:text-base transition-colors
+                    disabled:opacity-40 disabled:cursor-not-allowed
+                  "
+                >
+                  Save
+                </button>
+              </div>
+            ) : (
+              <div className="flex gap-2 items-center">
+                <code className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono">
+                  {maskedKey}
+                </code>
+                <button
+                  type="button"
+                  onClick={handleChange}
+                  className="
+                    rounded border border-border px-3 py-1.5 text-xs text-mid
+                    hover:border-accent hover:text-accent transition-colors
+                  "
+                >
+                  Change
+                </button>
+              </div>
+            )}
+
+            <p className="text-xs text-lo">
+              Free tier: 50 req/mo ·{' '}
+              <a
+                href="https://app.rentcast.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                Get a key at app.rentcast.io ↗
+              </a>
+            </p>
+          </div>
+
+          {/* Future connectors placeholder */}
+          <div className="rounded border border-dashed border-border px-4 py-3">
+            <p className="text-xs text-lo">+ Add another connector <span className="opacity-50">(coming soon)</span></p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end border-t border-border px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="
+              rounded border border-border px-4 py-1.5 text-xs text-mid
+              hover:border-accent hover:text-accent transition-colors
+            "
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -28,16 +28,18 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
     const trimmed = inputValue.trim();
     if (!trimmed) return;
     setRentCastKey(trimmed);
-    setStoredKey(trimmed);
+    const persisted = getRentCastKey();
+    setStoredKey(persisted);
     setInputValue('');
-    setIsEditing(false);
+    setIsEditing(persisted === null);
   };
 
   const handleRemove = () => {
     clearRentCastKey();
-    setStoredKey(null);
+    const persisted = getRentCastKey();
+    setStoredKey(persisted);
     setInputValue('');
-    setIsEditing(true);
+    setIsEditing(persisted === null);
   };
 
   const handleChange = () => {
@@ -45,9 +47,9 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
     setIsEditing(true);
   };
 
-  // Mask key: show last 4 chars, mask the rest
+  // Mask key: show last 4 chars, mask the rest (prefix-agnostic)
   const maskedKey = storedKey
-    ? `rc_live_${'•'.repeat(Math.max(0, storedKey.length - 12))}${storedKey.slice(-4)}`
+    ? `${'•'.repeat(Math.max(4, storedKey.length - 4))}${storedKey.slice(-4)}`
     : null;
 
   return (

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../state/connectorStorage';
 
 interface ConnectorSettingsModalProps {
@@ -14,6 +14,7 @@ interface ConnectorSettingsModalProps {
  */
 export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps) {
   const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
   const [storedKey, setStoredKey] = useState<string | null>(() => getRentCastKey());
   const [inputValue, setInputValue]   = useState('');
   const [isEditing, setIsEditing]     = useState(storedKey === null);
@@ -23,6 +24,35 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
+
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(
+          'button:not([disabled]), input:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0] as HTMLElement;
+      const last = focusable[focusable.length - 1] as HTMLElement;
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    panel.addEventListener('keydown', handler);
+    return () => panel.removeEventListener('keydown', handler);
+  }, [isEditing]); // re-query focusable elements when editing state changes
 
   const handleSave = () => {
     const trimmed = inputValue.trim();
@@ -61,7 +91,7 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
       aria-modal="true"
       aria-labelledby={titleId}
     >
-      <div className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
+      <div ref={panelRef} className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <h2 id={titleId} className="text-sm font-semibold text-hi">Settings</h2>

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -87,11 +87,14 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
     >
-      <div ref={panelRef} className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
           <h2 id={titleId} className="text-sm font-semibold text-hi">Settings</h2>

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../state/connectorStorage';
 
 interface ConnectorSettingsModalProps {
@@ -13,9 +13,16 @@ interface ConnectorSettingsModalProps {
  * Designed to grow: additional settings (dark mode, etc.) slot in below.
  */
 export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps) {
+  const titleId = useId();
   const [storedKey, setStoredKey] = useState<string | null>(() => getRentCastKey());
   const [inputValue, setInputValue]   = useState('');
   const [isEditing, setIsEditing]     = useState(storedKey === null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
 
   const handleSave = () => {
     const trimmed = inputValue.trim();
@@ -50,12 +57,12 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"
-      aria-label="Settings"
+      aria-labelledby={titleId}
     >
       <div className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
-          <h2 className="text-sm font-semibold text-hi">Settings</h2>
+          <h2 id={titleId} className="text-sm font-semibold text-hi">Settings</h2>
           <button
             type="button"
             onClick={onClose}

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -49,7 +49,7 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
 
   // Mask key: show last 4 chars, mask the rest (prefix-agnostic)
   const maskedKey = storedKey
-    ? `${'•'.repeat(Math.max(4, storedKey.length - 4))}${storedKey.slice(-4)}`
+    ? `${'•'.repeat(Math.max(0, storedKey.length - 4))}${storedKey.slice(-4)}`
     : null;
 
   return (
@@ -70,6 +70,7 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
             onClick={onClose}
             className="text-lo hover:text-hi transition-colors"
             aria-label="Close settings"
+            autoFocus={storedKey !== null && !isEditing}
           >
             ✕
           </button>
@@ -116,6 +117,10 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
                     focus:border-accent focus:outline-none
                   "
                   autoFocus
+                  autoComplete="off"
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  spellCheck={false}
                   aria-label="RentCast API key"
                 />
                 <button
@@ -133,7 +138,7 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
               </div>
             ) : (
               <div className="flex gap-2 items-center">
-                <code className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono">
+                <code className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono overflow-hidden break-all">
                   {maskedKey}
                 </code>
                 <button

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -24,6 +24,8 @@ export interface DealInputsFormProps {
    * - 'complex' — shows all sections (default, current behaviour).
    */
   uiMode?: UiMode;
+  /** RentCast API key from connectorStorage. Passed to AutofillBar (wired in RPE-43d). */
+  apiKey?: string | null;
 }
 
 /**
@@ -40,6 +42,7 @@ export function DealInputsForm({
   dispatch,
   proFormaMode = false,
   uiMode = 'complex',
+  apiKey: _apiKey,  // unused until RPE-43d
 }: DealInputsFormProps) {
   const { expenses } = state;
   const simple = uiMode === 'simple';

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -8,7 +8,7 @@
  * except the user's own API calls to RentCast.
  */
 
-const STORAGE_KEY = 'rpe:connectors:rentcast';
+export const STORAGE_KEY = 'rpe:connectors:rentcast';
 
 export function getRentCastKey(): string | null {
   try {

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -3,8 +3,8 @@
  *
  * Key: 'rpe:connectors:rentcast'
  *
- * The key belongs to the user — it is never sent anywhere except the
- * POST /property proxy call where the user explicitly triggers autofill.
+ * The key belongs to the user and is only read when the user explicitly
+ * triggers an autofill lookup.
  */
 
 const STORAGE_KEY = 'rpe:connectors:rentcast';

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -13,7 +13,9 @@ const STORAGE_KEY = 'rpe:connectors:rentcast';
 export function getRentCastKey(): string | null {
   try {
     const value = localStorage.getItem(STORAGE_KEY);
-    return value !== null && value.trim() !== '' ? value : null;
+    if (value === null) return null;
+    const trimmed = value.trim();
+    return trimmed !== '' ? trimmed : null;
   } catch {
     // localStorage unavailable (private browsing, SSR, etc.)
     return null;

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -1,0 +1,35 @@
+/**
+ * Persists the user's RentCast API key in localStorage.
+ *
+ * Key: 'rpe:connectors:rentcast'
+ *
+ * The key belongs to the user — it is never sent anywhere except the
+ * POST /property proxy call where the user explicitly triggers autofill.
+ */
+
+const STORAGE_KEY = 'rpe:connectors:rentcast';
+
+export function getRentCastKey(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable (private browsing, SSR, etc.)
+    return null;
+  }
+}
+
+export function setRentCastKey(key: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    // Silently ignore — storage quota exceeded or unavailable
+  }
+}
+
+export function clearRentCastKey(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Silently ignore
+  }
+}

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -12,7 +12,8 @@ const STORAGE_KEY = 'rpe:connectors:rentcast';
 
 export function getRentCastKey(): string | null {
   try {
-    return localStorage.getItem(STORAGE_KEY);
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value !== null && value.trim() !== '' ? value : null;
   } catch {
     // localStorage unavailable (private browsing, SSR, etc.)
     return null;
@@ -20,8 +21,10 @@ export function getRentCastKey(): string | null {
 }
 
 export function setRentCastKey(key: string): void {
+  const trimmed = key.trim();
+  if (!trimmed) return;
   try {
-    localStorage.setItem(STORAGE_KEY, key);
+    localStorage.setItem(STORAGE_KEY, trimmed);
   } catch {
     // Silently ignore — storage quota exceeded or unavailable
   }

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -3,8 +3,9 @@
  *
  * Key: 'rpe:connectors:rentcast'
  *
- * The key belongs to the user and is only read when the user explicitly
- * triggers an autofill lookup.
+ * The key is read on Evaluator mount, on Settings modal close, and when the
+ * user triggers an autofill lookup. It is never transmitted to any server
+ * except the user's own API calls to RentCast.
  */
 
 const STORAGE_KEY = 'rpe:connectors:rentcast';

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -52,7 +52,8 @@ describe('connectorStorage', () => {
   });
 
   it('getRentCastKey returns null when localStorage throws', () => {
-    const broken = { ...localStorage, getItem: () => { throw new Error('denied'); } };
+    const broken = new LocalStorageMock();
+    broken.getItem = () => { throw new Error('denied'); };
     vi.stubGlobal('localStorage', broken);
     expect(getRentCastKey()).toBeNull();
   });

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -55,6 +55,5 @@ describe('connectorStorage', () => {
     const broken = { ...localStorage, getItem: () => { throw new Error('denied'); } };
     vi.stubGlobal('localStorage', broken);
     expect(getRentCastKey()).toBeNull();
-    vi.unstubAllGlobals();
   });
 });

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -50,4 +50,11 @@ describe('connectorStorage', () => {
     setRentCastKey('new_key');
     expect(getRentCastKey()).toBe('new_key');
   });
+
+  it('getRentCastKey returns null when localStorage throws', () => {
+    const broken = { ...localStorage, getItem: () => { throw new Error('denied'); } };
+    vi.stubGlobal('localStorage', broken);
+    expect(getRentCastKey()).toBeNull();
+    vi.unstubAllGlobals();
+  });
 });

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../src/state/connectorStorage';
+import { getRentCastKey, setRentCastKey, clearRentCastKey, STORAGE_KEY } from '../src/state/connectorStorage';
 
 // ─── localStorage stub ────────────────────────────────────────────────────────
 
@@ -53,12 +53,12 @@ describe('connectorStorage', () => {
 
   it('getRentCastKey trims and returns null for whitespace-only stored value', () => {
     // Directly set a whitespace-only value to simulate legacy storage
-    localStorage.setItem('rpe:connectors:rentcast', '   ');
+    localStorage.setItem(STORAGE_KEY, '   ');
     expect(getRentCastKey()).toBeNull();
   });
 
   it('getRentCastKey trims surrounding whitespace from stored value', () => {
-    localStorage.setItem('rpe:connectors:rentcast', '  rc_live_abc  ');
+    localStorage.setItem(STORAGE_KEY, '  rc_live_abc  ');
     expect(getRentCastKey()).toBe('rc_live_abc');
   });
 

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../src/state/connectorStorage';
+
+// ─── localStorage stub ────────────────────────────────────────────────────────
+
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? (this.store[key] ?? null)
+      : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+  clear(): void {
+    this.store = {};
+  }
+}
+
+describe('connectorStorage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', new LocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('getRentCastKey returns null when nothing is stored', () => {
+    expect(getRentCastKey()).toBeNull();
+  });
+
+  it('setRentCastKey + getRentCastKey roundtrip', () => {
+    setRentCastKey('rc_live_abc123');
+    expect(getRentCastKey()).toBe('rc_live_abc123');
+  });
+
+  it('clearRentCastKey makes getRentCastKey return null', () => {
+    setRentCastKey('rc_live_abc123');
+    clearRentCastKey();
+    expect(getRentCastKey()).toBeNull();
+  });
+
+  it('setRentCastKey overwrites an existing key', () => {
+    setRentCastKey('old_key');
+    setRentCastKey('new_key');
+    expect(getRentCastKey()).toBe('new_key');
+  });
+});

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -51,6 +51,17 @@ describe('connectorStorage', () => {
     expect(getRentCastKey()).toBe('new_key');
   });
 
+  it('getRentCastKey trims and returns null for whitespace-only stored value', () => {
+    // Directly set a whitespace-only value to simulate legacy storage
+    localStorage.setItem('rpe:connectors:rentcast', '   ');
+    expect(getRentCastKey()).toBeNull();
+  });
+
+  it('getRentCastKey trims surrounding whitespace from stored value', () => {
+    localStorage.setItem('rpe:connectors:rentcast', '  rc_live_abc  ');
+    expect(getRentCastKey()).toBe('rc_live_abc');
+  });
+
   it('getRentCastKey returns null when localStorage throws', () => {
     const broken = new LocalStorageMock();
     broken.getItem = () => { throw new Error('denied'); };


### PR DESCRIPTION
## Summary

- New `connectorStorage.ts` — localStorage wrapper for the user's RentCast API key (`rpe:connectors:rentcast`)
- New `ConnectorSettingsModal.tsx` — modal with connected/disconnected states, masked key display (last 4 chars), Change/Remove/Save, Escape to close, `aria-labelledby`, app.rentcast.io link, "coming soon" placeholder
- `Evaluator.tsx` — ⚙ Settings button in header (first in button group), `showSettings`/`apiKey` state, `handleCloseSettings` refreshes key from storage; passes `apiKey` down to `DealInputsForm`
- `DealInputsForm.tsx` — `apiKey?: string | null` prop stub added (wired fully in RPE-43d)

## Test Plan
- [ ] `pnpm test packages/ui` — 4 new connectorStorage tests pass; full suite green
- [ ] `pnpm lint && pnpm typecheck` — clean
- [ ] Open Settings modal in browser — verify connected/disconnected states, masking, Escape close, backdrop click close

## Notes
Part of E7 RentCast autofill (RPE-43). No dependency on RPE-43a/b. Can be cherry-picked in parallel with RPE-43a.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)