### PR TITLE
RPE-43b: feat(api): POST /property route for RentCast autofill

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@rpe/engine": "workspace:*"
+    "@rpe/engine": "workspace:*",
+    "@rpe/rentcast": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,7 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { evaluate } from '@rpe/engine';
 import type { DealInputs, EvalOptions } from '@rpe/engine';
+import { handleProperty } from './routes/property.js';
 
 // Hoist __filename/__dirname for use in VERSION and the entry-point guard below.
 const __filename = fileURLToPath(import.meta.url);
@@ -351,6 +352,8 @@ export function createApp() {
     const asyncHandler =
       url === '/evaluate' || url === '/evaluate/'
         ? () => handleEvaluate(req, res)
+        : url === '/property' || url === '/property/'
+        ? () => handleProperty(req, res, json, readBody)
         : () => {
             json(res, 404, { error: `Unknown endpoint: ${url}` });
             return Promise.resolve();
@@ -375,6 +378,7 @@ if (resolve(process.argv[1] ?? '') === __filename) {
     console.log(`@rpe/api ${VERSION} listening on http://${host}:${port}`);
     console.log('  GET  /health');
     console.log('  POST /evaluate');
+    console.log('  POST /property');
   });
   server.on('error', (err) => {
     console.error('Server error:', err);

--- a/apps/api/src/routes/property.ts
+++ b/apps/api/src/routes/property.ts
@@ -73,8 +73,15 @@ export async function handleProperty(
         rate_limit: 429,
         unknown:    502,
       };
-      const status = statusMap[err.code];
-      json(res, status, { error: err.message });
+      // Use sanitised messages — never forward err.message which may contain
+      // the encoded address query string from the upstream RentCast request.
+      const clientMessages: Record<RentCastErrorCode, string> = {
+        bad_key:    'Invalid or expired API key.',
+        not_found:  'Property not found for this address.',
+        rate_limit: 'Rate limit reached. Check your RentCast plan.',
+        unknown:    'RentCast lookup failed.',
+      };
+      json(res, statusMap[err.code], { error: clientMessages[err.code] });
       return;
     }
     // Log address only — never apiKey

--- a/apps/api/src/routes/property.ts
+++ b/apps/api/src/routes/property.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { fetchPropertyData, RentCastError } from '@rpe/rentcast';
+import { fetchPropertyData, RentCastError, type RentCastErrorCode } from '@rpe/rentcast';
 
 // Imported from the parent module — passed in to avoid circular imports.
 type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
@@ -48,11 +48,11 @@ export async function handleProperty(
     return;
   }
   const obj = parsed as Record<string, unknown>;
-  if (typeof obj['address'] !== 'string' || obj['address'].trim() === '') {
+  if (!Object.hasOwn(obj, 'address') || typeof obj['address'] !== 'string' || obj['address'].trim() === '') {
     json(res, 400, { error: 'address is required and must be a non-empty string' });
     return;
   }
-  if (typeof obj['apiKey'] !== 'string' || obj['apiKey'].trim() === '') {
+  if (!Object.hasOwn(obj, 'apiKey') || typeof obj['apiKey'] !== 'string' || obj['apiKey'].trim() === '') {
     json(res, 400, { error: 'apiKey is required and must be a non-empty string' });
     return;
   }
@@ -67,13 +67,13 @@ export async function handleProperty(
     if (err instanceof RentCastError) {
       // Map RentCast error codes to HTTP status codes.
       // Never include apiKey in error response or logs.
-      const statusMap: Record<string, number> = {
+      const statusMap: Record<RentCastErrorCode, number> = {
         bad_key:    401,
         not_found:  404,
         rate_limit: 402,
         unknown:    502,
       };
-      const status = statusMap[err.code] ?? 502;
+      const status = statusMap[err.code];
       json(res, status, { error: err.message });
       return;
     }

--- a/apps/api/src/routes/property.ts
+++ b/apps/api/src/routes/property.ts
@@ -43,6 +43,10 @@ export async function handleProperty(
     return;
   }
 
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    json(res, 400, { error: 'Request body must be { address: string, apiKey: string }' });
+    return;
+  }
   const obj = parsed as Record<string, unknown>;
   if (typeof obj['address'] !== 'string' || obj['address'].trim() === '') {
     json(res, 400, { error: 'address is required and must be a non-empty string' });

--- a/apps/api/src/routes/property.ts
+++ b/apps/api/src/routes/property.ts
@@ -1,0 +1,80 @@
+/**
+ * POST /property — RentCast proxy route (RPE-43b)
+ *
+ * Receives { address: string, apiKey: string }, calls fetchPropertyData,
+ * and returns { data: PropertyData }.
+ *
+ * The apiKey is forwarded to RentCast and never written to any log output.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { fetchPropertyData, RentCastError } from '@rpe/rentcast';
+
+// Imported from the parent module — passed in to avoid circular imports.
+type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
+type ReadBodyFn = (req: IncomingMessage) => Promise<string>;
+
+export async function handleProperty(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: JsonFn,
+  readBody: ReadBodyFn,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed — use POST' });
+    return;
+  }
+
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to read request body';
+    const status = msg === 'Payload too large' ? 413 : 400;
+    json(res, status, { error: msg });
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    json(res, 400, { error: 'Invalid JSON' });
+    return;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj['address'] !== 'string' || obj['address'].trim() === '') {
+    json(res, 400, { error: 'address is required and must be a non-empty string' });
+    return;
+  }
+  if (typeof obj['apiKey'] !== 'string' || obj['apiKey'].trim() === '') {
+    json(res, 400, { error: 'apiKey is required and must be a non-empty string' });
+    return;
+  }
+
+  const address = obj['address'].trim();
+  const apiKey  = obj['apiKey'].trim();
+
+  try {
+    const data = await fetchPropertyData(address, apiKey);
+    json(res, 200, { data });
+  } catch (err) {
+    if (err instanceof RentCastError) {
+      // Map RentCast error codes to HTTP status codes.
+      // Never include apiKey in error response or logs.
+      const statusMap: Record<string, number> = {
+        bad_key:    401,
+        not_found:  404,
+        rate_limit: 402,
+        unknown:    502,
+      };
+      const status = statusMap[err.code] ?? 502;
+      json(res, status, { error: err.message });
+      return;
+    }
+    // Log address only — never apiKey
+    console.error('Property lookup error for address:', address, err instanceof Error ? err.stack : String(err));
+    json(res, 500, { error: 'Internal server error' });
+  }
+}

--- a/apps/api/src/routes/property.ts
+++ b/apps/api/src/routes/property.ts
@@ -70,7 +70,7 @@ export async function handleProperty(
       const statusMap: Record<RentCastErrorCode, number> = {
         bad_key:    401,
         not_found:  404,
-        rate_limit: 402,
+        rate_limit: 429,
         unknown:    502,
       };
       const status = statusMap[err.code];

--- a/apps/api/tests/property.test.ts
+++ b/apps/api/tests/property.test.ts
@@ -141,6 +141,16 @@ describe('POST /property', () => {
     expect(res.status).toBe(402);
   });
 
+  it('returns 502 when fetchPropertyData throws unknown RentCast error', async () => {
+    mockFetch.mockRejectedValue(new RentCastError('unknown', 'unknown error'));
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+    expect(res.status).toBe(502);
+  });
+
   // ── Security ────────────────────────────────────────────────────────────────
 
   it('apiKey value does not appear in response body on error', async () => {

--- a/apps/api/tests/property.test.ts
+++ b/apps/api/tests/property.test.ts
@@ -1,0 +1,156 @@
+/**
+ * RPE-43b: POST /property integration tests
+ *
+ * Uses vi.mock to stub fetchPropertyData so no real HTTP calls are made.
+ * Server lifecycle mirrors apps/api/tests/server.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+
+// Mock the rentcast client before importing createApp (hoisted by vitest)
+vi.mock('@rpe/rentcast', () => ({
+  fetchPropertyData: vi.fn(),
+  RentCastError: class RentCastError extends Error {
+    constructor(public code: string, message: string) { super(message); this.name = 'RentCastError'; }
+  },
+}));
+
+import { fetchPropertyData, RentCastError } from '@rpe/rentcast';
+const mockFetch = vi.mocked(fetchPropertyData);
+
+const VALID_BODY = { address: '123 Main St, Austin TX 78701', apiKey: 'rc_test_key' };
+
+const MOCK_DATA = {
+  purchasePrice: 342_000,
+  grossRent: 2_150,
+  sqft: 1_480,
+  units: 1,
+  annualTaxes: 4_210,
+};
+
+describe('POST /property', () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server = createApp();
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          const addr = server.address() as { port: number };
+          base = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(
+    () => new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  );
+
+  beforeEach(() => { vi.resetAllMocks(); });
+
+  // ── Happy path ──────────────────────────────────────────────────────────────
+
+  it('returns 200 with PropertyData on success', async () => {
+    mockFetch.mockResolvedValue(MOCK_DATA);
+
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body['data']).toEqual(MOCK_DATA);
+  });
+
+  it('calls fetchPropertyData with the address and apiKey from the request', async () => {
+    mockFetch.mockResolvedValue(MOCK_DATA);
+
+    await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(VALID_BODY.address, VALID_BODY.apiKey);
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  it('returns 400 when address is missing', async () => {
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ apiKey: 'key' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when apiKey is missing', async () => {
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: '123 Main St' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 405 for non-POST methods', async () => {
+    const res = await fetch(`${base}/property`);
+    expect(res.status).toBe(405);
+  });
+
+  // ── RentCast error mapping ──────────────────────────────────────────────────
+
+  it('returns 401 when fetchPropertyData throws bad_key', async () => {
+    mockFetch.mockRejectedValue(new RentCastError('bad_key', 'bad key'));
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when fetchPropertyData throws not_found', async () => {
+    mockFetch.mockRejectedValue(new RentCastError('not_found', 'not found'));
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 402 when fetchPropertyData throws rate_limit', async () => {
+    mockFetch.mockRejectedValue(new RentCastError('rate_limit', 'rate limit'));
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_BODY),
+    });
+    expect(res.status).toBe(402);
+  });
+
+  // ── Security ────────────────────────────────────────────────────────────────
+
+  it('apiKey value does not appear in response body on error', async () => {
+    mockFetch.mockRejectedValue(new RentCastError('bad_key', 'bad key'));
+    const res = await fetch(`${base}/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...VALID_BODY, apiKey: 'SECRET_KEY_VALUE' }),
+    });
+    const text = await res.text();
+    expect(text).not.toContain('SECRET_KEY_VALUE');
+  });
+});

--- a/apps/api/tests/property.test.ts
+++ b/apps/api/tests/property.test.ts
@@ -8,8 +8,10 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import type { Server } from 'node:http';
 import { createApp } from '../src/index';
+import { fetchPropertyData, RentCastError } from '@rpe/rentcast';
 
-// Mock the rentcast client before importing createApp (hoisted by vitest)
+// Vitest hoists vi.mock above all import statements, so @rpe/rentcast is stubbed
+// before createApp (and its route module that imports it) is evaluated.
 vi.mock('@rpe/rentcast', () => ({
   fetchPropertyData: vi.fn(),
   RentCastError: class RentCastError extends Error {
@@ -17,7 +19,6 @@ vi.mock('@rpe/rentcast', () => ({
   },
 }));
 
-import { fetchPropertyData, RentCastError } from '@rpe/rentcast';
 const mockFetch = vi.mocked(fetchPropertyData);
 
 const VALID_BODY = { address: '123 Main St, Austin TX 78701', apiKey: 'rc_test_key' };

--- a/apps/api/tests/property.test.ts
+++ b/apps/api/tests/property.test.ts
@@ -131,14 +131,14 @@ describe('POST /property', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 402 when fetchPropertyData throws rate_limit', async () => {
+  it('returns 429 when fetchPropertyData throws rate_limit', async () => {
     mockFetch.mockRejectedValue(new RentCastError('rate_limit', 'rate limit'));
     const res = await fetch(`${base}/property`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(VALID_BODY),
     });
-    expect(res.status).toBe(402);
+    expect(res.status).toBe(429);
   });
 
   it('returns 502 when fetchPropertyData throws unknown RentCast error', async () => {

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     sourcemap: true,
   },
   ssr: {
-    noExternal: ['@rpe/engine'],
+    noExternal: ['@rpe/engine', '@rpe/rentcast'],
   },
   resolve: {
     conditions: ['import', 'default'],

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -4,8 +4,8 @@ import { defineConfig } from 'vite';
  * Vite SSR build for the thin calc API server (RPE-40).
  *
  * - `ssr.entry`: bundles src/index.ts for Node.js.
- * - `ssr.noExternal: ['@rpe/engine']`: forces @rpe/engine source inline —
- *   Vite SSR externalises workspace deps by default; this overrides that.
+ * - `ssr.noExternal: ['@rpe/engine', '@rpe/rentcast']`: forces both workspace
+ *   packages inline — Vite SSR externalises workspace deps by default; this overrides that.
  * - Node built-ins (node:http, node:url, etc.) are automatically externalised.
  * - Output: dist/index.js (ESM, runnable with `node dist/index.js`).
  */

--- a/packages/rentcast/package.json
+++ b/packages/rentcast/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@rpe/rentcast",
+  "version": "1.3.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/rentcast/package.json
+++ b/packages/rentcast/package.json
@@ -6,7 +6,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -19,6 +19,12 @@ async function rcGet(path: string, apiKey: string): Promise<unknown> {
   return res.json() as Promise<unknown>;
 }
 
+function ensureRentCastError(reason: unknown): RentCastError {
+  if (reason instanceof RentCastError) return reason;
+  const msg = reason instanceof Error ? reason.message : String(reason);
+  return new RentCastError('unknown', `Network error: ${msg}`);
+}
+
 /**
  * Fetch property data from RentCast for the given address.
  *
@@ -47,8 +53,8 @@ export async function fetchPropertyData(
   ]);
 
   // AVM failures are fatal
-  if (avm.status === 'rejected') throw avm.reason as RentCastError;
-  if (rent.status === 'rejected') throw rent.reason as RentCastError;
+  if (avm.status === 'rejected') throw ensureRentCastError(avm.reason);
+  if (rent.status === 'rejected') throw ensureRentCastError(rent.reason);
 
   const avmData  = avm.value  as { price: number };
   const rentData = rent.value as { rent: number };

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -1,0 +1,82 @@
+import { RentCastError, type PropertyData, type RentCastErrorCode } from './types';
+
+const BASE = 'https://api.rentcast.io/v1';
+
+function statusToCode(status: number): RentCastErrorCode {
+  if (status === 401 || status === 403) return 'bad_key';
+  if (status === 404) return 'not_found';
+  if (status === 429) return 'rate_limit';
+  return 'unknown';
+}
+
+async function rcGet(path: string, apiKey: string): Promise<unknown> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path}`);
+  }
+  return res.json() as Promise<unknown>;
+}
+
+/**
+ * Fetch property data from RentCast for the given address.
+ *
+ * Makes three API calls in parallel:
+ *   /avm/value            → purchasePrice
+ *   /avm/rent/long-term   → grossRent
+ *   /properties           → sqft, units, annualTaxes (best-effort; null on 404)
+ *
+ * Throws RentCastError if either AVM call fails.
+ * /properties failure is soft — nullable fields return null.
+ *
+ * FIELD NAME VERIFICATION: Before shipping, confirm these field names against
+ * https://developers.rentcast.io/reference by running a live API call:
+ *   curl -H "X-Api-Key: $KEY" 'https://api.rentcast.io/v1/properties?address=123+Main+St&limit=1'
+ */
+export async function fetchPropertyData(
+  address: string,
+  apiKey: string,
+): Promise<PropertyData> {
+  const encoded = encodeURIComponent(address);
+
+  const [avm, rent, props] = await Promise.allSettled([
+    rcGet(`/avm/value?address=${encoded}`, apiKey),
+    rcGet(`/avm/rent/long-term?address=${encoded}`, apiKey),
+    rcGet(`/properties?address=${encoded}&limit=1`, apiKey),
+  ]);
+
+  // AVM failures are fatal
+  if (avm.status === 'rejected') throw avm.reason as RentCastError;
+  if (rent.status === 'rejected') throw rent.reason as RentCastError;
+
+  const avmData  = avm.value  as { price: number };
+  const rentData = rent.value as { rent: number };
+
+  let sqft: number | null        = null;
+  let units: number | null       = null;
+  let annualTaxes: number | null = null;
+
+  if (props.status === 'fulfilled') {
+    // /properties returns an array; we requested limit=1
+    const list = props.value as Array<{
+      squareFootage?: number;
+      units?: number;
+      // propertyTaxes is keyed by tax year: { "2023": { total: number } }
+      propertyTaxes?: Record<string, { total: number }>;
+    }>;
+    const p = list[0];
+    if (p) {
+      sqft  = typeof p.squareFootage === 'number' ? p.squareFootage : null;
+      units = typeof p.units         === 'number' ? p.units         : null;
+      if (p.propertyTaxes) {
+        const years      = Object.keys(p.propertyTaxes).sort().reverse();
+        const latestYear = years[0];
+        const latestTax  = latestYear ? p.propertyTaxes[latestYear] : undefined;
+        annualTaxes      = latestTax?.total ?? null;
+      }
+    }
+  }
+
+  return { purchasePrice: avmData.price, grossRent: rentData.rent, sqft, units, annualTaxes };
+}

--- a/packages/rentcast/src/index.ts
+++ b/packages/rentcast/src/index.ts
@@ -1,0 +1,3 @@
+export { fetchPropertyData } from './client';
+export { RentCastError } from './types';
+export type { PropertyData, RentCastErrorCode } from './types';

--- a/packages/rentcast/src/types.ts
+++ b/packages/rentcast/src/types.ts
@@ -1,0 +1,30 @@
+/** Codes that identify why a RentCast request failed. */
+export type RentCastErrorCode = 'not_found' | 'bad_key' | 'rate_limit' | 'unknown';
+
+/** Thrown by fetchPropertyData on any RentCast API error. */
+export class RentCastError extends Error {
+  constructor(
+    public readonly code: RentCastErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RentCastError';
+  }
+}
+
+/**
+ * Property data returned after a successful autofill lookup.
+ * Fields sourced from /properties are null when RentCast returns no record.
+ */
+export interface PropertyData {
+  /** AVM mid-point estimate from /avm/value */
+  purchasePrice: number;
+  /** Monthly rent estimate from /avm/rent/long-term */
+  grossRent: number;
+  /** Square footage from /properties — null if not found */
+  sqft: number | null;
+  /** Unit count from /properties — null if not found */
+  units: number | null;
+  /** Annual property taxes from /properties — null if not found */
+  annualTaxes: number | null;
+}

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -143,5 +143,13 @@ describe('fetchPropertyData', () => {
         (e: unknown) => e instanceof RentCastError && e.code === 'rate_limit',
       );
     });
+
+    it('throws RentCastError unknown when fetch rejects with a network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'unknown',
+      );
+    });
   });
 });

--- a/packages/rentcast/tests/client.test.ts
+++ b/packages/rentcast/tests/client.test.ts
@@ -1,0 +1,147 @@
+/**
+ * RPE-43a: fetchPropertyData unit tests
+ *
+ * All RentCast HTTP calls are mocked via vi.mock on globalThis.fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchPropertyData } from '../src/client';
+import { RentCastError } from '../src/types';
+
+// ─── Mock helpers ─────────────────────────────────────────────────────────────
+
+function mockOk(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function mockFail(status: number): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message: `HTTP ${status}` }),
+  } as unknown as Response;
+}
+
+// RentCast response shapes
+// Verify field names against https://developers.rentcast.io/reference before shipping.
+const AVM_VALUE_RESPONSE   = { price: 342_000, priceRangeLow: 315_000, priceRangeHigh: 369_000 };
+const AVM_RENT_RESPONSE    = { rent: 2_150, rentRangeLow: 1_950, rentRangeHigh: 2_350 };
+const PROPERTIES_RESPONSE  = [
+  {
+    squareFootage: 1_480,
+    units: 1,
+    // propertyTaxes is a record keyed by tax year: { "2023": { total: 4210 } }
+    // If the field name or shape differs in the live API, adjust here + in client.ts
+    propertyTaxes: { '2023': { total: 4_210 } },
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('fetchPropertyData', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('returns all five fields when all three calls succeed', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      const result = await fetchPropertyData('123 Main St, Austin TX', 'rc_test_key');
+
+      expect(result.purchasePrice).toBe(342_000);
+      expect(result.grossRent).toBe(2_150);
+      expect(result.sqft).toBe(1_480);
+      expect(result.units).toBe(1);
+      expect(result.annualTaxes).toBe(4_210);
+    });
+
+    it('makes all three RentCast calls in parallel', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValue(mockOk(AVM_VALUE_RESPONSE));
+
+      // Override later calls to return appropriate shapes
+      fetchSpy
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      await fetchPropertyData('123 Main St', 'key');
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('partial success', () => {
+    it('returns null sqft/units/annualTaxes when /properties returns 404', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockFail(404));
+
+      const result = await fetchPropertyData('123 Main St', 'key');
+
+      expect(result.purchasePrice).toBe(342_000);
+      expect(result.grossRent).toBe(2_150);
+      expect(result.sqft).toBeNull();
+      expect(result.units).toBeNull();
+      expect(result.annualTaxes).toBeNull();
+    });
+
+    it('returns null for nullable fields when properties response is empty array', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockOk(AVM_VALUE_RESPONSE))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk([]));
+
+      const result = await fetchPropertyData('123 Main St', 'key');
+
+      expect(result.sqft).toBeNull();
+      expect(result.units).toBeNull();
+      expect(result.annualTaxes).toBeNull();
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws RentCastError bad_key on 401', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(401));
+
+      await expect(fetchPropertyData('123 Main St', 'bad')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'bad_key',
+      );
+    });
+
+    it('throws RentCastError bad_key on 403', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(403));
+
+      await expect(fetchPropertyData('123 Main St', 'bad')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'bad_key',
+      );
+    });
+
+    it('throws RentCastError not_found on 404 from AVM call', async () => {
+      vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(mockFail(404))
+        .mockResolvedValueOnce(mockOk(AVM_RENT_RESPONSE))
+        .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+      await expect(fetchPropertyData('unknown address', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'not_found',
+      );
+    });
+
+    it('throws RentCastError rate_limit on 429', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockFail(429));
+
+      await expect(fetchPropertyData('123 Main St', 'key')).rejects.toSatisfy(
+        (e: unknown) => e instanceof RentCastError && e.code === 'rate_limit',
+      );
+    });
+  });
+});

--- a/packages/rentcast/tsconfig.json
+++ b/packages/rentcast/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}


### PR DESCRIPTION
## Summary

- New `POST /property` route in `apps/api` — thin HTTP proxy to `fetchPropertyData` from `@rpe/rentcast`
- 405 for non-POST; 400 for missing/invalid body, address, or apiKey fields
- Error code → HTTP status mapping: bad_key→401, not_found→404, rate_limit→429, unknown→502
- apiKey never logged on error — only address is logged for diagnostics

## Test Plan
- [ ] `pnpm test apps/api` — 10 tests pass (happy path, 400/405 validation, all error codes, security check)
- [ ] `pnpm lint && pnpm typecheck` — clean
- [ ] Depends on RPE-43a (now on v1.3.0)

## Notes
Part of E7 RentCast autofill (RPE-43). Cherry-pick order: RPE-43a ✅ → RPE-43b → RPE-43c ✅ → RPE-43d.