### PR TITLE
RPE-43d: feat(ui): useAutofill hook, AutofillBar, AutofillPreviewPopover

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,6 +4,10 @@
 # Used by Vite HTML env substitution (%VITE_APP_ORIGIN% in index.html)
 VITE_APP_ORIGIN=http://localhost:5173
 
+# ── API (RPE-43) ─────────────────────────────────────────────────────────────
+# Base URL for apps/api (RentCast autofill proxy). Defaults to localhost:3001.
+VITE_API_URL=http://localhost:3001
+
 # ── Ads (RPE-39) ─────────────────────────────────────────────────────────────
 # Override VITE_ADS_ENABLED=true via deployment env vars to enable ad slots.
 # The committed .env.production ships false; set real IDs + true at deploy time.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,8 +16,10 @@
     "@rpe/engine": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "jsdom": "^29.1.1",
     "typescript": "catalog:"
   }
 }

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -450,6 +450,10 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
   const [showSettings, setShowSettings]   = useState(false);
   const [apiKey, setApiKey]               = useState<string | null>(() => getRentCastKey());
 
+  const apiUrl =
+    (import.meta as { env?: { VITE_API_URL?: string } }).env?.['VITE_API_URL'] ??
+    'http://localhost:3001';
+
   // Refresh apiKey after the modal closes (user may have saved or removed)
   const handleCloseSettings = useCallback(() => {
     setShowSettings(false);
@@ -636,6 +640,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               proFormaMode={proFormaMode}
               uiMode={uiMode}
               apiKey={apiKey}
+              apiUrl={apiUrl}
             />
           </div>
         </aside>

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -16,6 +16,8 @@ import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from 
 import type { SavedDeal } from './state/savedDealsSchema';
 import { SIMPLE_RESULT_KEYS, type UiMode } from './state/uiMode';
 import { applySimpleBaselines } from './state/simpleBaselines';
+import { ConnectorSettingsModal } from './components/ConnectorSettingsModal';
+import { getRentCastKey } from './state/connectorStorage';
 
 // ─── Metric helpers ───────────────────────────────────────────────────────────
 
@@ -445,6 +447,15 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     }
   }, [proFormaMode]);
 
+  const [showSettings, setShowSettings]   = useState(false);
+  const [apiKey, setApiKey]               = useState<string | null>(() => getRentCastKey());
+
+  // Refresh apiKey after the modal closes (user may have saved or removed)
+  const handleCloseSettings = useCallback(() => {
+    setShowSettings(false);
+    setApiKey(getRentCastKey());
+  }, []);
+
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {
     setProFormaMode(pf);
@@ -533,6 +544,20 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
           <span className="hidden text-xs text-lo sm:inline">{proFormaMode ? 'Pro-Forma' : 'Screener'}</span>
         </div>
         <div className="no-print flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setShowSettings(true)}
+            className="
+              rounded border border-border px-3 py-1.5
+              text-xs text-mid uppercase tracking-widest
+              hover:border-accent hover:text-accent
+              transition-colors
+            "
+            aria-label="Open settings"
+            title="Settings"
+          >
+            ⚙
+          </button>
           <UiModeToggle uiMode={uiMode} onChange={handleSetUiMode} />
           <ModeToggle
             proFormaMode={proFormaMode}
@@ -610,6 +635,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               dispatch={dispatchToActive}
               proFormaMode={proFormaMode}
               uiMode={uiMode}
+              apiKey={apiKey}
             />
           </div>
         </aside>
@@ -647,6 +673,8 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
           )}
         </section>
       </main>
+
+      {showSettings && <ConnectorSettingsModal onClose={handleCloseSettings} />}
     </div>
   );
 }

--- a/packages/ui/src/components/AutofillBar.tsx
+++ b/packages/ui/src/components/AutofillBar.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useAutofill } from '../hooks/useAutofill';
+import { AutofillPreviewPopover } from './AutofillPreviewPopover';
+import type { Dispatch } from 'react';
+import type { DealAction } from '../state/dealReducer';
+
+interface AutofillBarProps {
+  dispatch: Dispatch<DealAction>;
+  apiKey: string | null;
+}
+
+/**
+ * Persistent address input bar rendered above the Acquisition section.
+ * Wraps useAutofill — handles all four states: idle, loading, error, preview.
+ *
+ * When apiKey is null (user hasn't connected RentCast), shows a prompt
+ * directing them to ⚙ Settings instead of the input.
+ */
+export function AutofillBar({ dispatch, apiKey }: AutofillBarProps) {
+  const [address, setAddress] = useState('');
+  const { status, previewData, errorMessage, trigger, apply, dismiss } = useAutofill({ dispatch, apiKey });
+
+  if (!apiKey) {
+    return (
+      <div className="px-5 py-3 border-b border-border bg-raised/50">
+        <p className="text-xs text-lo italic">
+          Connect RentCast in{' '}
+          <span className="text-mid not-italic">⚙ Settings</span>{' '}
+          to enable address autofill.
+        </p>
+      </div>
+    );
+  }
+
+  const handleTrigger = () => {
+    if (address.trim()) trigger(address);
+  };
+
+  return (
+    <div className="px-5 py-3 border-b border-border space-y-2">
+      {/* Label */}
+      <p className="text-xs uppercase tracking-widest text-lo">⚡ Autofill from address</p>
+
+      {/* Input row */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleTrigger(); }}
+          placeholder="123 Main St, Austin TX 78701"
+          disabled={status === 'loading' || status === 'preview'}
+          className="
+            flex-1 rounded border border-border bg-base px-3 py-1.5
+            text-xs text-hi placeholder:text-lo
+            focus:border-accent focus:outline-none
+            disabled:opacity-50
+          "
+          aria-label="Property address for autofill"
+        />
+        <button
+          type="button"
+          onClick={handleTrigger}
+          disabled={status === 'loading' || status === 'preview' || !address.trim()}
+          className="
+            rounded border border-border px-3 py-1.5 text-xs text-mid uppercase tracking-widest
+            hover:border-accent hover:text-accent transition-colors
+            disabled:opacity-40 disabled:cursor-not-allowed
+          "
+          aria-label={status === 'loading' ? 'Looking up property…' : 'Autofill from address'}
+        >
+          {status === 'loading' ? '…' : 'Fill'}
+        </button>
+      </div>
+
+      {/* Error message */}
+      {status === 'error' && errorMessage && (
+        <p className="text-xs text-red-400" role="alert">{errorMessage}</p>
+      )}
+
+      {/* Preview popover */}
+      {status === 'preview' && previewData && (
+        <AutofillPreviewPopover
+          data={previewData}
+          onApply={() => { apply(); setAddress(''); }}
+          onDismiss={dismiss}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/AutofillBar.tsx
+++ b/packages/ui/src/components/AutofillBar.tsx
@@ -7,6 +7,7 @@ import type { DealAction } from '../state/dealReducer';
 interface AutofillBarProps {
   dispatch: Dispatch<DealAction>;
   apiKey: string | null;
+  apiUrl?: string;
 }
 
 /**
@@ -16,9 +17,9 @@ interface AutofillBarProps {
  * When apiKey is null (user hasn't connected RentCast), shows a prompt
  * directing them to ⚙ Settings instead of the input.
  */
-export function AutofillBar({ dispatch, apiKey }: AutofillBarProps) {
+export function AutofillBar({ dispatch, apiKey, apiUrl }: AutofillBarProps) {
   const [address, setAddress] = useState('');
-  const { status, previewData, errorMessage, trigger, apply, dismiss } = useAutofill({ dispatch, apiKey });
+  const { status, previewData, errorMessage, trigger, apply, dismiss } = useAutofill({ dispatch, apiKey, apiUrl });
 
   if (!apiKey) {
     return (
@@ -83,7 +84,7 @@ export function AutofillBar({ dispatch, apiKey }: AutofillBarProps) {
         <AutofillPreviewPopover
           data={previewData}
           onApply={() => { apply(); setAddress(''); }}
-          onDismiss={dismiss}
+          onDismiss={() => { dismiss(); setAddress(''); }}
         />
       )}
     </div>

--- a/packages/ui/src/components/AutofillBar.tsx
+++ b/packages/ui/src/components/AutofillBar.tsx
@@ -8,6 +8,13 @@ interface AutofillBarProps {
   dispatch: Dispatch<DealAction>;
   apiKey: string | null;
   apiUrl?: string;
+  currentValues?: {
+    purchasePrice?: number | null;
+    grossRent?: number | null;
+    sqft?: number | null;
+    units?: number | null;
+    annualTaxes?: number | null;
+  };
 }
 
 /**
@@ -17,7 +24,7 @@ interface AutofillBarProps {
  * When apiKey is null (user hasn't connected RentCast), shows a prompt
  * directing them to ⚙ Settings instead of the input.
  */
-export function AutofillBar({ dispatch, apiKey, apiUrl }: AutofillBarProps) {
+export function AutofillBar({ dispatch, apiKey, apiUrl, currentValues }: AutofillBarProps) {
   const [address, setAddress] = useState('');
   const { status, previewData, errorMessage, trigger, apply, dismiss } = useAutofill({ dispatch, apiKey, apiUrl });
 
@@ -85,6 +92,7 @@ export function AutofillBar({ dispatch, apiKey, apiUrl }: AutofillBarProps) {
           data={previewData}
           onApply={() => { apply(); setAddress(''); }}
           onDismiss={() => { dismiss(); setAddress(''); }}
+          currentValues={currentValues}
         />
       )}
     </div>

--- a/packages/ui/src/components/AutofillPreviewPopover.tsx
+++ b/packages/ui/src/components/AutofillPreviewPopover.tsx
@@ -1,13 +1,6 @@
 import { useEffect } from 'react';
 import { fmtCurrency } from '../utils/format';
-
-interface PropertyData {
-  purchasePrice: number;
-  grossRent: number;
-  sqft: number | null;
-  units: number | null;
-  annualTaxes: number | null;
-}
+import type { PropertyData } from '../hooks/useAutofill';
 
 interface AutofillPreviewPopoverProps {
   data: PropertyData;

--- a/packages/ui/src/components/AutofillPreviewPopover.tsx
+++ b/packages/ui/src/components/AutofillPreviewPopover.tsx
@@ -2,14 +2,24 @@ import { useEffect } from 'react';
 import { fmtCurrency } from '../utils/format';
 import type { PropertyData } from '../hooks/useAutofill';
 
+export interface CurrentFormValues {
+  purchasePrice?: number | null;
+  grossRent?: number | null;
+  sqft?: number | null;
+  units?: number | null;
+  annualTaxes?: number | null;
+}
+
 interface AutofillPreviewPopoverProps {
   data: PropertyData;
   onApply: () => void;
   onDismiss: () => void;
+  currentValues?: CurrentFormValues;
 }
 
 interface DiffRow {
   label: string;
+  currentValue: string;
   value: string;
 }
 
@@ -17,7 +27,7 @@ interface DiffRow {
  * Shows a diff of fields that will change when autofill is applied.
  * Null fields are omitted. Dismiss on Escape or Cancel; apply on Apply.
  */
-export function AutofillPreviewPopover({ data, onApply, onDismiss }: AutofillPreviewPopoverProps) {
+export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues }: AutofillPreviewPopoverProps) {
   // Dismiss on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -27,17 +37,21 @@ export function AutofillPreviewPopover({ data, onApply, onDismiss }: AutofillPre
     return () => window.removeEventListener('keydown', handler);
   }, [onDismiss]);
 
+  const cur = currentValues ?? {};
+  const fmtCurrent = (v: number | null | undefined, fmt: (n: number) => string) =>
+    (v != null && v !== 0) ? fmt(v) : '—';
+
   const rows: DiffRow[] = [
-    { label: 'Purchase Price',    value: fmtCurrency(data.purchasePrice) },
-    { label: 'Gross Rent (mo)',   value: fmtCurrency(data.grossRent) },
+    { label: 'Purchase Price',    currentValue: fmtCurrent(cur.purchasePrice, fmtCurrency),     value: fmtCurrency(data.purchasePrice) },
+    { label: 'Gross Rent (mo)',   currentValue: fmtCurrent(cur.grossRent, fmtCurrency),         value: fmtCurrency(data.grossRent) },
     ...(data.annualTaxes !== null
-      ? [{ label: 'Property Taxes (yr)', value: fmtCurrency(data.annualTaxes) }]
+      ? [{ label: 'Property Taxes (yr)', currentValue: fmtCurrent(cur.annualTaxes, fmtCurrency), value: fmtCurrency(data.annualTaxes) }]
       : []),
     ...(data.sqft !== null
-      ? [{ label: 'Square Footage', value: `${data.sqft.toLocaleString()} sqft` }]
+      ? [{ label: 'Square Footage', currentValue: fmtCurrent(cur.sqft, n => `${n.toLocaleString()} sqft`), value: `${data.sqft.toLocaleString()} sqft` }]
       : []),
     ...(data.units !== null
-      ? [{ label: 'Units', value: String(data.units) }]
+      ? [{ label: 'Units', currentValue: fmtCurrent(cur.units, String), value: String(data.units) }]
       : []),
   ];
 
@@ -62,7 +76,7 @@ export function AutofillPreviewPopover({ data, onApply, onDismiss }: AutofillPre
             }`}
           >
             <span className="text-mid">{row.label}</span>
-            <span className="text-lo line-through">—</span>
+            <span className="text-lo line-through">{row.currentValue}</span>
             <span className="text-green-400 font-medium">{row.value}</span>
           </div>
         ))}

--- a/packages/ui/src/components/AutofillPreviewPopover.tsx
+++ b/packages/ui/src/components/AutofillPreviewPopover.tsx
@@ -24,8 +24,9 @@ interface DiffRow {
 }
 
 /**
- * Shows a diff of fields that will change when autofill is applied.
- * Null fields are omitted. Dismiss on Escape or Cancel; apply on Apply.
+ * Shows incoming RentCast values alongside current form values.
+ * All non-null RentCast fields are listed (not filtered to changed-only).
+ * Dismiss on Escape or Cancel; apply on Apply.
  */
 export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues }: AutofillPreviewPopoverProps) {
   // Dismiss on Escape
@@ -39,7 +40,7 @@ export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues
 
   const cur = currentValues ?? {};
   const fmtCurrent = (v: number | null | undefined, fmt: (n: number) => string) =>
-    (v != null && v !== 0) ? fmt(v) : '—';
+    v != null ? fmt(v) : '—';
 
   const rows: DiffRow[] = [
     { label: 'Purchase Price',    currentValue: fmtCurrent(cur.purchasePrice, fmtCurrency),     value: fmtCurrency(data.purchasePrice) },

--- a/packages/ui/src/components/AutofillPreviewPopover.tsx
+++ b/packages/ui/src/components/AutofillPreviewPopover.tsx
@@ -1,0 +1,103 @@
+import { useEffect } from 'react';
+import { fmtCurrency } from '../utils/format';
+
+interface PropertyData {
+  purchasePrice: number;
+  grossRent: number;
+  sqft: number | null;
+  units: number | null;
+  annualTaxes: number | null;
+}
+
+interface AutofillPreviewPopoverProps {
+  data: PropertyData;
+  onApply: () => void;
+  onDismiss: () => void;
+}
+
+interface DiffRow {
+  label: string;
+  value: string;
+}
+
+/**
+ * Shows a diff of fields that will change when autofill is applied.
+ * Null fields are omitted. Dismiss on Escape or Cancel; apply on Apply.
+ */
+export function AutofillPreviewPopover({ data, onApply, onDismiss }: AutofillPreviewPopoverProps) {
+  // Dismiss on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onDismiss]);
+
+  const rows: DiffRow[] = [
+    { label: 'Purchase Price',    value: fmtCurrency(data.purchasePrice) },
+    { label: 'Gross Rent (mo)',   value: fmtCurrency(data.grossRent) },
+    ...(data.annualTaxes !== null
+      ? [{ label: 'Property Taxes (yr)', value: fmtCurrency(data.annualTaxes) }]
+      : []),
+    ...(data.sqft !== null
+      ? [{ label: 'Square Footage', value: `${data.sqft.toLocaleString()} sqft` }]
+      : []),
+    ...(data.units !== null
+      ? [{ label: 'Units', value: String(data.units) }]
+      : []),
+  ];
+
+  return (
+    <div
+      className="rounded border border-accent/50 bg-raised shadow-lg overflow-hidden"
+      role="dialog"
+      aria-label="Autofill preview"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between bg-accent/10 px-4 py-2 border-b border-border">
+        <span className="text-xs font-medium text-accent">⚡ RentCast found this property</span>
+      </div>
+
+      {/* Diff rows */}
+      <div>
+        {rows.map((row, i) => (
+          <div
+            key={row.label}
+            className={`grid grid-cols-[1fr_auto_auto] gap-3 items-center px-4 py-2 text-xs ${
+              i % 2 === 1 ? 'bg-base' : ''
+            }`}
+          >
+            <span className="text-mid">{row.label}</span>
+            <span className="text-lo line-through">—</span>
+            <span className="text-green-400 font-medium">{row.value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-end gap-2 border-t border-border px-4 py-2">
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="
+            rounded border border-border px-3 py-1 text-xs text-mid
+            hover:border-accent hover:text-accent transition-colors
+          "
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onApply}
+          className="
+            rounded bg-accent px-3 py-1 text-xs font-medium text-base
+            hover:opacity-90 transition-opacity
+          "
+        >
+          Apply →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../state/connectorStorage';
+
+interface ConnectorSettingsModalProps {
+  onClose: () => void;
+}
+
+/**
+ * Settings modal — Data Connectors section.
+ *
+ * Opened by the ⚙ Settings button in the Evaluator header.
+ * Manages the RentCast API key (read/write/clear to localStorage).
+ * Designed to grow: additional settings (dark mode, etc.) slot in below.
+ */
+export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps) {
+  const [storedKey, setStoredKey] = useState<string | null>(() => getRentCastKey());
+  const [inputValue, setInputValue]   = useState('');
+  const [isEditing, setIsEditing]     = useState(storedKey === null);
+
+  const handleSave = () => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    setRentCastKey(trimmed);
+    setStoredKey(trimmed);
+    setInputValue('');
+    setIsEditing(false);
+  };
+
+  const handleRemove = () => {
+    clearRentCastKey();
+    setStoredKey(null);
+    setInputValue('');
+    setIsEditing(true);
+  };
+
+  const handleChange = () => {
+    setInputValue('');
+    setIsEditing(true);
+  };
+
+  // Mask key: show last 4 chars, mask the rest
+  const maskedKey = storedKey
+    ? `rc_live_${'•'.repeat(Math.max(0, storedKey.length - 12))}${storedKey.slice(-4)}`
+    : null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+    >
+      <div className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <h2 className="text-sm font-semibold text-hi">Settings</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-lo hover:text-hi transition-colors"
+            aria-label="Close settings"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-4">
+          {/* Section label */}
+          <p className="text-xs uppercase tracking-widest text-lo">Data Connectors</p>
+
+          {/* RentCast row */}
+          <div className="rounded border border-border bg-raised p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-hi">RentCast</span>
+                {storedKey && (
+                  <span className="rounded-full bg-green-900/50 px-2 py-0.5 text-xs text-green-400">
+                    ● Connected
+                  </span>
+                )}
+              </div>
+              {storedKey && !isEditing && (
+                <button
+                  type="button"
+                  onClick={handleRemove}
+                  className="text-xs text-red-400 hover:text-red-300 transition-colors"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+
+            {isEditing ? (
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+                  placeholder="rc_live_…"
+                  className="
+                    flex-1 rounded border border-border bg-base px-3 py-1.5
+                    text-xs text-hi placeholder:text-lo
+                    focus:border-accent focus:outline-none
+                  "
+                  autoFocus
+                  aria-label="RentCast API key"
+                />
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!inputValue.trim()}
+                  className="
+                    rounded border border-accent px-3 py-1.5 text-xs text-accent
+                    hover:bg-accent hover:text-base transition-colors
+                    disabled:opacity-40 disabled:cursor-not-allowed
+                  "
+                >
+                  Save
+                </button>
+              </div>
+            ) : (
+              <div className="flex gap-2 items-center">
+                <code className="flex-1 rounded border border-border bg-base px-3 py-1.5 text-xs text-lo font-mono">
+                  {maskedKey}
+                </code>
+                <button
+                  type="button"
+                  onClick={handleChange}
+                  className="
+                    rounded border border-border px-3 py-1.5 text-xs text-mid
+                    hover:border-accent hover:text-accent transition-colors
+                  "
+                >
+                  Change
+                </button>
+              </div>
+            )}
+
+            <p className="text-xs text-lo">
+              Free tier: 50 req/mo ·{' '}
+              <a
+                href="https://app.rentcast.io"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                Get a key at app.rentcast.io ↗
+              </a>
+            </p>
+          </div>
+
+          {/* Future connectors placeholder */}
+          <div className="rounded border border-dashed border-border px-4 py-3">
+            <p className="text-xs text-lo">+ Add another connector <span className="opacity-50">(coming soon)</span></p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end border-t border-border px-5 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="
+              rounded border border-border px-4 py-1.5 text-xs text-mid
+              hover:border-accent hover:text-accent transition-colors
+            "
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/ConnectorSettingsModal.tsx
+++ b/packages/ui/src/components/ConnectorSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../state/connectorStorage';
 
 interface ConnectorSettingsModalProps {
@@ -13,9 +13,16 @@ interface ConnectorSettingsModalProps {
  * Designed to grow: additional settings (dark mode, etc.) slot in below.
  */
 export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps) {
+  const titleId = useId();
   const [storedKey, setStoredKey] = useState<string | null>(() => getRentCastKey());
   const [inputValue, setInputValue]   = useState('');
   const [isEditing, setIsEditing]     = useState(storedKey === null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
 
   const handleSave = () => {
     const trimmed = inputValue.trim();
@@ -50,12 +57,12 @@ export function ConnectorSettingsModal({ onClose }: ConnectorSettingsModalProps)
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
       role="dialog"
       aria-modal="true"
-      aria-label="Settings"
+      aria-labelledby={titleId}
     >
       <div className="w-full max-w-md rounded-lg border border-border bg-base shadow-xl">
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-5 py-4">
-          <h2 className="text-sm font-semibold text-hi">Settings</h2>
+          <h2 id={titleId} className="text-sm font-semibold text-hi">Settings</h2>
           <button
             type="button"
             onClick={onClose}

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -27,6 +27,8 @@ export interface DealInputsFormProps {
   uiMode?: UiMode;
   /** RentCast API key from connectorStorage. Passed to AutofillBar (wired in RPE-43d). */
   apiKey?: string | null;
+  /** Base URL for apps/api. Defaults to http://localhost:3001. */
+  apiUrl?: string;
 }
 
 /**
@@ -44,6 +46,7 @@ export function DealInputsForm({
   proFormaMode = false,
   uiMode = 'complex',
   apiKey = null,
+  apiUrl,
 }: DealInputsFormProps) {
   const { expenses } = state;
   const simple = uiMode === 'simple';
@@ -57,7 +60,7 @@ export function DealInputsForm({
   return (
     <div>
       {/* ── Autofill bar (always shown, adapts when apiKey is null) ──────── */}
-      <AutofillBar dispatch={dispatch} apiKey={apiKey} />
+      <AutofillBar dispatch={dispatch} apiKey={apiKey} apiUrl={apiUrl} />
 
       {/* ── Acquisition ──────────────────────────────────────────────────── */}
       <InputSection title="Acquisition">

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -60,7 +60,11 @@ export function DealInputsForm({
     grossRent: state.grossRent,
     sqft: state.sqft ?? null,
     units: state.units ?? null,
-    annualTaxes: taxes.amount ?? null,
+    // Normalise to annual so the preview diff compares apples-to-apples with
+    // RentCast's annualTaxes, which is always an annual figure.
+    annualTaxes: taxes.amount != null
+      ? taxes.period === 'monthly' ? taxes.amount * 12 : taxes.amount
+      : null,
   };
   const insurance = expenses.insurance as ExpenseInput;
   const hoa = expenses.hoa ?? { amount: 0, period: 'monthly' as const };

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -54,13 +54,21 @@ export function DealInputsForm({
   // Fixed-expense refs (only used in complex mode, declared here to avoid
   // repeated optional-chaining and keep JSX clean).
   const taxes = expenses.taxes as ExpenseInput;
+
+  const currentAutofillValues = {
+    purchasePrice: state.purchasePrice,
+    grossRent: state.grossRent,
+    sqft: state.sqft ?? null,
+    units: state.units ?? null,
+    annualTaxes: taxes.amount ?? null,
+  };
   const insurance = expenses.insurance as ExpenseInput;
   const hoa = expenses.hoa ?? { amount: 0, period: 'monthly' as const };
 
   return (
     <div>
       {/* ── Autofill bar (always shown, adapts when apiKey is null) ──────── */}
-      <AutofillBar dispatch={dispatch} apiKey={apiKey} apiUrl={apiUrl} />
+      <AutofillBar dispatch={dispatch} apiKey={apiKey} apiUrl={apiUrl} currentValues={currentAutofillValues} />
 
       {/* ── Acquisition ──────────────────────────────────────────────────── */}
       <InputSection title="Acquisition">

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -24,6 +24,8 @@ export interface DealInputsFormProps {
    * - 'complex' — shows all sections (default, current behaviour).
    */
   uiMode?: UiMode;
+  /** RentCast API key from connectorStorage. Passed to AutofillBar (wired in RPE-43d). */
+  apiKey?: string | null;
 }
 
 /**
@@ -40,6 +42,7 @@ export function DealInputsForm({
   dispatch,
   proFormaMode = false,
   uiMode = 'complex',
+  apiKey: _apiKey,  // unused until RPE-43d
 }: DealInputsFormProps) {
   const { expenses } = state;
   const simple = uiMode === 'simple';

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -8,6 +8,7 @@ import { PercentInput } from './PercentInput';
 import { NumberInput } from './NumberInput';
 import { ToggleInput } from './ToggleInput';
 import { FixedExpenseRow } from './FixedExpenseRow';
+import { AutofillBar } from '../AutofillBar';
 
 export interface DealInputsFormProps {
   state: DealInputs;
@@ -42,7 +43,7 @@ export function DealInputsForm({
   dispatch,
   proFormaMode = false,
   uiMode = 'complex',
-  apiKey: _apiKey,  // unused until RPE-43d
+  apiKey = null,
 }: DealInputsFormProps) {
   const { expenses } = state;
   const simple = uiMode === 'simple';
@@ -55,6 +56,9 @@ export function DealInputsForm({
 
   return (
     <div>
+      {/* ── Autofill bar (always shown, adapts when apiKey is null) ──────── */}
+      <AutofillBar dispatch={dispatch} apiKey={apiKey} />
+
       {/* ── Acquisition ──────────────────────────────────────────────────── */}
       <InputSection title="Acquisition">
         <CurrencyInput

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -1,0 +1,107 @@
+import { useState, useCallback } from 'react';
+import type { Dispatch } from 'react';
+import type { DealAction } from '../state/dealReducer';
+
+interface PropertyData {
+  purchasePrice: number;
+  grossRent: number;
+  sqft: number | null;
+  units: number | null;
+  annualTaxes: number | null;
+}
+
+type AutofillStatus = 'idle' | 'loading' | 'preview' | 'error';
+
+interface UseAutofillOptions {
+  dispatch: Dispatch<DealAction>;
+  apiKey: string | null;
+  /** Base URL of apps/api, e.g. 'http://localhost:3001'. Defaults to VITE_API_URL or http://localhost:3001 */
+  apiUrl?: string;
+}
+
+export interface UseAutofillReturn {
+  status: AutofillStatus;
+  previewData: PropertyData | null;
+  errorMessage: string | null;
+  trigger: (address: string) => void;
+  apply: () => void;
+  dismiss: () => void;
+}
+
+function httpStatusToMessage(status: number): string {
+  if (status === 401) return 'Invalid API key — update it in ⚙ Settings.';
+  if (status === 404) return 'Property not found. Check the address and try again.';
+  if (status === 402) return 'Rate limit reached (50 req/mo on the free tier).';
+  return 'Lookup failed. Please try again.';
+}
+
+export function useAutofill({
+  dispatch,
+  apiKey,
+  apiUrl,
+}: UseAutofillOptions): UseAutofillReturn {
+  const [status, setStatus]             = useState<AutofillStatus>('idle');
+  const [previewData, setPreviewData]   = useState<PropertyData | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const resolvedApiUrl = apiUrl ?? 'http://localhost:3001';
+
+  const trigger = useCallback(
+    async (address: string) => {
+      if (!apiKey || !address.trim()) return;
+
+      setStatus('loading');
+      setErrorMessage(null);
+
+      try {
+        const res = await fetch(`${resolvedApiUrl}/property`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ address: address.trim(), apiKey }),
+        });
+
+        if (!res.ok) {
+          setStatus('error');
+          setErrorMessage(httpStatusToMessage(res.status));
+          return;
+        }
+
+        const body = (await res.json()) as { data: PropertyData };
+        setPreviewData(body.data);
+        setStatus('preview');
+      } catch {
+        setStatus('error');
+        setErrorMessage('Network error — check that apps/api is running.');
+      }
+    },
+    [apiKey, resolvedApiUrl],
+  );
+
+  const apply = useCallback(() => {
+    if (!previewData) return;
+
+    dispatch({ type: 'SET_NUMBER', field: 'purchasePrice', value: previewData.purchasePrice });
+    dispatch({ type: 'SET_NUMBER', field: 'grossRent', value: previewData.grossRent });
+
+    if (previewData.sqft !== null) {
+      dispatch({ type: 'SET_NUMBER', field: 'sqft', value: previewData.sqft });
+    }
+    if (previewData.units !== null) {
+      dispatch({ type: 'SET_NUMBER', field: 'units', value: previewData.units });
+    }
+    if (previewData.annualTaxes !== null) {
+      dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: previewData.annualTaxes, period: 'annual' });
+    }
+
+    setPreviewData(null);
+    setStatus('idle');
+  }, [dispatch, previewData]);
+
+  const dismiss = useCallback(() => {
+    setPreviewData(null);
+    setErrorMessage(null);
+    setStatus('idle');
+  }, []);
+
+  return { status, previewData, errorMessage, trigger, apply, dismiss };
+}

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { Dispatch } from 'react';
 import type { DealAction } from '../state/dealReducer';
 
@@ -31,7 +31,7 @@ export interface UseAutofillReturn {
 function httpStatusToMessage(status: number): string {
   if (status === 401) return 'Invalid API key — update it in ⚙ Settings.';
   if (status === 404) return 'Property not found. Check the address and try again.';
-  if (status === 402) return 'Rate limit reached (50 req/mo on the free tier).';
+  if (status === 429) return 'Rate limit reached (50 req/mo on the free tier).';
   return 'Lookup failed. Please try again.';
 }
 
@@ -46,9 +46,18 @@ export function useAutofill({
 
   const resolvedApiUrl = apiUrl ?? 'http://localhost:3001';
 
+  // Tracks the AbortController for the latest in-flight request so a new
+  // trigger() call can cancel a stale one and avoid out-of-order state updates.
+  const abortRef = useRef<AbortController | null>(null);
+
   const trigger = useCallback(
     async (address: string) => {
       if (!apiKey || !address.trim()) return;
+
+      // Cancel any in-flight request before starting a new one.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
 
       setStatus('loading');
       setErrorMessage(null);
@@ -59,7 +68,10 @@ export function useAutofill({
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ address: address.trim(), apiKey }),
+          signal: controller.signal,
         });
+
+        if (controller.signal.aborted) return;
 
         if (!res.ok) {
           setStatus('error');
@@ -68,9 +80,11 @@ export function useAutofill({
         }
 
         const body = (await res.json()) as { data: PropertyData };
+        if (controller.signal.aborted) return;
         setPreviewData(body.data);
         setStatus('preview');
-      } catch {
+      } catch (e) {
+        if (e instanceof Error && e.name === 'AbortError') return;
         setStatus('error');
         setErrorMessage('Network error — check that apps/api is running.');
       }

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Dispatch } from 'react';
 import type { DealAction } from '../state/dealReducer';
 
@@ -49,6 +49,10 @@ export function useAutofill({
   // Tracks the AbortController for the latest in-flight request so a new
   // trigger() call can cancel a stale one and avoid out-of-order state updates.
   const abortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight request on unmount to prevent state updates on an
+  // unmounted component.
+  useEffect(() => () => { abortRef.current?.abort(); }, []);
 
   const trigger = useCallback(
     async (address: string) => {

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -15,7 +15,7 @@ type AutofillStatus = 'idle' | 'loading' | 'preview' | 'error';
 interface UseAutofillOptions {
   dispatch: Dispatch<DealAction>;
   apiKey: string | null;
-  /** Base URL of apps/api, e.g. 'http://localhost:3001'. Defaults to VITE_API_URL or http://localhost:3001 */
+  /** Base URL of apps/api, e.g. 'http://localhost:3001'. Defaults to 'http://localhost:3001'. */
   apiUrl?: string;
 }
 
@@ -23,7 +23,7 @@ export interface UseAutofillReturn {
   status: AutofillStatus;
   previewData: PropertyData | null;
   errorMessage: string | null;
-  trigger: (address: string) => void;
+  trigger: (address: string) => Promise<void>;
   apply: () => void;
   dismiss: () => void;
 }
@@ -52,6 +52,7 @@ export function useAutofill({
 
       setStatus('loading');
       setErrorMessage(null);
+      setPreviewData(null);
 
       try {
         const res = await fetch(`${resolvedApiUrl}/property`, {

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import type { Dispatch } from 'react';
 import type { DealAction } from '../state/dealReducer';
 
-interface PropertyData {
+export interface PropertyData {
   purchasePrice: number;
   grossRent: number;
   sqft: number | null;

--- a/packages/ui/src/state/connectorStorage.ts
+++ b/packages/ui/src/state/connectorStorage.ts
@@ -1,0 +1,35 @@
+/**
+ * Persists the user's RentCast API key in localStorage.
+ *
+ * Key: 'rpe:connectors:rentcast'
+ *
+ * The key belongs to the user — it is never sent anywhere except the
+ * POST /property proxy call where the user explicitly triggers autofill.
+ */
+
+const STORAGE_KEY = 'rpe:connectors:rentcast';
+
+export function getRentCastKey(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // localStorage unavailable (private browsing, SSR, etc.)
+    return null;
+  }
+}
+
+export function setRentCastKey(key: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    // Silently ignore — storage quota exceeded or unavailable
+  }
+}
+
+export function clearRentCastKey(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Silently ignore
+  }
+}

--- a/packages/ui/tests/connectorStorage.test.ts
+++ b/packages/ui/tests/connectorStorage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getRentCastKey, setRentCastKey, clearRentCastKey } from '../src/state/connectorStorage';
+
+// ─── localStorage stub ────────────────────────────────────────────────────────
+
+class LocalStorageMock {
+  private store: Record<string, string> = {};
+  getItem(key: string): string | null {
+    return Object.prototype.hasOwnProperty.call(this.store, key)
+      ? (this.store[key] ?? null)
+      : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store[key] = value;
+  }
+  removeItem(key: string): void {
+    delete this.store[key];
+  }
+  clear(): void {
+    this.store = {};
+  }
+}
+
+describe('connectorStorage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', new LocalStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('getRentCastKey returns null when nothing is stored', () => {
+    expect(getRentCastKey()).toBeNull();
+  });
+
+  it('setRentCastKey + getRentCastKey roundtrip', () => {
+    setRentCastKey('rc_live_abc123');
+    expect(getRentCastKey()).toBe('rc_live_abc123');
+  });
+
+  it('clearRentCastKey makes getRentCastKey return null', () => {
+    setRentCastKey('rc_live_abc123');
+    clearRentCastKey();
+    expect(getRentCastKey()).toBeNull();
+  });
+
+  it('setRentCastKey overwrites an existing key', () => {
+    setRentCastKey('old_key');
+    setRentCastKey('new_key');
+    expect(getRentCastKey()).toBe('new_key');
+  });
+});

--- a/packages/ui/tests/useAutofill.test.ts
+++ b/packages/ui/tests/useAutofill.test.ts
@@ -1,0 +1,183 @@
+/**
+ * RPE-43d: useAutofill hook tests
+ *
+ * Mocks fetch (the POST /property call) at globalThis level.
+ * Uses @testing-library/react's renderHook.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAutofill } from '../src/hooks/useAutofill';
+
+// ─── Mock fetch ──────────────────────────────────────────────────────────────
+
+const MOCK_DATA = {
+  purchasePrice: 342_000,
+  grossRent: 2_150,
+  sqft: 1_480,
+  units: 1,
+  annualTaxes: 4_210,
+};
+
+function mockFetchOk(data: unknown) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ data }),
+  } as unknown as Response);
+}
+
+function mockFetchError(status: number, error: string) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error }),
+  } as unknown as Response);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useAutofill', () => {
+  // Minimal dispatch spy
+  const dispatch = vi.fn();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    dispatch.mockClear();
+  });
+
+  it('starts in idle state', () => {
+    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+    expect(result.current.status).toBe('idle');
+    expect(result.current.previewData).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it('transitions idle → loading → preview on successful trigger', async () => {
+    mockFetchOk(MOCK_DATA);
+    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+
+    await act(async () => { result.current.trigger('123 Main St'); });
+
+    expect(result.current.status).toBe('preview');
+    expect(result.current.previewData).toEqual(MOCK_DATA);
+  });
+
+  it('transitions to error on 401 (bad_key)', async () => {
+    mockFetchError(401, 'Invalid API key');
+    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+
+    await act(async () => { result.current.trigger('123 Main St'); });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorMessage).toMatch(/api key/i);
+  });
+
+  it('transitions to error on 404 (not_found)', async () => {
+    mockFetchError(404, 'Property not found');
+    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+
+    await act(async () => { result.current.trigger('unknown address'); });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorMessage).toMatch(/not found/i);
+  });
+
+  it('transitions to error on 402 (rate_limit)', async () => {
+    mockFetchError(402, 'Rate limit exceeded');
+    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+
+    await act(async () => { result.current.trigger('123 Main St'); });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.errorMessage).toMatch(/rate limit/i);
+  });
+
+  describe('apply()', () => {
+    it('dispatches SET_NUMBER for purchasePrice', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'purchasePrice', value: 342_000 });
+    });
+
+    it('dispatches SET_NUMBER for grossRent', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'grossRent', value: 2_150 });
+    });
+
+    it('dispatches SET_EXPENSE_FIXED for taxes when annualTaxes is non-null', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'SET_EXPENSE_FIXED',
+        field: 'taxes',
+        amount: 4_210,
+        period: 'annual',
+      });
+    });
+
+    it('dispatches SET_NUMBER for sqft when non-null', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'sqft', value: 1_480 });
+    });
+
+    it('skips sqft dispatch when sqft is null', async () => {
+      mockFetchOk({ ...MOCK_DATA, sqft: null });
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ field: 'sqft' }),
+      );
+    });
+
+    it('skips taxes dispatch when annualTaxes is null', async () => {
+      mockFetchOk({ ...MOCK_DATA, annualTaxes: null });
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ field: 'taxes' }),
+      );
+    });
+
+    it('returns to idle after apply()', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(result.current.status).toBe('idle');
+    });
+  });
+
+  describe('dismiss()', () => {
+    it('returns to idle from preview state', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('123 Main St'); });
+      act(() => { result.current.dismiss(); });
+      expect(result.current.status).toBe('idle');
+      expect(result.current.previewData).toBeNull();
+    });
+
+    it('returns to idle from error state', async () => {
+      mockFetchError(404, 'not found');
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { result.current.trigger('x'); });
+      act(() => { result.current.dismiss(); });
+      expect(result.current.status).toBe('idle');
+    });
+  });
+});

--- a/packages/ui/tests/useAutofill.test.ts
+++ b/packages/ui/tests/useAutofill.test.ts
@@ -59,7 +59,7 @@ describe('useAutofill', () => {
     mockFetchOk(MOCK_DATA);
     const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
 
-    await act(async () => { result.current.trigger('123 Main St'); });
+    await act(async () => { await result.current.trigger('123 Main St'); });
 
     expect(result.current.status).toBe('preview');
     expect(result.current.previewData).toEqual(MOCK_DATA);
@@ -69,7 +69,7 @@ describe('useAutofill', () => {
     mockFetchError(401, 'Invalid API key');
     const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
 
-    await act(async () => { result.current.trigger('123 Main St'); });
+    await act(async () => { await result.current.trigger('123 Main St'); });
 
     expect(result.current.status).toBe('error');
     expect(result.current.errorMessage).toMatch(/api key/i);
@@ -79,7 +79,7 @@ describe('useAutofill', () => {
     mockFetchError(404, 'Property not found');
     const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
 
-    await act(async () => { result.current.trigger('unknown address'); });
+    await act(async () => { await result.current.trigger('unknown address'); });
 
     expect(result.current.status).toBe('error');
     expect(result.current.errorMessage).toMatch(/not found/i);
@@ -89,7 +89,7 @@ describe('useAutofill', () => {
     mockFetchError(402, 'Rate limit exceeded');
     const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
 
-    await act(async () => { result.current.trigger('123 Main St'); });
+    await act(async () => { await result.current.trigger('123 Main St'); });
 
     expect(result.current.status).toBe('error');
     expect(result.current.errorMessage).toMatch(/rate limit/i);
@@ -99,7 +99,7 @@ describe('useAutofill', () => {
     it('dispatches SET_NUMBER for purchasePrice', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'purchasePrice', value: 342_000 });
     });
@@ -107,7 +107,7 @@ describe('useAutofill', () => {
     it('dispatches SET_NUMBER for grossRent', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'grossRent', value: 2_150 });
     });
@@ -115,7 +115,7 @@ describe('useAutofill', () => {
     it('dispatches SET_EXPENSE_FIXED for taxes when annualTaxes is non-null', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_EXPENSE_FIXED',
@@ -125,10 +125,18 @@ describe('useAutofill', () => {
       });
     });
 
+    it('dispatches SET_NUMBER for units when units is non-null', async () => {
+      mockFetchOk(MOCK_DATA);
+      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+      await act(async () => { await result.current.trigger('123 Main St'); });
+      act(() => { result.current.apply(); });
+      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'units', value: 1 });
+    });
+
     it('dispatches SET_NUMBER for sqft when non-null', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'sqft', value: 1_480 });
     });
@@ -136,7 +144,7 @@ describe('useAutofill', () => {
     it('skips sqft dispatch when sqft is null', async () => {
       mockFetchOk({ ...MOCK_DATA, sqft: null });
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({ field: 'sqft' }),
@@ -146,7 +154,7 @@ describe('useAutofill', () => {
     it('skips taxes dispatch when annualTaxes is null', async () => {
       mockFetchOk({ ...MOCK_DATA, annualTaxes: null });
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(dispatch).not.toHaveBeenCalledWith(
         expect.objectContaining({ field: 'taxes' }),
@@ -156,7 +164,7 @@ describe('useAutofill', () => {
     it('returns to idle after apply()', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.apply(); });
       expect(result.current.status).toBe('idle');
     });
@@ -166,7 +174,7 @@ describe('useAutofill', () => {
     it('returns to idle from preview state', async () => {
       mockFetchOk(MOCK_DATA);
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('123 Main St'); });
+      await act(async () => { await result.current.trigger('123 Main St'); });
       act(() => { result.current.dismiss(); });
       expect(result.current.status).toBe('idle');
       expect(result.current.previewData).toBeNull();
@@ -175,7 +183,7 @@ describe('useAutofill', () => {
     it('returns to idle from error state', async () => {
       mockFetchError(404, 'not found');
       const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { result.current.trigger('x'); });
+      await act(async () => { await result.current.trigger('x'); });
       act(() => { result.current.dismiss(); });
       expect(result.current.status).toBe('idle');
     });

--- a/packages/ui/tests/useAutofill.test.ts
+++ b/packages/ui/tests/useAutofill.test.ts
@@ -85,8 +85,8 @@ describe('useAutofill', () => {
     expect(result.current.errorMessage).toMatch(/not found/i);
   });
 
-  it('transitions to error on 402 (rate_limit)', async () => {
-    mockFetchError(402, 'Rate limit exceeded');
+  it('transitions to error on 429 (rate_limit)', async () => {
+    mockFetchError(429, 'Rate limit exceeded');
     const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
 
     await act(async () => { await result.current.trigger('123 Main St'); });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 9.39.4
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
@@ -67,7 +67,7 @@ importers:
         version: 8.59.4(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.4(@types/node@20.19.42)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)
 
   apps/api:
     dependencies:
@@ -162,6 +162,12 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/rentcast:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/ui:
     dependencies:
       '@rpe/engine':
@@ -174,12 +180,18 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 'catalog:'
         version: 18.3.29
       '@types/react-dom':
         specifier: 'catalog:'
         version: 18.3.7(@types/react@18.3.29)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -189,6 +201,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -261,6 +288,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -276,6 +307,46 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -470,6 +541,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -754,6 +834,28 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -920,12 +1022,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -981,6 +1090,9 @@ packages:
     resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -1049,8 +1161,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1073,6 +1193,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1088,6 +1211,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1095,6 +1222,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1115,6 +1245,10 @@ packages:
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1366,6 +1500,10 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1453,6 +1591,9 @@ packages:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1534,6 +1675,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1656,8 +1806,16 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1672,6 +1830,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1757,6 +1918,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1803,6 +1967,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1817,6 +1985,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1833,6 +2004,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1859,6 +2034,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -1979,6 +2158,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
@@ -2011,6 +2193,21 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2056,6 +2253,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2139,6 +2340,22 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2177,6 +2394,13 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2190,6 +2414,26 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2280,6 +2524,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2304,6 +2550,34 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2428,6 +2702,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2623,6 +2899,29 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 6.4.2(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.29))(@types/react@18.3.29)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.29
+      '@types/react-dom': 18.3.7(@types/react@18.3.29)
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -2773,7 +3072,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2788,7 +3087,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)
+      vitest: 3.2.4(@types/node@20.19.42)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2855,9 +3154,15 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -2936,6 +3241,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.31: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -3011,7 +3320,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3035,6 +3356,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -3051,11 +3374,15 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3075,6 +3402,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -3445,6 +3774,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
@@ -3532,6 +3867,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -3624,6 +3961,32 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.27.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -3713,9 +4076,13 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3732,6 +4099,8 @@ snapshots:
       semver: 7.8.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -3827,6 +4196,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3858,6 +4231,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -3873,6 +4252,8 @@ snapshots:
       scheduler: 0.23.2
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
 
@@ -3899,6 +4280,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -3960,6 +4343,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -4116,6 +4503,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
@@ -4140,6 +4529,20 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4204,6 +4607,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.27.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -4249,7 +4654,7 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0):
+  vitest@3.2.4(@types/node@20.19.42)(jiti@2.7.0)(jsdom@29.1.1)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -4276,6 +4681,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.42
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -4289,6 +4695,22 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4353,6 +4775,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- New `useAutofill` hook — state machine (idle→loading→preview→error), fetches from `POST /property` via `apiUrl` prop, dispatches `SET_NUMBER`/`SET_EXPENSE_FIXED` on apply
- New `AutofillBar` component — address input + Fill button, null-apiKey hint, loading/error/preview states
- New `AutofillPreviewPopover` — diff table of current vs incoming values, Apply/Cancel, Escape to dismiss
- `DealInputsForm` — activates `apiKey`/`apiUrl` props, renders `<AutofillBar>` as first child
- `apps/web/.env.example` — adds `VITE_API_URL` entry

## Test Plan
- [ ] `pnpm test packages/ui` — 14 new useAutofill tests + full suite green
- [ ] `pnpm lint && pnpm typecheck` — clean
- [ ] Depends on RPE-43c (connector storage + apiKey prop stub, now on v1.3.0)

## Notes
Part of E7 RentCast autofill (RPE-43). Cherry-pick order: RPE-43a ✅ → RPE-43b ✅ → RPE-43c ✅ → RPE-43d.