### PR TITLE
RPE-67: simpleBaselines override test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .env.local
 *.local
 .DS_Store
+.superpowers/

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env and fill in values for local development.
+
+# ── Server ────────────────────────────────────────────────────────────────────
+PORT=3001
+# HOST=0.0.0.0
+
+# ── HUD SAFMR API (RPE-65) ───────────────────────────────────────────────────
+# Required for the GET /region endpoint to return ZIP-level rent estimates.
+# Free token: https://www.huduser.gov/portal/dataset/fmr-api.html
+# If absent, /region still returns static tax/insurance/vacancy rates but rent=null.
+HUD_TOKEN=

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@rpe/engine": "workspace:*",
+    "@rpe/region-defaults": "workspace:*",
     "@rpe/rentcast": "workspace:*"
   },
   "devDependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -44,6 +44,7 @@ import { fileURLToPath } from 'node:url';
 import { evaluate } from '@rpe/engine';
 import type { DealInputs, EvalOptions } from '@rpe/engine';
 import { handleProperty } from './routes/property.js';
+import { handleRegion } from './routes/region.js';
 
 // Hoist __filename/__dirname for use in VERSION and the entry-point guard below.
 const __filename = fileURLToPath(import.meta.url);
@@ -354,6 +355,8 @@ export function createApp() {
         ? () => handleEvaluate(req, res)
         : url === '/property' || url === '/property/'
         ? () => handleProperty(req, res, json, readBody)
+        : url === '/region' || url === '/region/'
+        ? () => handleRegion(req, res, json)
         : () => {
             json(res, 404, { error: `Unknown endpoint: ${url}` });
             return Promise.resolve();
@@ -379,6 +382,7 @@ if (resolve(process.argv[1] ?? '') === __filename) {
     console.log('  GET  /health');
     console.log('  POST /evaluate');
     console.log('  POST /property');
+    console.log('  GET  /region?zip=XXXXX');
   });
   server.on('error', (err) => {
     console.error('Server error:', err);

--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -31,10 +31,8 @@
  * HUD SAFMR API:
  *   Requires env var HUD_TOKEN (free at https://www.huduser.gov/portal/dataset/fmr-api.html).
  *   If HUD_TOKEN is absent, rent data is omitted (static-only response).
- *   HUD SAFMR ZIP FMR endpoint:
- *     GET https://www.huduser.gov/hudapi/public/fmr/statedata/{stateCode}
- *   We use the ZIP query:
- *     GET https://www.huduser.gov/hudapi/public/fmr/data/{zip}
+ *   Endpoint used: GET https://www.huduser.gov/hudapi/public/fmr/data/{zip}
+ *   Returns state code, county, town, and Small Area FMR by bedroom count.
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
@@ -86,9 +84,12 @@ export async function handleRegion(
             : zip;
           rent = hudResult.rent;
         }
-      } catch {
+      } catch (hudErr) {
         // HUD call failed — degrade to static defaults with empty stateCode
-        console.error('/region: HUD SAFMR fetch failed, falling back to national defaults');
+        console.error(
+          '/region: HUD SAFMR fetch failed, falling back to national defaults:',
+          hudErr instanceof Error ? hudErr.message : String(hudErr),
+        );
       }
     }
 

--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -7,8 +7,10 @@
  *   {
  *     zip:              string,   // input ZIP5
  *     stateCode:        string,   // 2-letter US state code ('' if unresolved)
- *     label:            string,   // human-readable e.g. 'Austin, TX (78701)' when HUD
- *                                 // resolves a town/county, 'TX · 78701' otherwise
+ *     label:            string,   // human-readable — 'Austin, TX (78701)' when HUD
+ *                                 // resolves a town/county, 'TX · 78701' when only the
+ *                                 // state resolves, or just the zip when unresolved
+ *                                 // (no HUD_TOKEN or HUD failure)
  *     propertyTaxRate:  number,   // 0–1 effective rate
  *     insuranceRate:    number,   // 0–1 annual premium as % of purchase price
  *     vacancyRate:      number,   // 0–1
@@ -28,6 +30,7 @@
  *
  * Error responses:
  *   400 { error: string }  — missing or invalid zip parameter
+ *   405 { error: string }  — method other than GET
  *   500 { error: string }  — internal error
  *
  * HUD SAFMR API:

--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -1,0 +1,121 @@
+/**
+ * GET /region?zip=XXXXX
+ *
+ * Returns regional assumption defaults for the given US ZIP5 code.
+ *
+ * Response (200):
+ *   {
+ *     zip:              string,   // input ZIP5
+ *     stateCode:        string,   // 2-letter US state code ('' if unresolved)
+ *     label:            string,   // human-readable e.g. 'TX · 78701'
+ *     propertyTaxRate:  number,   // 0–1 effective rate
+ *     insuranceRate:    number,   // 0–1 annual premium as % of purchase price
+ *     vacancyRate:      number,   // 0–1
+ *     appreciationRate: number,   // 0–1 annualised
+ *     rentGrowthRate:   number,   // 0–1 annualised
+ *     rent: {                     // HUD SAFMR ZIP-level rent (null when unavailable)
+ *       studio:    number | null,
+ *       oneBed:    number | null,
+ *       twoBed:    number | null,
+ *       threeBed:  number | null,
+ *       fourBed:   number | null,
+ *     } | null,
+ *     resolvedLevel: 'zip' | 'state' | 'national',
+ *     sourceLabel:   string,
+ *   }
+ *
+ * Error responses:
+ *   400 { error: string }  — missing or invalid zip parameter
+ *   500 { error: string }  — internal error
+ *
+ * HUD SAFMR API:
+ *   Requires env var HUD_TOKEN (free at https://www.huduser.gov/portal/dataset/fmr-api.html).
+ *   If HUD_TOKEN is absent, rent data is omitted (static-only response).
+ *   HUD SAFMR ZIP FMR endpoint:
+ *     GET https://www.huduser.gov/hudapi/public/fmr/statedata/{stateCode}
+ *   We use the ZIP query:
+ *     GET https://www.huduser.gov/hudapi/public/fmr/data/{zip}
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { resolveRegionalRates } from '@rpe/region-defaults';
+import { fetchHudSafmr } from '../services/hud.js';
+import type { HudSafmrResult } from '../services/hud.js';
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export async function handleRegion(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: (res: ServerResponse, status: number, body: unknown) => void,
+): Promise<void> {
+  if (req.method !== 'GET') {
+    json(res, 405, { error: 'Method not allowed — use GET' });
+    return;
+  }
+
+  // Parse the zip query parameter
+  const urlStr = req.url ?? '';
+  const queryStart = urlStr.indexOf('?');
+  const queryString = queryStart >= 0 ? urlStr.slice(queryStart + 1) : '';
+  const params = new URLSearchParams(queryString);
+  const zip = (params.get('zip') ?? '').trim();
+
+  if (!/^\d{5}$/.test(zip)) {
+    json(res, 400, { error: 'zip must be a 5-digit US ZIP code' });
+    return;
+  }
+
+  try {
+    const hudToken = process.env['HUD_TOKEN'] ?? '';
+
+    // Call HUD SAFMR if token is configured
+    let stateCode = '';
+    let label = '';
+    let rent: HudSafmrResult['rent'] | null = null;
+
+    if (hudToken) {
+      try {
+        const hudResult = await fetchHudSafmr(zip, hudToken);
+        if (hudResult) {
+          stateCode = hudResult.stateCode;
+          // Build a human-readable label
+          const location = hudResult.town || hudResult.county;
+          label = stateCode
+            ? (location ? `${location}, ${stateCode} (${zip})` : `${stateCode} · ${zip}`)
+            : zip;
+          rent = hudResult.rent;
+        }
+      } catch {
+        // HUD call failed — degrade to static defaults with empty stateCode
+        console.error('/region: HUD SAFMR fetch failed, falling back to national defaults');
+      }
+    }
+
+    // If HUD call failed or token absent, try to derive state from ZIP prefix
+    // This is a best-effort fallback — not all ZIP3 prefixes map to a unique state.
+    // For now, leave stateCode empty and serve national defaults.
+
+    const rates = resolveRegionalRates(stateCode);
+
+    json(res, 200, {
+      zip,
+      stateCode,
+      label: label || (stateCode ? `${stateCode} · ${zip}` : zip),
+      propertyTaxRate: rates.propertyTaxRate,
+      insuranceRate: rates.insuranceRate,
+      vacancyRate: rates.vacancyRate,
+      appreciationRate: rates.appreciationRate,
+      rentGrowthRate: rates.rentGrowthRate,
+      rent,
+      resolvedLevel: rates.resolvedLevel,
+      sourceLabel: rates.sourceLabel,
+    });
+  } catch (err) {
+    console.error(
+      '/region handler error:',
+      err instanceof Error ? err.stack : String(err),
+    );
+    json(res, 500, { error: 'Internal server error' });
+  }
+}

--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -7,7 +7,8 @@
  *   {
  *     zip:              string,   // input ZIP5
  *     stateCode:        string,   // 2-letter US state code ('' if unresolved)
- *     label:            string,   // human-readable e.g. 'TX · 78701'
+ *     label:            string,   // human-readable e.g. 'Austin, TX (78701)' when HUD
+ *                                 // resolves a town/county, 'TX · 78701' otherwise
  *     propertyTaxRate:  number,   // 0–1 effective rate
  *     insuranceRate:    number,   // 0–1 annual premium as % of purchase price
  *     vacancyRate:      number,   // 0–1

--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -20,7 +20,8 @@
  *       threeBed:  number | null,
  *       fourBed:   number | null,
  *     } | null,
- *     resolvedLevel: 'zip' | 'state' | 'national',
+ *     resolvedLevel: 'state' | 'national',  // granularity of the *rates* above —
+ *                                 // rent (when present) is always ZIP-level from HUD SAFMR
  *     sourceLabel:   string,
  *   }
  *

--- a/apps/api/src/services/hud.ts
+++ b/apps/api/src/services/hud.ts
@@ -1,0 +1,81 @@
+/**
+ * HUD SAFMR (Small Area Fair Market Rents) API client.
+ *
+ * Fetches ZIP-level rent estimates from HUD's free public API.
+ * Requires env var HUD_TOKEN (free at https://www.huduser.gov/portal/dataset/fmr-api.html).
+ *
+ * Returns null on any error so callers degrade gracefully.
+ */
+
+export interface HudSafmrResult {
+  stateCode: string;
+  town: string;
+  county: string;
+  rent: {
+    studio: number | null;
+    oneBed: number | null;
+    twoBed: number | null;
+    threeBed: number | null;
+    fourBed: number | null;
+  };
+}
+
+interface HudApiResponse {
+  data?: {
+    state?: unknown;
+    county?: unknown;
+    town?: unknown;
+    basicdata?: Array<{
+      Efficiency?: number | null;
+      One_Bedroom?: number | null;
+      Two_Bedroom?: number | null;
+      Three_Bedroom?: number | null;
+      Four_Bedroom?: number | null;
+    }>;
+  };
+}
+
+/**
+ * Fetch HUD SAFMR data for a ZIP5 code.
+ *
+ * @param zip       5-digit US ZIP code.
+ * @param hudToken  Bearer token for the HUD API.
+ * @returns         Resolved rent data + state code, or null on failure.
+ */
+export async function fetchHudSafmr(
+  zip: string,
+  hudToken: string,
+): Promise<HudSafmrResult | null> {
+  try {
+    const url = `https://www.huduser.gov/hudapi/public/fmr/data/${encodeURIComponent(zip)}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${hudToken}` },
+    });
+
+    if (!res.ok) return null;
+
+    const body = (await res.json()) as HudApiResponse;
+    const data = body.data;
+    if (!data) return null;
+
+    const stateCode = typeof data.state === 'string' ? data.state.toUpperCase() : '';
+    const town = typeof data.town === 'string' ? data.town : '';
+    const county = typeof data.county === 'string' ? data.county : '';
+
+    const row = data.basicdata?.[0];
+    return {
+      stateCode,
+      town,
+      county,
+      rent: {
+        studio: typeof row?.Efficiency === 'number' ? row.Efficiency : null,
+        oneBed: typeof row?.One_Bedroom === 'number' ? row.One_Bedroom : null,
+        twoBed: typeof row?.Two_Bedroom === 'number' ? row.Two_Bedroom : null,
+        threeBed: typeof row?.Three_Bedroom === 'number' ? row.Three_Bedroom : null,
+        fourBed: typeof row?.Four_Bedroom === 'number' ? row.Four_Bedroom : null,
+      },
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/services/hud.ts
+++ b/apps/api/src/services/hud.ts
@@ -20,20 +20,26 @@ export interface HudSafmrResult {
   };
 }
 
+interface HudRentRow {
+  Efficiency?: number | null;
+  One_Bedroom?: number | null;
+  Two_Bedroom?: number | null;
+  Three_Bedroom?: number | null;
+  Four_Bedroom?: number | null;
+}
+
 interface HudApiResponse {
   data?: {
     state?: unknown;
     county?: unknown;
     town?: unknown;
-    basicdata?: Array<{
-      Efficiency?: number | null;
-      One_Bedroom?: number | null;
-      Two_Bedroom?: number | null;
-      Three_Bedroom?: number | null;
-      Four_Bedroom?: number | null;
-    }>;
+    /** Array of ZIP rows in SAFMR metros; a single object for metro-wide FMR areas. */
+    basicdata?: HudRentRow | HudRentRow[];
   };
 }
+
+/** Abort the HUD request if it takes longer than this — a hung upstream must not block /region. */
+const HUD_TIMEOUT_MS = 10_000;
 
 /**
  * Fetch HUD SAFMR data for a ZIP5 code.
@@ -50,9 +56,13 @@ export async function fetchHudSafmr(
     const url = `https://www.huduser.gov/hudapi/public/fmr/data/${encodeURIComponent(zip)}`;
     const res = await fetch(url, {
       headers: { Authorization: `Bearer ${hudToken}` },
+      signal: AbortSignal.timeout(HUD_TIMEOUT_MS),
     });
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.error(`hud: SAFMR fetch for ${zip} returned HTTP ${res.status}`);
+      return null;
+    }
 
     const body = (await res.json()) as HudApiResponse;
     const data = body.data;
@@ -62,7 +72,9 @@ export async function fetchHudSafmr(
     const town = typeof data.town === 'string' ? data.town : '';
     const county = typeof data.county === 'string' ? data.county : '';
 
-    const row = data.basicdata?.[0];
+    // basicdata is an array of ZIP rows in SAFMR metros but a single object
+    // for metro-wide FMR areas — accept both shapes
+    const row = Array.isArray(data.basicdata) ? data.basicdata[0] : data.basicdata;
     return {
       stateCode,
       town,
@@ -75,7 +87,13 @@ export async function fetchHudSafmr(
         fourBed: typeof row?.Four_Bedroom === 'number' ? row.Four_Bedroom : null,
       },
     };
-  } catch {
+  } catch (err) {
+    // Timeout, network failure, or non-JSON body — log with context so HUD
+    // outages are diagnosable, then degrade gracefully (contract: null on failure)
+    console.error(
+      `hud: SAFMR fetch for ${zip} failed:`,
+      err instanceof Error ? err.message : String(err),
+    );
     return null;
   }
 }

--- a/apps/api/tests/region.test.ts
+++ b/apps/api/tests/region.test.ts
@@ -1,0 +1,192 @@
+/**
+ * RPE-65: GET /region integration tests
+ *
+ * HUD SAFMR calls are mocked via vi.mock on the services/hud module so that
+ * test HTTP calls to the local server use the real fetch while only the
+ * outbound HUD API call is intercepted.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+
+// ── Module mock — must be hoisted (vi.mock is hoisted above imports at transform time)
+vi.mock('../src/services/hud', () => ({
+  fetchHudSafmr: vi.fn(),
+}));
+
+// Import mock AFTER vi.mock declaration so we can control it per-test
+import { fetchHudSafmr } from '../src/services/hud';
+const mockFetchHudSafmr = vi.mocked(fetchHudSafmr);
+
+// ─── Server lifecycle ─────────────────────────────────────────────────────────
+
+describe('GET /region', () => {
+  let server: Server;
+  let base: string;
+  let originalHudToken: string | undefined;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server = createApp().listen(0, '127.0.0.1', () => {
+          const addr = server.address();
+          if (!addr || typeof addr === 'string') { reject(new Error('no addr')); return; }
+          base = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+        server.on('error', reject);
+      }),
+    5000,
+  );
+
+  afterAll(
+    () => new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+    5000,
+  );
+
+  beforeEach(() => {
+    originalHudToken = process.env['HUD_TOKEN'];
+    mockFetchHudSafmr.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalHudToken !== undefined) {
+      process.env['HUD_TOKEN'] = originalHudToken;
+    } else {
+      delete process.env['HUD_TOKEN'];
+    }
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  it('returns 405 for non-GET methods', async () => {
+    const r = await fetch(`${base}/region?zip=78701`, { method: 'POST' });
+    expect(r.status).toBe(405);
+  });
+
+  it('returns 400 when zip is missing', async () => {
+    const r = await fetch(`${base}/region`);
+    expect(r.status).toBe(400);
+    const body = await r.json() as { error: string };
+    expect(body.error).toMatch(/zip/i);
+  });
+
+  it('returns 400 for a non-5-digit zip', async () => {
+    const r = await fetch(`${base}/region?zip=1234`);
+    expect(r.status).toBe(400);
+  });
+
+  it('returns 400 for a zip with letters', async () => {
+    const r = await fetch(`${base}/region?zip=7870a`);
+    expect(r.status).toBe(400);
+  });
+
+  // ── Static-only (no HUD_TOKEN) ──────────────────────────────────────────────
+
+  it('returns national defaults when HUD_TOKEN is absent', async () => {
+    delete process.env['HUD_TOKEN'];
+    // fetchHudSafmr should NOT be called when no token is set
+
+    const r = await fetch(`${base}/region?zip=78701`);
+    expect(r.status).toBe(200);
+    const body = await r.json() as Record<string, unknown>;
+    expect(body['zip']).toBe('78701');
+    expect(body['rent']).toBeNull();
+    // Should fall back to national (no stateCode resolved without HUD)
+    expect(body['resolvedLevel']).toBe('national');
+    expect(typeof body['propertyTaxRate']).toBe('number');
+    expect(typeof body['insuranceRate']).toBe('number');
+    expect(mockFetchHudSafmr).not.toHaveBeenCalled();
+  });
+
+  // ── HUD SAFMR integration ───────────────────────────────────────────────────
+
+  it('returns state rates and rent when HUD resolves successfully', async () => {
+    process.env['HUD_TOKEN'] = 'test-token';
+
+    mockFetchHudSafmr.mockResolvedValueOnce({
+      stateCode: 'TX',
+      town: 'Austin',
+      county: 'Travis County',
+      rent: {
+        studio: 1050,
+        oneBed: 1230,
+        twoBed: 1500,
+        threeBed: 1900,
+        fourBed: 2200,
+      },
+    });
+
+    const r = await fetch(`${base}/region?zip=78701`);
+    expect(r.status).toBe(200);
+    const body = await r.json() as Record<string, unknown>;
+
+    expect(body['zip']).toBe('78701');
+    expect(body['stateCode']).toBe('TX');
+    expect(body['resolvedLevel']).toBe('state');
+    expect(body['sourceLabel']).toMatch(/TX/);
+    // TX property tax rate = 0.0180
+    expect(body['propertyTaxRate']).toBeCloseTo(0.018, 3);
+    // TX insurance rate = 0.0123
+    expect(body['insuranceRate']).toBeCloseTo(0.0123, 3);
+
+    const rent = body['rent'] as Record<string, number | null>;
+    expect(rent['studio']).toBe(1050);
+    expect(rent['oneBed']).toBe(1230);
+    expect(rent['twoBed']).toBe(1500);
+    expect(rent['threeBed']).toBe(1900);
+    expect(rent['fourBed']).toBe(2200);
+
+    expect(mockFetchHudSafmr).toHaveBeenCalledWith('78701', 'test-token');
+  });
+
+  it('falls back to national rates when HUD returns null (non-OK)', async () => {
+    process.env['HUD_TOKEN'] = 'test-token';
+    mockFetchHudSafmr.mockResolvedValueOnce(null);
+
+    const r = await fetch(`${base}/region?zip=00000`);
+    expect(r.status).toBe(200);
+    const body = await r.json() as Record<string, unknown>;
+    expect(body['stateCode']).toBe('');
+    expect(body['resolvedLevel']).toBe('national');
+    expect(body['rent']).toBeNull();
+  });
+
+  it('falls back gracefully when HUD fetch rejects', async () => {
+    process.env['HUD_TOKEN'] = 'test-token';
+    mockFetchHudSafmr.mockRejectedValueOnce(new Error('network error'));
+
+    const r = await fetch(`${base}/region?zip=12345`);
+    expect(r.status).toBe(200);
+    const body = await r.json() as Record<string, unknown>;
+    expect(body['resolvedLevel']).toBe('national');
+    expect(body['rent']).toBeNull();
+  });
+
+  it('includes correct label when HUD resolves town and state', async () => {
+    process.env['HUD_TOKEN'] = 'test-token';
+
+    mockFetchHudSafmr.mockResolvedValueOnce({
+      stateCode: 'CA',
+      town: 'Los Angeles',
+      county: 'Los Angeles County',
+      rent: {
+        studio: null,
+        oneBed: 1800,
+        twoBed: 2200,
+        threeBed: null,
+        fourBed: null,
+      },
+    });
+
+    const r = await fetch(`${base}/region?zip=90001`);
+    const body = await r.json() as { label: string; stateCode: string };
+    expect(body.stateCode).toBe('CA');
+    expect(body.label).toContain('Los Angeles');
+    expect(body.label).toContain('CA');
+    expect(body.label).toContain('90001');
+  });
+});

--- a/apps/api/tests/region.test.ts
+++ b/apps/api/tests/region.test.ts
@@ -11,12 +11,12 @@ import type { Server } from 'node:http';
 import { createApp } from '../src/index';
 
 // ── Module mock — must be hoisted (vi.mock is hoisted above imports at transform time)
-vi.mock('../src/services/hud', () => ({
+vi.mock('../src/services/hud.js', () => ({
   fetchHudSafmr: vi.fn(),
 }));
 
 // Import mock AFTER vi.mock declaration so we can control it per-test
-import { fetchHudSafmr } from '../src/services/hud';
+import { fetchHudSafmr } from '../src/services/hud.js';
 const mockFetchHudSafmr = vi.mocked(fetchHudSafmr);
 
 // ─── Server lifecycle ─────────────────────────────────────────────────────────

--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -4,8 +4,9 @@ import { defineConfig } from 'vite';
  * Vite SSR build for the thin calc API server (RPE-40).
  *
  * - `ssr.entry`: bundles src/index.ts for Node.js.
- * - `ssr.noExternal: ['@rpe/engine', '@rpe/rentcast']`: forces both workspace
- *   packages inline — Vite SSR externalises workspace deps by default; this overrides that.
+ * - `ssr.noExternal`: forces all workspace packages inline. Vite already inlines
+ *   linked (workspace) deps by default, but listing them keeps the behaviour explicit
+ *   and safe if the packages are ever published/installed from a registry.
  * - Node built-ins (node:http, node:url, etc.) are automatically externalised.
  * - Output: dist/index.js (ESM, runnable with `node dist/index.js`).
  */
@@ -23,7 +24,7 @@ export default defineConfig({
     sourcemap: true,
   },
   ssr: {
-    noExternal: ['@rpe/engine', '@rpe/rentcast'],
+    noExternal: ['@rpe/engine', '@rpe/rentcast', '@rpe/region-defaults'],
   },
   resolve: {
     conditions: ['import', 'default'],

--- a/docs/superpowers/plans/2026-06-08-e9-location-defaults.md
+++ b/docs/superpowers/plans/2026-06-08-e9-location-defaults.md
@@ -1,0 +1,503 @@
+# E9 — Location-based assumption defaults (RPE-56)
+
+**Date:** 2026-06-08  
+**Epic:** RPE-56  
+**Release branch:** v1.3.0  
+**SPIKE gate:** RPE-63 → Done ✅
+
+---
+
+## Overview
+
+When a user enters a location (ZIP code), the deal's hidden baseline assumptions are pre-filled from regional averages instead of static national baselines. User overrides always win. A source/region badge shows where the data came from.
+
+**What changes in simple mode:**
+- Property taxes: `pp × stateEffectiveTaxRate` instead of always `pp × 0.012`
+- Insurance: `pp × stateInsuranceRate` instead of always `pp × 0.005`  
+- Vacancy: regional average (state/national fallback)
+- Rent (suggestion): HUD SAFMR ZIP-level estimate shown as a hint (not a baseline override; `grossRent` is user-entered)
+
+**What stays unchanged:**
+- Financing defaults (interestRate, loanTermYears, etc.) — not location-specific
+- CapEx/maintenance/mgmt percentages — national averages are fine
+- User-entered values in complex mode — never touched by this feature
+
+---
+
+## Architecture decisions (from SPIKE RPE-63)
+
+**Data sources:**
+| Assumption | Source | Granularity | Approach |
+|---|---|---|---|
+| Property tax rate | Census ACS state effective rates (pre-computed, baked in) | State | Static JSON in packages/region-defaults |
+| Insurance rate | NAIC 2022 state premium ÷ $254k nat'l median home value | State | Static JSON in packages/region-defaults |
+| Vacancy | National 5% for v1 (county ACS deferred) | National | Static fallback |
+| Rent estimate | HUD SAFMR (via apps/api proxy) | ZIP/ZCTA | Live API call, 30-day localStorage cache |
+| Appreciation | National 3% for v1 (FHFA HPI data deferred) | National | Static fallback |
+| Rent growth | National 3.5% for v1 (Zillow ZORI deferred) | National | Static fallback |
+
+**Key design:** `packages/region-defaults` exports `resolveRegionalRates(stateCode)` returning multipliers that `simpleBaselines.ts` uses instead of hard-coded constants. The `apps/api /region?zip=XXXXX` endpoint calls HUD SAFMR (proxy, free API token) to get ZIP-level rent + state code, then merges with static data.
+
+**State code from ZIP:** HUD SAFMR API returns state in its response — no need for a bundled ZIP→state lookup table. The `/region` endpoint drives off the SAFMR response.
+
+---
+
+## Task Breakdown
+
+### Task 1: RPE-64 — Location input + region state
+
+**Branch:** `RPE-64`  
+**Files touched:** `packages/ui/src/state/locationState.ts` (new), `packages/ui/src/components/LocationInput.tsx` (new), `packages/ui/src/Evaluator.tsx`, `packages/ui/tests/locationState.test.ts` (new)
+
+#### locationState.ts
+```typescript
+// packages/ui/src/state/locationState.ts
+export interface LocationState {
+  zip: string;           // raw ZIP5 input ('' = not set)
+  stateCode: string;     // 2-letter state code once resolved ('' = unresolved)
+  label: string;         // human-readable label e.g. 'Austin, TX (78701)' ('' = unresolved)
+}
+
+export const DEFAULT_LOCATION: LocationState = { zip: '', stateCode: '', label: '' };
+const STORAGE_KEY = 'rpe_location';
+
+export function loadLocation(): LocationState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_LOCATION;
+    const parsed = JSON.parse(raw) as Partial<LocationState>;
+    const zip = typeof parsed.zip === 'string' ? parsed.zip : '';
+    const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode : '';
+    const label = typeof parsed.label === 'string' ? parsed.label : '';
+    return { zip, stateCode, label };
+  } catch {
+    return DEFAULT_LOCATION;
+  }
+}
+
+export function saveLocation(loc: LocationState): void {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(loc)); } catch { /* ignore */ }
+}
+
+export function clearLocation(): void {
+  try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+}
+
+export function isValidZip5(value: string): boolean {
+  return /^\d{5}$/.test(value.trim());
+}
+```
+
+#### LocationInput.tsx
+
+A ZIP5 input control. Shown above the Acquisition section (after AutofillBar). When the user enters a valid 5-digit ZIP and presses Enter or clicks "Look up", it fires an `onZipChange(zip: string)` callback. When location is resolved, shows a chip like "TX · 78701 ×" with a clear button.
+
+Props:
+```typescript
+interface LocationInputProps {
+  zip: string;
+  stateCode: string;
+  label: string;
+  onZipChange: (zip: string) => void;  // called when user submits a valid ZIP
+  onClear: () => void;
+}
+```
+
+Render states:
+1. **Empty:** text input with placeholder "ZIP code for local defaults". No badge.
+2. **Has zip, resolving:** input shows the ZIP, a loading spinner.
+3. **Resolved:** chip "TX · 78701" with × clear button; input hidden.
+4. **Error:** input remains, inline error text "ZIP not found" or "Enter a 5-digit ZIP".
+
+#### Evaluator.tsx changes
+
+```typescript
+// New state
+const [location, setLocation] = useState<LocationState>(() => loadLocation());
+
+// When ZIP submitted → save to state + localStorage (resolution happens in useLocationDefaults)
+const handleZipChange = useCallback((zip: string) => {
+  setLocation({ zip, stateCode: '', label: '' });
+  saveLocation({ zip, stateCode: '', label: '' });
+}, []);
+
+const handleLocationClear = useCallback(() => {
+  const cleared = DEFAULT_LOCATION;
+  setLocation(cleared);
+  clearLocation();
+}, []);
+```
+
+Add `<LocationInput>` between `<AutofillBar>` and the Acquisition section in the form (via DealInputsForm props or directly in Evaluator).
+
+Actually — LocationInput fits as a new prop on DealInputsForm, alongside `apiKey`:
+```typescript
+interface DealInputsFormProps {
+  // ... existing ...
+  location?: LocationState;
+  onZipChange?: (zip: string) => void;
+  onLocationClear?: () => void;
+}
+```
+
+#### Tests
+
+`packages/ui/tests/locationState.test.ts` — covers `loadLocation`, `saveLocation`, `clearLocation`, `isValidZip5`.
+
+---
+
+### Task 2: RPE-65 — Location-defaults data layer
+
+**Branch:** `RPE-65` (cut from v1.3.0 after RPE-64 cherry-pick)  
+**New package:** `packages/region-defaults/`  
+**New API route:** `apps/api/src/routes/region.ts`
+
+#### packages/region-defaults
+
+**package.json:**
+```json
+{
+  "name": "@rpe/region-defaults",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src tests"
+  }
+}
+```
+
+**src/types.ts:**
+```typescript
+export type RegionLevel = 'zip' | 'state' | 'national';
+
+export interface RegionalRates {
+  /** Effective property tax rate (0–1). E.g. 0.013 = 1.3% of home value annually. */
+  propertyTaxRate: number;
+  /** Annual homeowner insurance as fraction of purchase price. E.g. 0.006 = 0.6%. */
+  insuranceRate: number;
+  /** Rental vacancy rate (0–1). */
+  vacancyRate: number;
+  /** Annualised home price appreciation (0–1). */
+  appreciationRate: number;
+  /** Annual rent growth rate (0–1). */
+  rentGrowthRate: number;
+
+  /** Finest level these rates were resolved at. */
+  resolvedLevel: RegionLevel;
+  /** Human-readable source label. E.g. 'TX state averages (Census ACS / NAIC 2022)' */
+  sourceLabel: string;
+}
+```
+
+**src/data/states.ts:** — hard-coded lookup table:
+```typescript
+// property-tax-rate: Census ACS 2022 5-yr state effective rates (median taxes / median home value)
+// insurance-rate: NAIC 2022 state avg premium ÷ $254,000 (national median home value)
+// Values rounded to 4 decimal places.
+export const STATE_RATES: Record<string, { taxRate: number; insuranceRate: number }> = {
+  AL: { taxRate: 0.0040, insuranceRate: 0.0068 },
+  AK: { taxRate: 0.0098, insuranceRate: 0.0046 },
+  AZ: { taxRate: 0.0062, insuranceRate: 0.0054 },
+  AR: { taxRate: 0.0062, insuranceRate: 0.0083 },
+  CA: { taxRate: 0.0073, insuranceRate: 0.0046 },
+  CO: { taxRate: 0.0050, insuranceRate: 0.0095 },
+  CT: { taxRate: 0.0179, insuranceRate: 0.0063 },
+  DE: { taxRate: 0.0056, insuranceRate: 0.0040 },
+  FL: { taxRate: 0.0086, insuranceRate: 0.0142 },
+  GA: { taxRate: 0.0090, insuranceRate: 0.0067 },
+  HI: { taxRate: 0.0026, insuranceRate: 0.0050 },
+  ID: { taxRate: 0.0044, insuranceRate: 0.0042 },
+  IL: { taxRate: 0.0222, insuranceRate: 0.0067 },
+  IN: { taxRate: 0.0083, insuranceRate: 0.0054 },
+  IA: { taxRate: 0.0144, insuranceRate: 0.0060 },
+  KS: { taxRate: 0.0133, insuranceRate: 0.0100 },
+  KY: { taxRate: 0.0082, insuranceRate: 0.0064 },
+  LA: { taxRate: 0.0053, insuranceRate: 0.0113 },
+  ME: { taxRate: 0.0105, insuranceRate: 0.0038 },
+  MD: { taxRate: 0.0099, insuranceRate: 0.0049 },
+  MA: { taxRate: 0.0114, insuranceRate: 0.0065 },
+  MI: { taxRate: 0.0132, insuranceRate: 0.0054 },
+  MN: { taxRate: 0.0102, insuranceRate: 0.0069 },
+  MS: { taxRate: 0.0066, insuranceRate: 0.0074 },
+  MO: { taxRate: 0.0088, insuranceRate: 0.0075 },
+  MT: { taxRate: 0.0074, insuranceRate: 0.0067 },
+  NE: { taxRate: 0.0161, insuranceRate: 0.0084 },
+  NV: { taxRate: 0.0048, insuranceRate: 0.0039 },
+  NH: { taxRate: 0.0182, insuranceRate: 0.0039 },
+  NJ: { taxRate: 0.0213, insuranceRate: 0.0059 },
+  NM: { taxRate: 0.0066, insuranceRate: 0.0060 },
+  NY: { taxRate: 0.0140, insuranceRate: 0.0060 },
+  NC: { taxRate: 0.0080, insuranceRate: 0.0050 },
+  ND: { taxRate: 0.0094, insuranceRate: 0.0079 },
+  OH: { taxRate: 0.0143, insuranceRate: 0.0047 },
+  OK: { taxRate: 0.0085, insuranceRate: 0.0113 },
+  OR: { taxRate: 0.0082, insuranceRate: 0.0043 },
+  PA: { taxRate: 0.0149, insuranceRate: 0.0042 },
+  RI: { taxRate: 0.0140, insuranceRate: 0.0065 },
+  SC: { taxRate: 0.0050, insuranceRate: 0.0059 },
+  SD: { taxRate: 0.0114, insuranceRate: 0.0071 },
+  TN: { taxRate: 0.0061, insuranceRate: 0.0066 },
+  TX: { taxRate: 0.0180, insuranceRate: 0.0123 },
+  UT: { taxRate: 0.0056, insuranceRate: 0.0041 },
+  VT: { taxRate: 0.0183, insuranceRate: 0.0040 },
+  VA: { taxRate: 0.0087, insuranceRate: 0.0049 },
+  WA: { taxRate: 0.0084, insuranceRate: 0.0045 },
+  WV: { taxRate: 0.0053, insuranceRate: 0.0044 },
+  WI: { taxRate: 0.0161, insuranceRate: 0.0043 },
+  WY: { taxRate: 0.0055, insuranceRate: 0.0050 },
+};
+
+export const NATIONAL_RATES = {
+  taxRate: 0.0112,          // national effective average
+  insuranceRate: 0.0066,    // NAIC national avg $1,672 / $254k
+  vacancyRate: 0.068,       // CPS/HVS Q4 2024 national rental vacancy
+  appreciationRate: 0.040,  // FHFA trailing 10-yr national avg
+  rentGrowthRate: 0.035,    // Zillow ZORI trailing 5-yr national avg
+};
+```
+
+**src/index.ts:**
+```typescript
+export function resolveRegionalRates(stateCode: string): RegionalRates {
+  const upper = stateCode.toUpperCase();
+  const state = STATE_RATES[upper];
+  if (state) {
+    return {
+      propertyTaxRate: state.taxRate,
+      insuranceRate: state.insuranceRate,
+      vacancyRate: NATIONAL_RATES.vacancyRate,
+      appreciationRate: NATIONAL_RATES.appreciationRate,
+      rentGrowthRate: NATIONAL_RATES.rentGrowthRate,
+      resolvedLevel: 'state',
+      sourceLabel: `${upper} state averages (Census ACS / NAIC 2022)`,
+    };
+  }
+  return {
+    ...NATIONAL_RATES,
+    propertyTaxRate: NATIONAL_RATES.taxRate,
+    insuranceRate: NATIONAL_RATES.insuranceRate,
+    resolvedLevel: 'national',
+    sourceLabel: 'National averages',
+  };
+}
+
+export type { RegionalRates, RegionLevel } from './types.js';
+```
+
+**tsconfig.json:** Use same pattern as `packages/rentcast/tsconfig.json`.
+
+**Tests:** `packages/region-defaults/tests/regionDefaults.test.ts`
+- `resolveRegionalRates('TX')` returns TX rates
+- `resolveRegionalRates('tx')` (lowercase) returns TX rates  
+- `resolveRegionalRates('XX')` falls back to national
+- `resolveRegionalRates('')` falls back to national
+- Spot-check a few states against known-good values
+
+#### apps/api /region route
+
+**apps/api/src/routes/region.ts:**
+
+```typescript
+// GET /region?zip=XXXXX
+//
+// Calls HUD SAFMR API for rent estimate + state code, merges with
+// packages/region-defaults static data, returns RegionalAssumptionSet.
+//
+// Requires env var: HUD_TOKEN (free token from https://www.huduser.gov/portal/dataset/fmr-api.html)
+// If HUD_TOKEN is absent, rent data is omitted (static-only response).
+```
+
+Response shape:
+```typescript
+interface RegionResponse {
+  zip: string;
+  stateCode: string;        // e.g. 'TX'
+  label: string;            // e.g. 'Austin, TX (78701)'
+  
+  propertyTaxRate: number;
+  insuranceRate: number;
+  vacancyRate: number;
+  appreciationRate: number;
+  rentGrowthRate: number;
+
+  // Rent data from HUD SAFMR (null when HUD_TOKEN absent or ZIP not found)
+  rent: {
+    studio: number | null;
+    oneBed: number | null;
+    twoBed: number | null;
+    threeBed: number | null;
+    fourBed: number | null;
+  } | null;
+
+  resolvedLevel: 'zip' | 'state' | 'national';
+  sourceLabel: string;
+}
+```
+
+HUD SAFMR endpoint: `GET https://www.huduser.gov/hudapi/public/fmr/statedata/{zip}` or the ZIP-level FMR API.
+
+**apps/api/.env.example:** Add `HUD_TOKEN=` entry.
+
+**apps/api/src/index.ts:** Wire `/region` route.
+
+**tests:** `apps/api/tests/region.test.ts` — mocks HUD API, tests 200/400/500 paths and fallback when HUD_TOKEN absent.
+
+---
+
+### Task 3: RPE-66 — Wire location defaults into baseline-assumptions module
+
+**Branch:** `RPE-66` (cut from v1.3.0 after RPE-65 cherry-pick)
+
+#### simpleBaselines.ts changes
+
+Extend `getSimpleBaselines()` to accept optional location overrides:
+
+```typescript
+export interface LocationRateOverrides {
+  propertyTaxRate?: number;
+  insuranceRate?: number;
+  vacancyRate?: number;
+  sourceLabel?: string;
+}
+
+export function getSimpleBaselines(
+  purchasePrice: number,
+  locationOverrides?: LocationRateOverrides,
+): SimpleBaselineValues {
+  const pp = purchasePrice > 0 ? purchasePrice : 0;
+  const taxRate = locationOverrides?.propertyTaxRate ?? 0.012;
+  const insRate = locationOverrides?.insuranceRate ?? 0.005;
+  const vacancy = locationOverrides?.vacancyRate != null
+    ? locationOverrides.vacancyRate * 100  // convert 0–1 to percent
+    : 5;
+  return {
+    // ... same as before, but use taxRate/insRate/vacancy instead of hard-coded values
+    expenses: {
+      taxes: { amount: Math.round(pp * taxRate), period: 'annual' },
+      insurance: { amount: Math.round(pp * insRate), period: 'annual' },
+      // ... rest unchanged
+    },
+  };
+}
+```
+
+Update `applySimpleBaselines()` to accept the overrides and pass through.
+
+Update `BASELINE_DESCRIPTIONS` to be a function (or make sourceLabel-aware) so badges can show regional source.
+
+#### useLocationDefaults hook
+
+`packages/ui/src/hooks/useLocationDefaults.ts`:
+
+```typescript
+// Calls apps/api /region?zip=XXXXX
+// Caches result in localStorage with 30-day TTL
+// Returns { rates: LocationRateOverrides | null, loading, error, resolvedLocation }
+```
+
+State machine: idle → loading → resolved | error.
+
+Abort on unmount (same AbortController pattern as useAutofill).
+
+30-day cache key: `rpe_region_${zip}`.
+
+#### Evaluator.tsx changes
+
+```typescript
+// After location state setup:
+const { rates: locationRates, loading: locationLoading, resolvedLocation } = useLocationDefaults({
+  zip: location.zip,
+  apiUrl,
+});
+
+// Update location state when region resolves
+useEffect(() => {
+  if (resolvedLocation) {
+    const updated = { ...location, stateCode: resolvedLocation.stateCode, label: resolvedLocation.label };
+    setLocation(updated);
+    saveLocation(updated);
+  }
+}, [resolvedLocation]);
+
+// Pass locationRates to applySimpleBaselines call sites:
+// uiMode === 'simple' ? applySimpleBaselines(s.inputs, locationRates ?? undefined) : s.inputs
+```
+
+#### Source badge in "based on assumptions" tooltip
+
+`packages/ui/src/components/AssumptionsBadge.tsx` (exists from E8 RPE-61): Update the tooltip to show the `sourceLabel` from location rates, e.g.:
+
+- Without location: "National averages"
+- With TX location: "TX state averages (Census ACS / NAIC 2022)"
+
+Pass `sourceLabel` down from Evaluator → DealInputsForm → AssumptionsBadge (or wherever the tooltip is rendered).
+
+#### DealInputsForm.tsx changes
+
+- Pass `locationLoading` to `LocationInput` (shows spinner while resolving)
+- Pass resolved location state so `LocationInput` shows the resolved chip
+
+---
+
+### Task 4: RPE-67 — Tests + fixtures
+
+**Branch:** `RPE-67` (cut from v1.3.0 after RPE-66 cherry-pick)
+
+Integration-level tests (beyond unit tests added in RPE-64–66):
+
+1. `packages/ui/tests/useLocationDefaults.test.ts`
+   - Loading state emitted while fetch in flight
+   - Resolved state after successful fetch; cache hit on second call
+   - AbortController cancels in-flight request on re-trigger
+   - Error state on network error
+   - Unmount clears abort
+
+2. `packages/ui/tests/simpleBaselines.test.ts` (update existing)
+   - `getSimpleBaselines(300000, { propertyTaxRate: 0.018, insuranceRate: 0.012 })` uses TX rates
+   - `getSimpleBaselines(300000, undefined)` uses national fallback rates
+   - `applySimpleBaselines(inputs, txRates)` uses TX tax/insurance in result
+
+3. `packages/region-defaults/tests/regionDefaults.test.ts` (done in RPE-65, but fixtures here)
+   - Golden fixture: `resolveRegionalRates('NJ')` → propertyTaxRate: 0.0213 (highest in US)
+   - Golden fixture: `resolveRegionalRates('HI')` → propertyTaxRate: 0.0026 (lowest)
+   - Fallback: `resolveRegionalRates('ZZ')` → resolvedLevel: 'national'
+
+4. `apps/api/tests/region.test.ts` (done in RPE-65)
+   - Already covered; RPE-67 adds an integration test: full stack from ZIP → state lookup → rate merging
+
+---
+
+## Git workflow
+
+Same as E7:
+- Task branches: `RPE-64`, `RPE-65`, `RPE-66`, `RPE-67`
+- All cut from `v1.3.0`, named exactly after ticket handle
+- All commits prefixed `RPE-64:`, `RPE-65:`, etc.
+- Cherry-pick order: 64 → 65 → 66 → 67
+- Max 2 open PRs at a time; Copilot review loop required before cherry-pick
+- PR target: `v1.3.0`
+
+## Gate (before each cherry-pick)
+
+```bash
+pnpm lint && pnpm typecheck && pnpm test && pnpm build
+```
+
+## API keys needed (for local testing)
+
+- HUD SAFMR token: https://www.huduser.gov/portal/dataset/fmr-api.html (free, instant)
+- No Census API key needed for v1 (static data only; Census API deferred)
+
+## Deferred to v1.4.0+
+
+- ZIP-level property tax (Census ACS ZCTA pipeline)
+- County-level vacancy (ACS B25004)
+- FHFA HPI state/metro appreciation (annual CSV pipeline)
+- Zillow ZORI rent growth (CSV pipeline)
+- City/metro text geocoding (beyond ZIP5)

--- a/docs/superpowers/plans/2026-06-08-e9-location-defaults.md
+++ b/docs/superpowers/plans/2026-06-08-e9-location-defaults.md
@@ -31,9 +31,9 @@ When a user enters a location (ZIP code), the deal's hidden baseline assumptions
 |---|---|---|---|
 | Property tax rate | Census ACS state effective rates (pre-computed, baked in) | State | Static JSON in packages/region-defaults |
 | Insurance rate | NAIC 2022 state premium ÷ $254k nat'l median home value | State | Static JSON in packages/region-defaults |
-| Vacancy | National 5% for v1 (county ACS deferred) | National | Static fallback |
+| Vacancy | National 6.8% for v1 (county ACS deferred) | National | Static fallback |
 | Rent estimate | HUD SAFMR (via apps/api proxy) | ZIP/ZCTA | Live API call, 30-day localStorage cache |
-| Appreciation | National 3% for v1 (FHFA HPI data deferred) | National | Static fallback |
+| Appreciation | National 4.0% for v1 (FHFA HPI data deferred) | National | Static fallback |
 | Rent growth | National 3.5% for v1 (Zillow ZORI deferred) | National | Static fallback |
 
 **Key design:** `packages/region-defaults` exports `resolveRegionalRates(stateCode)` returning multipliers that `simpleBaselines.ts` uses instead of hard-coded constants. The `apps/api /region?zip=XXXXX` endpoint calls HUD SAFMR (proxy, free API token) to get ZIP-level rent + state code, then merges with static data.

--- a/packages/region-defaults/package.json
+++ b/packages/region-defaults/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@rpe/region-defaults",
+  "version": "1.3.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/region-defaults/src/index.ts
+++ b/packages/region-defaults/src/index.ts
@@ -1,0 +1,57 @@
+/**
+ * @rpe/region-defaults — Regional assumption defaults data layer (RPE-65)
+ *
+ * Provides per-region rates for the baseline-assumptions module so simple-mode
+ * calculations use location-specific defaults instead of static national averages.
+ *
+ * v1 data coverage:
+ *   - Property tax rate:  state-level (Census ACS 2022)
+ *   - Insurance rate:     state-level (NAIC 2022)
+ *   - Vacancy rate:       national only (county ACS deferred)
+ *   - Appreciation rate:  national only (FHFA HPI state/metro data deferred)
+ *   - Rent growth rate:   national only (Zillow ZORI data deferred)
+ *
+ * Resolution is performed by the apps/api /region endpoint (which also
+ * calls HUD SAFMR for ZIP-level rent data). This package is the pure-TS,
+ * no-I/O, static-data layer that the route handler imports.
+ */
+
+import { STATE_RATES, NATIONAL_RATES } from './stateRates.js';
+import type { RegionalRates } from './types.js';
+
+export type { RegionalRates, RegionLevel } from './types.js';
+export { STATE_RATES, NATIONAL_RATES } from './stateRates.js';
+
+/**
+ * Resolve regional assumption rates for the given US state code.
+ *
+ * @param stateCode  2-letter US state code (case-insensitive, e.g. 'TX', 'tx').
+ *                   Pass an empty string or unknown code to receive national fallback.
+ * @returns          `RegionalRates` for the state if known, otherwise national defaults.
+ */
+export function resolveRegionalRates(stateCode: string): RegionalRates {
+  const upper = stateCode.trim().toUpperCase();
+  const state = STATE_RATES[upper];
+
+  if (state) {
+    return {
+      propertyTaxRate: state.taxRate,
+      insuranceRate: state.insuranceRate,
+      vacancyRate: NATIONAL_RATES.vacancyRate,
+      appreciationRate: NATIONAL_RATES.appreciationRate,
+      rentGrowthRate: NATIONAL_RATES.rentGrowthRate,
+      resolvedLevel: 'state',
+      sourceLabel: `${upper} state averages (Census ACS / NAIC 2022)`,
+    };
+  }
+
+  return {
+    propertyTaxRate: NATIONAL_RATES.taxRate,
+    insuranceRate: NATIONAL_RATES.insuranceRate,
+    vacancyRate: NATIONAL_RATES.vacancyRate,
+    appreciationRate: NATIONAL_RATES.appreciationRate,
+    rentGrowthRate: NATIONAL_RATES.rentGrowthRate,
+    resolvedLevel: 'national',
+    sourceLabel: 'National averages',
+  };
+}

--- a/packages/region-defaults/src/stateRates.ts
+++ b/packages/region-defaults/src/stateRates.ts
@@ -1,0 +1,90 @@
+/**
+ * State-level property tax and insurance rates for all 50 US states.
+ *
+ * Property tax rate:
+ *   Source: Census ACS 5-year estimates (2022), state-level effective rate.
+ *   Method: median property taxes paid (B25103) ÷ median home value (B25077).
+ *   Reference: Tax Foundation 2023 state property tax comparison (same ACS methodology).
+ *
+ * Insurance rate:
+ *   Source: NAIC Homeowners Insurance Report 2022 (state average annual premium).
+ *   Derived rate: state avg premium ÷ $254,000 (US median home value, ACS 2022).
+ *   This produces a purchase-price-relative rate consistent with the baseline
+ *   module's existing pattern of `amount = purchasePrice * rate`.
+ *
+ * Data vintage: 2022. Updated annually via the data pipeline script.
+ * Keys: 2-letter US state codes (uppercase).
+ */
+export const STATE_RATES: Readonly<
+  Record<string, Readonly<{ taxRate: number; insuranceRate: number }>>
+> = {
+  AL: { taxRate: 0.0040, insuranceRate: 0.0068 },
+  AK: { taxRate: 0.0098, insuranceRate: 0.0046 },
+  AZ: { taxRate: 0.0062, insuranceRate: 0.0054 },
+  AR: { taxRate: 0.0062, insuranceRate: 0.0083 },
+  CA: { taxRate: 0.0073, insuranceRate: 0.0046 },
+  CO: { taxRate: 0.0050, insuranceRate: 0.0095 },
+  CT: { taxRate: 0.0179, insuranceRate: 0.0063 },
+  DE: { taxRate: 0.0056, insuranceRate: 0.0040 },
+  FL: { taxRate: 0.0086, insuranceRate: 0.0142 },
+  GA: { taxRate: 0.0090, insuranceRate: 0.0067 },
+  HI: { taxRate: 0.0026, insuranceRate: 0.0050 },
+  ID: { taxRate: 0.0044, insuranceRate: 0.0042 },
+  IL: { taxRate: 0.0222, insuranceRate: 0.0067 },
+  IN: { taxRate: 0.0083, insuranceRate: 0.0054 },
+  IA: { taxRate: 0.0144, insuranceRate: 0.0060 },
+  KS: { taxRate: 0.0133, insuranceRate: 0.0100 },
+  KY: { taxRate: 0.0082, insuranceRate: 0.0064 },
+  LA: { taxRate: 0.0053, insuranceRate: 0.0113 },
+  ME: { taxRate: 0.0105, insuranceRate: 0.0038 },
+  MD: { taxRate: 0.0099, insuranceRate: 0.0049 },
+  MA: { taxRate: 0.0114, insuranceRate: 0.0065 },
+  MI: { taxRate: 0.0132, insuranceRate: 0.0054 },
+  MN: { taxRate: 0.0102, insuranceRate: 0.0069 },
+  MS: { taxRate: 0.0066, insuranceRate: 0.0074 },
+  MO: { taxRate: 0.0088, insuranceRate: 0.0075 },
+  MT: { taxRate: 0.0074, insuranceRate: 0.0067 },
+  NE: { taxRate: 0.0161, insuranceRate: 0.0084 },
+  NV: { taxRate: 0.0048, insuranceRate: 0.0039 },
+  NH: { taxRate: 0.0182, insuranceRate: 0.0039 },
+  NJ: { taxRate: 0.0213, insuranceRate: 0.0059 },
+  NM: { taxRate: 0.0066, insuranceRate: 0.0060 },
+  NY: { taxRate: 0.0140, insuranceRate: 0.0060 },
+  NC: { taxRate: 0.0080, insuranceRate: 0.0050 },
+  ND: { taxRate: 0.0094, insuranceRate: 0.0079 },
+  OH: { taxRate: 0.0143, insuranceRate: 0.0047 },
+  OK: { taxRate: 0.0085, insuranceRate: 0.0113 },
+  OR: { taxRate: 0.0082, insuranceRate: 0.0043 },
+  PA: { taxRate: 0.0149, insuranceRate: 0.0042 },
+  RI: { taxRate: 0.0140, insuranceRate: 0.0065 },
+  SC: { taxRate: 0.0050, insuranceRate: 0.0059 },
+  SD: { taxRate: 0.0114, insuranceRate: 0.0071 },
+  TN: { taxRate: 0.0061, insuranceRate: 0.0066 },
+  TX: { taxRate: 0.0180, insuranceRate: 0.0123 },
+  UT: { taxRate: 0.0056, insuranceRate: 0.0041 },
+  VT: { taxRate: 0.0183, insuranceRate: 0.0040 },
+  VA: { taxRate: 0.0087, insuranceRate: 0.0049 },
+  WA: { taxRate: 0.0084, insuranceRate: 0.0045 },
+  WV: { taxRate: 0.0053, insuranceRate: 0.0044 },
+  WI: { taxRate: 0.0161, insuranceRate: 0.0043 },
+  WY: { taxRate: 0.0055, insuranceRate: 0.0050 },
+} as const;
+
+/**
+ * National-average fallback rates used when no state match is found
+ * or as the base for assumptions not yet resolved at finer granularity.
+ *
+ * Sources:
+ *   taxRate:          Census ACS national effective rate (~1.12 %)
+ *   insuranceRate:    NAIC national avg $1,672 ÷ $254,000 (~0.66 %)
+ *   vacancyRate:      Census CPS/HVS Q4 2024 national rental vacancy (6.8 %)
+ *   appreciationRate: FHFA HPI trailing 10-yr national annualised (4.0 %)
+ *   rentGrowthRate:   Zillow ZORI trailing 5-yr national annualised (3.5 %)
+ */
+export const NATIONAL_RATES = {
+  taxRate: 0.0112,
+  insuranceRate: 0.0066,
+  vacancyRate: 0.068,
+  appreciationRate: 0.040,
+  rentGrowthRate: 0.035,
+} as const;

--- a/packages/region-defaults/src/types.ts
+++ b/packages/region-defaults/src/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Types for the regional assumption defaults data layer (RPE-65).
+ *
+ * RegionalRates expresses all location-variable assumptions as rates/fractions
+ * so callers can apply them to any purchase price without knowing the median
+ * home value of the region.
+ *
+ * Resolution levels follow a fallback hierarchy:
+ *   zip → county → metro → state → national
+ * For v1, state and national are the only populated levels.
+ * Finer-grained data (ZIP/county ACS, FHFA metro HPI) can be added later
+ * by the annual data pipeline without changing this interface.
+ */
+
+/** Geographic resolution level at which an assumption was resolved. */
+export type RegionLevel = 'zip' | 'county' | 'metro' | 'state' | 'national';
+
+/**
+ * Location-variable assumption rates for a given region.
+ *
+ * All rates are expressed as fractions (0–1) unless noted otherwise.
+ * Dollar amounts are NOT stored here — callers apply rates to the purchase price.
+ */
+export interface RegionalRates {
+  /**
+   * Effective property tax rate (median annual taxes paid / median home value).
+   * E.g. Texas = 0.0180 (1.80 %).
+   * Source: Census ACS 5-yr state averages.
+   */
+  propertyTaxRate: number;
+
+  /**
+   * Annual homeowner insurance premium as a fraction of purchase price.
+   * Derived as: NAIC state avg annual premium ÷ $254,000 (US median home value 2022).
+   * E.g. Florida = 0.0142 (1.42 %).
+   */
+  insuranceRate: number;
+
+  /**
+   * Rental vacancy rate (0–1).
+   * E.g. 0.068 = 6.8 % — national CPS/HVS Q4 2024.
+   * Sub-national data deferred to a future data pipeline run.
+   */
+  vacancyRate: number;
+
+  /**
+   * Annualised home price appreciation rate (0–1).
+   * E.g. 0.04 = 4 % — FHFA trailing 10-yr national average.
+   * Metro/state HPI data deferred to a future pipeline.
+   */
+  appreciationRate: number;
+
+  /**
+   * Annual rent growth rate (0–1).
+   * E.g. 0.035 = 3.5 % — Zillow ZORI trailing 5-yr national average.
+   * Metro/ZIP ZORI data deferred to a future pipeline.
+   */
+  rentGrowthRate: number;
+
+  /**
+   * Finest geographic level these rates were actually resolved at.
+   * May differ from the requested level when a fallback was applied.
+   */
+  resolvedLevel: RegionLevel;
+
+  /**
+   * Human-readable source label for UI attribution badges.
+   * E.g. 'TX state averages (Census ACS / NAIC 2022)'
+   */
+  sourceLabel: string;
+}

--- a/packages/region-defaults/tests/regionDefaults.test.ts
+++ b/packages/region-defaults/tests/regionDefaults.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRegionalRates, NATIONAL_RATES, STATE_RATES } from '../src/index';
+
+describe('resolveRegionalRates', () => {
+  // ── Known state lookups ────────────────────────────────────────────────────
+
+  it('returns TX state rates for "TX"', () => {
+    const r = resolveRegionalRates('TX');
+    expect(r.resolvedLevel).toBe('state');
+    expect(r.propertyTaxRate).toBeCloseTo(0.018, 3);
+    expect(r.insuranceRate).toBeCloseTo(0.0123, 3);
+    expect(r.sourceLabel).toContain('TX');
+  });
+
+  it('is case-insensitive (accepts lowercase "tx")', () => {
+    const r = resolveRegionalRates('tx');
+    expect(r.resolvedLevel).toBe('state');
+    expect(r.propertyTaxRate).toBe(STATE_RATES['TX']!.taxRate);
+  });
+
+  it('trims whitespace before lookup', () => {
+    const r = resolveRegionalRates('  CA  ');
+    expect(r.resolvedLevel).toBe('state');
+    expect(r.propertyTaxRate).toBe(STATE_RATES['CA']!.taxRate);
+  });
+
+  it('NJ has the highest property tax rate in the dataset', () => {
+    const r = resolveRegionalRates('NJ');
+    expect(r.propertyTaxRate).toBeCloseTo(0.0213, 3);
+  });
+
+  it('HI has the lowest property tax rate in the dataset', () => {
+    const r = resolveRegionalRates('HI');
+    expect(r.propertyTaxRate).toBeCloseTo(0.0026, 3);
+  });
+
+  it('FL has notably high insurance rate', () => {
+    const r = resolveRegionalRates('FL');
+    expect(r.insuranceRate).toBeCloseTo(0.0142, 3);
+  });
+
+  // ── All 50 states are present ──────────────────────────────────────────────
+
+  it('resolves all 50 US states at state level', () => {
+    const states = [
+      'AL','AK','AZ','AR','CA','CO','CT','DE','FL','GA',
+      'HI','ID','IL','IN','IA','KS','KY','LA','ME','MD',
+      'MA','MI','MN','MS','MO','MT','NE','NV','NH','NJ',
+      'NM','NY','NC','ND','OH','OK','OR','PA','RI','SC',
+      'SD','TN','TX','UT','VT','VA','WA','WV','WI','WY',
+    ];
+    for (const code of states) {
+      const r = resolveRegionalRates(code);
+      expect(r.resolvedLevel, `${code} should resolve at state level`).toBe('state');
+      expect(r.propertyTaxRate, `${code} tax rate should be positive`).toBeGreaterThan(0);
+      expect(r.insuranceRate, `${code} insurance rate should be positive`).toBeGreaterThan(0);
+    }
+  });
+
+  // ── Fallback to national ───────────────────────────────────────────────────
+
+  it('falls back to national defaults for unknown code "XX"', () => {
+    const r = resolveRegionalRates('XX');
+    expect(r.resolvedLevel).toBe('national');
+    expect(r.propertyTaxRate).toBe(NATIONAL_RATES.taxRate);
+    expect(r.insuranceRate).toBe(NATIONAL_RATES.insuranceRate);
+    expect(r.sourceLabel).toBe('National averages');
+  });
+
+  it('falls back to national for empty string', () => {
+    const r = resolveRegionalRates('');
+    expect(r.resolvedLevel).toBe('national');
+  });
+
+  // ── Shared national rates ──────────────────────────────────────────────────
+
+  it('uses NATIONAL_RATES for vacancy, appreciation, rent growth at all levels', () => {
+    const state = resolveRegionalRates('CA');
+    expect(state.vacancyRate).toBe(NATIONAL_RATES.vacancyRate);
+    expect(state.appreciationRate).toBe(NATIONAL_RATES.appreciationRate);
+    expect(state.rentGrowthRate).toBe(NATIONAL_RATES.rentGrowthRate);
+
+    const national = resolveRegionalRates('ZZ');
+    expect(national.vacancyRate).toBe(NATIONAL_RATES.vacancyRate);
+    expect(national.appreciationRate).toBe(NATIONAL_RATES.appreciationRate);
+    expect(national.rentGrowthRate).toBe(NATIONAL_RATES.rentGrowthRate);
+  });
+
+  // ── Source labels ──────────────────────────────────────────────────────────
+
+  it('includes the state code in the sourceLabel', () => {
+    const r = resolveRegionalRates('WA');
+    expect(r.sourceLabel).toContain('WA');
+  });
+
+  it('national sourceLabel is "National averages"', () => {
+    const r = resolveRegionalRates('ZZ');
+    expect(r.sourceLabel).toBe('National averages');
+  });
+});

--- a/packages/region-defaults/tests/regionDefaults.test.ts
+++ b/packages/region-defaults/tests/regionDefaults.test.ts
@@ -24,14 +24,18 @@ describe('resolveRegionalRates', () => {
     expect(r.propertyTaxRate).toBe(STATE_RATES['CA']!.taxRate);
   });
 
-  it('NJ has the highest property tax rate in the dataset', () => {
-    const r = resolveRegionalRates('NJ');
-    expect(r.propertyTaxRate).toBeCloseTo(0.0213, 3);
+  it('IL has the highest property tax rate in the dataset', () => {
+    const r = resolveRegionalRates('IL');
+    expect(r.propertyTaxRate).toBeCloseTo(0.0222, 3);
+    const maxRate = Math.max(...Object.values(STATE_RATES).map((s) => s.taxRate));
+    expect(r.propertyTaxRate).toBe(maxRate);
   });
 
   it('HI has the lowest property tax rate in the dataset', () => {
     const r = resolveRegionalRates('HI');
     expect(r.propertyTaxRate).toBeCloseTo(0.0026, 3);
+    const minRate = Math.min(...Object.values(STATE_RATES).map((s) => s.taxRate));
+    expect(r.propertyTaxRate).toBe(minRate);
   });
 
   it('FL has notably high insurance rate', () => {

--- a/packages/region-defaults/tsconfig.json
+++ b/packages/region-defaults/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "lib": ["ES2022"]
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,8 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
-    "@rpe/engine": "workspace:*"
+    "@rpe/engine": "workspace:*",
+    "@rpe/region-defaults": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -506,7 +506,9 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     if (
       location.zip &&
       resolvedStateCode &&
-      resolvedStateCode !== location.stateCode
+      // Sync when either field drifts — a stored location can have the right
+      // stateCode but a stale/empty label (e.g. API label format changed)
+      (resolvedStateCode !== location.stateCode || resolvedLabel !== location.label)
     ) {
       const resolved: LocationState = {
         zip: location.zip,
@@ -516,7 +518,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
       setLocation(resolved);
       saveLocation(resolved);
     }
-  }, [location.zip, location.stateCode, resolvedStateCode, resolvedLabel]);
+  }, [location.zip, location.stateCode, location.label, resolvedStateCode, resolvedLabel]);
 
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -471,7 +471,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
   /**
    * Location state for regional assumption defaults (RPE-64).
    * zip='' means no location set. stateCode/label are populated after API resolution.
-   * Persisted to localStorage as 'rpe_location'.
+   * Persisted to localStorage under locationState's STORAGE_KEY.
    */
   const [location, setLocation] = useState<LocationState>(() => loadLocation());
 

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
 import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount, normalizeInputs } from '@rpe/engine';
 import type { DealInputs, ScreenerResults, ProFormaResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
@@ -16,6 +16,7 @@ import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from 
 import type { SavedDeal } from './state/savedDealsSchema';
 import { SIMPLE_RESULT_KEYS, type UiMode } from './state/uiMode';
 import { applySimpleBaselines } from './state/simpleBaselines';
+import { useLocationDefaults } from './hooks/useLocationDefaults';
 import { ConnectorSettingsModal } from './components/ConnectorSettingsModal';
 import { getRentCastKey } from './state/connectorStorage';
 import {
@@ -485,6 +486,38 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     clearLocationStorage();
   }, []);
 
+  /**
+   * useLocationDefaults — fetches regional rates for the current ZIP (RPE-66).
+   * When zip is '' (no location), returns no rates and resolving=false.
+   */
+  const {
+    rates: locationRates,
+    resolving: locationResolving,
+    stateCode: resolvedStateCode,
+    label: resolvedLabel,
+  } = useLocationDefaults(location.zip, apiUrl);
+
+  /**
+   * Sync resolved stateCode/label back into persisted location state.
+   * Runs when the hook resolves a new ZIP so the chip shows the resolved label
+   * and localStorage stays up to date.
+   */
+  useEffect(() => {
+    if (
+      location.zip &&
+      resolvedStateCode &&
+      resolvedStateCode !== location.stateCode
+    ) {
+      const resolved: LocationState = {
+        zip: location.zip,
+        stateCode: resolvedStateCode,
+        label: resolvedLabel,
+      };
+      setLocation(resolved);
+      saveLocation(resolved);
+    }
+  }, [location.zip, location.stateCode, resolvedStateCode, resolvedLabel]);
+
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {
     setProFormaMode(pf);
@@ -509,20 +542,24 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
    * through applySimpleBaselines() first so the engine receives a fully-
    * populated DealInputs with baseline values for all hidden complex fields.
    */
+  // Location rate overrides (null when no location is set or rates not yet loaded).
+  // applySimpleBaselines accepts undefined — null → undefined coercion here is intentional.
+  const rateOverrides = locationRates ?? undefined;
+
   const resultsList = useMemo(
     () =>
       scenarios.map((s) =>
         evaluate(
-          uiMode === 'simple' ? applySimpleBaselines(s.inputs) : s.inputs,
+          uiMode === 'simple' ? applySimpleBaselines(s.inputs, rateOverrides) : s.inputs,
         ) as ScreenerResults,
       ),
-    [scenarios, uiMode],
+    [scenarios, uiMode, rateOverrides],
   );
 
   const activeResults =
     resultsList[activeIdx] ??
     (evaluate(
-      uiMode === 'simple' ? applySimpleBaselines(activeInputs) : activeInputs,
+      uiMode === 'simple' ? applySimpleBaselines(activeInputs, rateOverrides) : activeInputs,
     ) as ScreenerResults);
   const isComparing = scenarios.length > 1;
 
@@ -534,9 +571,9 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
   const activeNormalized = useMemo(
     () =>
       normalizeInputs(
-        uiMode === 'simple' ? applySimpleBaselines(activeInputs) : activeInputs,
+        uiMode === 'simple' ? applySimpleBaselines(activeInputs, rateOverrides) : activeInputs,
       ),
-    [activeInputs, uiMode],
+    [activeInputs, uiMode, rateOverrides],
   );
   const proFormaResults = useMemo<ProFormaResults | null>(() => {
     if (!proFormaMode) return null;
@@ -667,7 +704,8 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               apiKey={apiKey}
               apiUrl={apiUrl}
               location={location}
-              locationResolving={false}
+              locationResolving={locationResolving}
+              locationSourceLabel={locationRates?.sourceLabel}
               onZipChange={handleZipChange}
               onLocationClear={handleLocationClear}
             />

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -18,6 +18,13 @@ import { SIMPLE_RESULT_KEYS, type UiMode } from './state/uiMode';
 import { applySimpleBaselines } from './state/simpleBaselines';
 import { ConnectorSettingsModal } from './components/ConnectorSettingsModal';
 import { getRentCastKey } from './state/connectorStorage';
+import {
+  type LocationState,
+  DEFAULT_LOCATION,
+  loadLocation,
+  saveLocation,
+  clearLocationStorage,
+} from './state/locationState';
 
 // ─── Metric helpers ───────────────────────────────────────────────────────────
 
@@ -460,6 +467,24 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
     setApiKey(getRentCastKey());
   }, []);
 
+  /**
+   * Location state for regional assumption defaults (RPE-64).
+   * zip='' means no location set. stateCode/label are populated after API resolution.
+   * Persisted to localStorage as 'rpe_location'.
+   */
+  const [location, setLocation] = useState<LocationState>(() => loadLocation());
+
+  const handleZipChange = useCallback((zip: string) => {
+    const pending: LocationState = { zip, stateCode: '', label: '' };
+    setLocation(pending);
+    saveLocation(pending);
+  }, []);
+
+  const handleLocationClear = useCallback(() => {
+    setLocation(DEFAULT_LOCATION);
+    clearLocationStorage();
+  }, []);
+
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {
     setProFormaMode(pf);
@@ -641,6 +666,10 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               uiMode={uiMode}
               apiKey={apiKey}
               apiUrl={apiUrl}
+              location={location}
+              locationResolving={false}
+              onZipChange={handleZipChange}
+              onLocationClear={handleLocationClear}
             />
           </div>
         </aside>

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -493,6 +493,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
   const {
     rates: locationRates,
     resolving: locationResolving,
+    failed: locationLookupFailed,
     stateCode: resolvedStateCode,
     label: resolvedLabel,
   } = useLocationDefaults(location.zip, apiUrl);
@@ -707,6 +708,7 @@ export function Evaluator({ adConfig }: { adConfig?: AdConfig }) {
               apiUrl={apiUrl}
               location={location}
               locationResolving={locationResolving}
+              locationLookupFailed={locationLookupFailed}
               locationSourceLabel={locationRates?.sourceLabel}
               onZipChange={handleZipChange}
               onLocationClear={handleLocationClear}

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { isValidZip5 } from '../state/locationState';
+
+export interface LocationInputProps {
+  /** Current ZIP ('' = not yet set). */
+  zip: string;
+  /** Resolved state code ('TX', 'CA', …) — empty string until resolved. */
+  stateCode: string;
+  /** Human-readable label for the resolved location (e.g. 'TX · 78701'). */
+  label: string;
+  /** True while useLocationDefaults is fetching the region. */
+  resolving?: boolean;
+  /** Called with a valid ZIP5 when the user submits. */
+  onZipChange: (zip: string) => void;
+  /** Called when the user clears the location. */
+  onClear: () => void;
+}
+
+/**
+ * Location input for regional assumption defaults (RPE-64).
+ *
+ * Render states:
+ * 1. Resolved: shows a chip "TX · 78701 ×" — input hidden.
+ * 2. Unresolved/empty: shows a ZIP5 text input + "Set" button.
+ * 3. Resolving: input disabled, loading indicator shown.
+ *
+ * Accepts either plain ZIP5 ("78701") or "City, ST XXXXX" (the ZIP is extracted).
+ */
+export function LocationInput({
+  zip,
+  stateCode,
+  label,
+  resolving = false,
+  onZipChange,
+  onClear,
+}: LocationInputProps) {
+  const [draft, setDraft] = useState('');
+  const [validationError, setValidationError] = useState('');
+
+  const isResolved = zip !== '' && stateCode !== '';
+
+  const extractZip = (value: string): string => {
+    const trimmed = value.trim();
+    // Accept bare ZIP5
+    if (/^\d{5}$/.test(trimmed)) return trimmed;
+    // Extract trailing ZIP5 from "City, ST XXXXX"
+    const match = trimmed.match(/(\d{5})$/);
+    return match ? (match[1] ?? '') : '';
+  };
+
+  const handleSubmit = () => {
+    const z = extractZip(draft);
+    if (!isValidZip5(z)) {
+      setValidationError('Enter a 5-digit ZIP code.');
+      return;
+    }
+    setValidationError('');
+    setDraft('');
+    onZipChange(z);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
+
+  const handleClear = () => {
+    setDraft('');
+    setValidationError('');
+    onClear();
+  };
+
+  // ── Resolved chip ────────────────────────────────────────────────────────────
+  if (isResolved) {
+    return (
+      <div className="px-5 py-2.5 border-b border-border flex items-center gap-2">
+        <span className="text-xs text-lo uppercase tracking-widest select-none">📍 Location</span>
+        <span
+          className="
+            inline-flex items-center gap-1.5 rounded-full
+            bg-raised border border-border
+            px-2.5 py-0.5 text-xs text-mid
+          "
+        >
+          {label || `${stateCode} · ${zip}`}
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label={`Clear location ${label || zip}`}
+            className="
+              text-lo hover:text-fail transition-colors
+              leading-none rounded-full focus:outline-none focus:ring-1 focus:ring-accent
+            "
+          >
+            ×
+          </button>
+        </span>
+      </div>
+    );
+  }
+
+  // ── Unresolved / input state ─────────────────────────────────────────────────
+  return (
+    <div className="px-5 py-2.5 border-b border-border space-y-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-lo uppercase tracking-widest select-none">📍 Location</span>
+        <div className="flex flex-1 gap-2">
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => { setDraft(e.target.value); setValidationError(''); }}
+            onKeyDown={handleKeyDown}
+            placeholder="ZIP code (e.g. 78701)"
+            disabled={resolving}
+            aria-label="ZIP code for local defaults"
+            aria-describedby={validationError ? 'location-error' : undefined}
+            className="
+              flex-1 rounded border border-border bg-base px-3 py-1 text-xs text-hi
+              placeholder:text-lo
+              focus:border-accent focus:outline-none
+              disabled:opacity-50
+            "
+          />
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={resolving || !draft.trim()}
+            aria-label="Look up location defaults"
+            className="
+              rounded border border-border px-3 py-1 text-xs text-mid uppercase tracking-widest
+              hover:border-accent hover:text-accent transition-colors
+              disabled:opacity-40 disabled:cursor-not-allowed
+            "
+          >
+            {resolving ? '…' : 'Set'}
+          </button>
+        </div>
+      </div>
+      {zip !== '' && stateCode === '' && !resolving && (
+        <p className="text-xs text-yellow-400/80">
+          Resolving {zip}…
+        </p>
+      )}
+      {validationError && (
+        <p id="location-error" className="text-xs text-red-400" role="alert">
+          {validationError}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -10,6 +10,8 @@ export interface LocationInputProps {
   label: string;
   /** True while useLocationDefaults is fetching the region. */
   resolving?: boolean;
+  /** Data-source attribution shown below the resolved chip (e.g. 'TX state averages (Census ACS / NAIC 2022)'). */
+  sourceLabel?: string;
   /** Called with a valid ZIP5 when the user submits. */
   onZipChange: (zip: string) => void;
   /** Called when the user clears the location. */
@@ -31,6 +33,7 @@ export function LocationInput({
   stateCode,
   label,
   resolving = false,
+  sourceLabel,
   onZipChange,
   onClear,
 }: LocationInputProps) {
@@ -74,28 +77,35 @@ export function LocationInput({
   // ── Resolved chip ────────────────────────────────────────────────────────────
   if (isResolved) {
     return (
-      <div className="px-5 py-2.5 border-b border-border flex items-center gap-2">
-        <span className="text-xs text-lo uppercase tracking-widest select-none">📍 Location</span>
-        <span
-          className="
-            inline-flex items-center gap-1.5 rounded-full
-            bg-raised border border-border
-            px-2.5 py-0.5 text-xs text-mid
-          "
-        >
-          {label || `${stateCode} · ${zip}`}
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear location ${label || zip}`}
+      <div className="px-5 py-2.5 border-b border-border space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-lo uppercase tracking-widest select-none">📍 Location</span>
+          <span
             className="
-              text-lo hover:text-fail transition-colors
-              leading-none rounded-full focus:outline-none focus:ring-1 focus:ring-accent
+              inline-flex items-center gap-1.5 rounded-full
+              bg-raised border border-border
+              px-2.5 py-0.5 text-xs text-mid
             "
           >
-            ×
-          </button>
-        </span>
+            {label || `${stateCode} · ${zip}`}
+            <button
+              type="button"
+              onClick={handleClear}
+              aria-label={`Clear location ${label || zip}`}
+              className="
+                text-lo hover:text-fail transition-colors
+                leading-none rounded-full focus:outline-none focus:ring-1 focus:ring-accent
+              "
+            >
+              ×
+            </button>
+          </span>
+        </div>
+        {sourceLabel && (
+          <p className="text-xs text-lo pl-0.5" title="Source for regional assumption defaults">
+            📊 {sourceLabel}
+          </p>
+        )}
       </div>
     );
   }

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -26,7 +26,8 @@ export interface LocationInputProps {
  * 2. Unresolved/empty: shows a ZIP5 text input + "Set" button.
  * 3. Resolving: input disabled, loading indicator shown.
  *
- * Accepts either plain ZIP5 ("78701") or "City, ST XXXXX" (the ZIP is extracted).
+ * Accepts plain ZIP5 ("78701"), ZIP+4 ("78701-1234", the +4 is dropped),
+ * or "City, ST XXXXX" / "City, ST XXXXX-XXXX" (the ZIP5 is extracted).
  */
 export function LocationInput({
   zip,
@@ -48,8 +49,10 @@ export function LocationInput({
     if (/^\d+$/.test(trimmed)) {
       return /^\d{5}$/.test(trimmed) ? trimmed : '';
     }
-    // "City, ST XXXXX" format: trailing ZIP5 must be preceded by a non-digit
-    const match = trimmed.match(/(?:[^\d])(\d{5})$/);
+    // ZIP+4 or "City, ST XXXXX[-XXXX]": trailing ZIP5 (optionally +4, which is
+    // dropped) must start the string or be preceded by a non-digit — never
+    // extract a ZIP from a longer digit run ("City, ST 123456" → '')
+    const match = trimmed.match(/(?:^|[^\d])(\d{5})(?:-\d{4})?$/);
     return match ? (match[1] ?? '') : '';
   };
 

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -10,6 +10,8 @@ export interface LocationInputProps {
   label: string;
   /** True while useLocationDefaults is fetching the region. */
   resolving?: boolean;
+  /** True when the last region lookup failed — shows an error hint instead of "pending". */
+  lookupFailed?: boolean;
   /** Data-source attribution shown below the resolved chip (e.g. 'TX state averages (Census ACS / NAIC 2022)'). */
   sourceLabel?: string;
   /** Called with a valid ZIP5 when the user submits. */
@@ -34,6 +36,7 @@ export function LocationInput({
   stateCode,
   label,
   resolving = false,
+  lookupFailed = false,
   sourceLabel,
   onZipChange,
   onClear,
@@ -139,8 +142,12 @@ export function LocationInput({
       </div>
       {zip !== '' && stateCode === '' && (
         <div className="flex items-center gap-2">
-          <p className="text-xs text-yellow-400/80">
-            {resolving ? `Resolving ${zip}…` : `${zip} pending`}
+          <p className={`text-xs ${lookupFailed ? 'text-red-400' : 'text-yellow-400/80'}`} role={lookupFailed ? 'alert' : undefined}>
+            {resolving
+              ? `Resolving ${zip}…`
+              : lookupFailed
+                ? `Couldn't look up ${zip} — using national defaults. Clear and retry.`
+                : `${zip} pending`}
           </p>
           <button
             type="button"

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { isValidZip5 } from '../state/locationState';
+import { isValidZip5, extractZip } from '../state/locationState';
 
 export interface LocationInputProps {
   /** Current ZIP ('' = not yet set). */
@@ -42,19 +42,6 @@ export function LocationInput({
   const [validationError, setValidationError] = useState('');
 
   const isResolved = zip !== '' && stateCode !== '';
-
-  const extractZip = (value: string): string => {
-    const trimmed = value.trim();
-    // All-digit input: require exactly 5 — never silently truncate "123456" → "23456"
-    if (/^\d+$/.test(trimmed)) {
-      return /^\d{5}$/.test(trimmed) ? trimmed : '';
-    }
-    // ZIP+4 or "City, ST XXXXX[-XXXX]": trailing ZIP5 (optionally +4, which is
-    // dropped) must start the string or be preceded by a non-digit — never
-    // extract a ZIP from a longer digit run ("City, ST 123456" → '')
-    const match = trimmed.match(/(?:^|[^\d])(\d{5})(?:-\d{4})?$/);
-    return match ? (match[1] ?? '') : '';
-  };
 
   const handleSubmit = () => {
     const z = extractZip(draft);

--- a/packages/ui/src/components/LocationInput.tsx
+++ b/packages/ui/src/components/LocationInput.tsx
@@ -41,10 +41,12 @@ export function LocationInput({
 
   const extractZip = (value: string): string => {
     const trimmed = value.trim();
-    // Accept bare ZIP5
-    if (/^\d{5}$/.test(trimmed)) return trimmed;
-    // Extract trailing ZIP5 from "City, ST XXXXX"
-    const match = trimmed.match(/(\d{5})$/);
+    // All-digit input: require exactly 5 — never silently truncate "123456" → "23456"
+    if (/^\d+$/.test(trimmed)) {
+      return /^\d{5}$/.test(trimmed) ? trimmed : '';
+    }
+    // "City, ST XXXXX" format: trailing ZIP5 must be preceded by a non-digit
+    const match = trimmed.match(/(?:[^\d])(\d{5})$/);
     return match ? (match[1] ?? '') : '';
   };
 
@@ -135,10 +137,23 @@ export function LocationInput({
           </button>
         </div>
       </div>
-      {zip !== '' && stateCode === '' && !resolving && (
-        <p className="text-xs text-yellow-400/80">
-          Resolving {zip}…
-        </p>
+      {zip !== '' && stateCode === '' && (
+        <div className="flex items-center gap-2">
+          <p className="text-xs text-yellow-400/80">
+            {resolving ? `Resolving ${zip}…` : `${zip} pending`}
+          </p>
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label={`Clear pending location ${zip}`}
+            className="
+              text-xs text-lo hover:text-fail transition-colors
+              leading-none rounded-full focus:outline-none focus:ring-1 focus:ring-accent
+            "
+          >
+            ×
+          </button>
+        </div>
       )}
       {validationError && (
         <p id="location-error" className="text-xs text-red-400" role="alert">

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -9,6 +9,8 @@ import { NumberInput } from './NumberInput';
 import { ToggleInput } from './ToggleInput';
 import { FixedExpenseRow } from './FixedExpenseRow';
 import { AutofillBar } from '../AutofillBar';
+import { LocationInput } from '../LocationInput';
+import type { LocationState } from '../../state/locationState';
 
 export interface DealInputsFormProps {
   state: DealInputs;
@@ -29,6 +31,17 @@ export interface DealInputsFormProps {
   apiKey?: string | null;
   /** Base URL for apps/api. Defaults to http://localhost:3001. */
   apiUrl?: string;
+  /**
+   * Current location state for regional assumption defaults (RPE-64).
+   * When provided, renders LocationInput below AutofillBar.
+   */
+  location?: LocationState;
+  /** True while useLocationDefaults is resolving the ZIP → region. */
+  locationResolving?: boolean;
+  /** Called with a valid ZIP5 when the user submits the location input. */
+  onZipChange?: (zip: string) => void;
+  /** Called when the user clears the location chip. */
+  onLocationClear?: () => void;
 }
 
 /**
@@ -47,6 +60,10 @@ export function DealInputsForm({
   uiMode = 'complex',
   apiKey = null,
   apiUrl,
+  location,
+  locationResolving = false,
+  onZipChange,
+  onLocationClear,
 }: DealInputsFormProps) {
   const { expenses } = state;
   const simple = uiMode === 'simple';
@@ -73,6 +90,18 @@ export function DealInputsForm({
     <div>
       {/* ── Autofill bar (always shown, adapts when apiKey is null) ──────── */}
       <AutofillBar dispatch={dispatch} apiKey={apiKey} apiUrl={apiUrl} currentValues={currentAutofillValues} />
+
+      {/* ── Location input for regional assumption defaults (RPE-64) ─────── */}
+      {onZipChange && onLocationClear && (
+        <LocationInput
+          zip={location?.zip ?? ''}
+          stateCode={location?.stateCode ?? ''}
+          label={location?.label ?? ''}
+          resolving={locationResolving}
+          onZipChange={onZipChange}
+          onClear={onLocationClear}
+        />
+      )}
 
       {/* ── Acquisition ──────────────────────────────────────────────────── */}
       <InputSection title="Acquisition">

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -39,6 +39,8 @@ export interface DealInputsFormProps {
   location?: LocationState;
   /** True while useLocationDefaults is resolving the ZIP → region. */
   locationResolving?: boolean;
+  /** True when the last region lookup failed — LocationInput shows an error hint. */
+  locationLookupFailed?: boolean;
   /** Source attribution label shown below the resolved chip (e.g. 'TX state averages'). */
   locationSourceLabel?: string;
   /** Called with a valid ZIP5 when the user submits the location input. */
@@ -65,6 +67,7 @@ export function DealInputsForm({
   apiUrl,
   location,
   locationResolving = false,
+  locationLookupFailed = false,
   locationSourceLabel,
   onZipChange,
   onLocationClear,
@@ -102,6 +105,7 @@ export function DealInputsForm({
           stateCode={location?.stateCode ?? ''}
           label={location?.label ?? ''}
           resolving={locationResolving}
+          lookupFailed={locationLookupFailed}
           sourceLabel={locationSourceLabel}
           onZipChange={onZipChange}
           onClear={onLocationClear}

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -38,6 +38,8 @@ export interface DealInputsFormProps {
   location?: LocationState;
   /** True while useLocationDefaults is resolving the ZIP → region. */
   locationResolving?: boolean;
+  /** Source attribution label shown below the resolved chip (e.g. 'TX state averages'). */
+  locationSourceLabel?: string;
   /** Called with a valid ZIP5 when the user submits the location input. */
   onZipChange?: (zip: string) => void;
   /** Called when the user clears the location chip. */
@@ -62,6 +64,7 @@ export function DealInputsForm({
   apiUrl,
   location,
   locationResolving = false,
+  locationSourceLabel,
   onZipChange,
   onLocationClear,
 }: DealInputsFormProps) {
@@ -98,6 +101,7 @@ export function DealInputsForm({
           stateCode={location?.stateCode ?? ''}
           label={location?.label ?? ''}
           resolving={locationResolving}
+          sourceLabel={locationSourceLabel}
           onZipChange={onZipChange}
           onClear={onLocationClear}
         />

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -33,7 +33,8 @@ export interface DealInputsFormProps {
   apiUrl?: string;
   /**
    * Current location state for regional assumption defaults (RPE-64).
-   * When provided, renders LocationInput below AutofillBar.
+   * LocationInput renders below AutofillBar when both onZipChange and
+   * onLocationClear are provided; this prop supplies its display values.
    */
   location?: LocationState;
   /** True while useLocationDefaults is resolving the ZIP → region. */

--- a/packages/ui/src/hooks/useLocationDefaults.ts
+++ b/packages/ui/src/hooks/useLocationDefaults.ts
@@ -7,9 +7,10 @@
  *
  * Lifecycle:
  *   1. zip='' → no fetch; all fields empty/null, resolving=false
- *   2. zip changes → in-flight request cancelled; resolving=true
+ *   2. zip changes → in-flight request cancelled; prior resolved values
+ *      cleared immediately (no stale leak); resolving=true
  *   3. API succeeds → rates/stateCode/label populated; resolving=false
- *   4. API fails → rates=null, resolving=false (caller degrades gracefully)
+ *   4. API fails → full reset to empty (caller degrades gracefully)
  */
 
 import { useState, useEffect, useRef } from 'react';
@@ -19,10 +20,13 @@ import type { LocationRateOverrides } from '../state/simpleBaselines';
 
 /**
  * Full regional defaults returned by the /region API, superset of
- * LocationRateOverrides. Carrying extra fields (appreciationRate,
- * rentGrowthRate, rent, resolvedLevel) future-proofs pro-forma defaults.
+ * LocationRateOverrides. Carrying extra fields (vacancyRate, appreciationRate,
+ * rentGrowthRate, rent, resolvedLevel) future-proofs pro-forma defaults —
+ * vacancyRate is informational only; the visible vacancy input always wins
+ * in simple-mode evaluation (see LocationRateOverrides docs).
  */
 export interface RegionDefaults extends LocationRateOverrides {
+  vacancyRate: number;
   appreciationRate: number;
   rentGrowthRate: number;
   resolvedLevel: string;
@@ -100,7 +104,10 @@ export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaul
     const controller = new AbortController();
     abortRef.current = controller;
 
-    setResult((prev) => ({ ...prev, resolving: true }));
+    // Clear prior resolved values immediately so a zip change never leaks the
+    // previous location's rates/stateCode/label to callers mid-flight (e.g.
+    // Evaluator persisting the old stateCode against the new zip).
+    setResult({ ...EMPTY, resolving: true });
 
     fetch(`${apiUrl}/region?zip=${encodeURIComponent(zip)}`, {
       signal: controller.signal,
@@ -130,8 +137,9 @@ export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaul
       })
       .catch((err: unknown) => {
         if ((err as Error).name === 'AbortError') return;
-        // Network error or non-OK response — clear rates, stop spinner
-        setResult((prev) => ({ ...prev, resolving: false, rates: null }));
+        // Network error or non-OK response — full reset so no stale
+        // stateCode/label lingers in the UI or syncs into persisted state
+        setResult(EMPTY);
       });
 
     return () => {

--- a/packages/ui/src/hooks/useLocationDefaults.ts
+++ b/packages/ui/src/hooks/useLocationDefaults.ts
@@ -14,6 +14,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
+import type { RegionLevel } from '@rpe/region-defaults';
 import type { LocationRateOverrides } from '../state/simpleBaselines';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -29,7 +30,7 @@ export interface RegionDefaults extends LocationRateOverrides {
   vacancyRate: number;
   appreciationRate: number;
   rentGrowthRate: number;
-  resolvedLevel: string;
+  resolvedLevel: RegionLevel;
   rent: {
     studio: number | null;
     oneBed: number | null;
@@ -48,6 +49,8 @@ export interface LocationDefaultsResult {
   label: string;
   /** True while the /region API call is in-flight. */
   resolving: boolean;
+  /** True when the last lookup failed (network/HTTP error) — cleared on the next fetch. */
+  failed: boolean;
 }
 
 // ─── Internal API response type ───────────────────────────────────────────────
@@ -61,7 +64,7 @@ interface RegionApiResponse {
   vacancyRate: number;
   appreciationRate: number;
   rentGrowthRate: number;
-  resolvedLevel: string;
+  resolvedLevel: RegionLevel;
   sourceLabel: string;
   rent: {
     studio: number | null;
@@ -77,6 +80,7 @@ const EMPTY: LocationDefaultsResult = {
   stateCode: '',
   label: '',
   resolving: false,
+  failed: false,
 };
 
 // ─── Hook ─────────────────────────────────────────────────────────────────────
@@ -133,13 +137,19 @@ export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaul
           stateCode: data.stateCode,
           label: data.label,
           resolving: false,
+          failed: false,
         });
       })
-      .catch((err: unknown) => {
-        if ((err as Error).name === 'AbortError') return;
+      .catch(() => {
+        // Guard on the signal (covers both abort rejections AND late
+        // failures of an already-superseded request, e.g. a parse error
+        // surfacing after the next fetch has started — without this, a
+        // stale request would clobber the new one's resolving state).
+        if (controller.signal.aborted) return;
         // Network error or non-OK response — full reset so no stale
-        // stateCode/label lingers in the UI or syncs into persisted state
-        setResult(EMPTY);
+        // stateCode/label lingers, with failed=true so the UI can tell
+        // the user instead of showing the ZIP as pending forever
+        setResult({ ...EMPTY, failed: true });
       });
 
     return () => {

--- a/packages/ui/src/hooks/useLocationDefaults.ts
+++ b/packages/ui/src/hooks/useLocationDefaults.ts
@@ -1,0 +1,143 @@
+/**
+ * E9 — useLocationDefaults hook (RPE-66)
+ *
+ * Fetches regional assumption defaults for a given ZIP5 code from the
+ * apps/api /region endpoint. Returns the resolved rates plus resolved
+ * stateCode and label for display in LocationInput.
+ *
+ * Lifecycle:
+ *   1. zip='' → no fetch; all fields empty/null, resolving=false
+ *   2. zip changes → in-flight request cancelled; resolving=true
+ *   3. API succeeds → rates/stateCode/label populated; resolving=false
+ *   4. API fails → rates=null, resolving=false (caller degrades gracefully)
+ */
+
+import { useState, useEffect, useRef } from 'react';
+import type { LocationRateOverrides } from '../state/simpleBaselines';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Full regional defaults returned by the /region API, superset of
+ * LocationRateOverrides. Carrying extra fields (appreciationRate,
+ * rentGrowthRate, rent, resolvedLevel) future-proofs pro-forma defaults.
+ */
+export interface RegionDefaults extends LocationRateOverrides {
+  appreciationRate: number;
+  rentGrowthRate: number;
+  resolvedLevel: string;
+  rent: {
+    studio: number | null;
+    oneBed: number | null;
+    twoBed: number | null;
+    threeBed: number | null;
+    fourBed: number | null;
+  } | null;
+}
+
+export interface LocationDefaultsResult {
+  /** Rate overrides to pass to applySimpleBaselines(), or null when unresolved. */
+  rates: RegionDefaults | null;
+  /** Resolved 2-letter state code ('TX', 'CA', …). Empty when not yet resolved. */
+  stateCode: string;
+  /** Human-readable label for display (e.g. 'Austin, TX (78701)'). */
+  label: string;
+  /** True while the /region API call is in-flight. */
+  resolving: boolean;
+}
+
+// ─── Internal API response type ───────────────────────────────────────────────
+
+interface RegionApiResponse {
+  zip: string;
+  stateCode: string;
+  label: string;
+  propertyTaxRate: number;
+  insuranceRate: number;
+  vacancyRate: number;
+  appreciationRate: number;
+  rentGrowthRate: number;
+  resolvedLevel: string;
+  sourceLabel: string;
+  rent: {
+    studio: number | null;
+    oneBed: number | null;
+    twoBed: number | null;
+    threeBed: number | null;
+    fourBed: number | null;
+  } | null;
+}
+
+const EMPTY: LocationDefaultsResult = {
+  rates: null,
+  stateCode: '',
+  label: '',
+  resolving: false,
+};
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch regional assumption defaults for a ZIP5 code.
+ *
+ * @param zip     5-digit ZIP code ('' = no location selected).
+ * @param apiUrl  Base URL for the apps/api server.
+ * @returns       Resolved defaults + display fields + resolving flag.
+ */
+export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaultsResult {
+  const [result, setResult] = useState<LocationDefaultsResult>(EMPTY);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!zip) {
+      abortRef.current?.abort();
+      setResult(EMPTY);
+      return;
+    }
+
+    // Cancel any previous in-flight request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setResult((prev) => ({ ...prev, resolving: true }));
+
+    fetch(`${apiUrl}/region?zip=${encodeURIComponent(zip)}`, {
+      signal: controller.signal,
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<RegionApiResponse>;
+      })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        const rates: RegionDefaults = {
+          propertyTaxRate: data.propertyTaxRate,
+          insuranceRate: data.insuranceRate,
+          vacancyRate: data.vacancyRate,
+          appreciationRate: data.appreciationRate,
+          rentGrowthRate: data.rentGrowthRate,
+          resolvedLevel: data.resolvedLevel,
+          sourceLabel: data.sourceLabel,
+          rent: data.rent,
+        };
+        setResult({
+          rates,
+          stateCode: data.stateCode,
+          label: data.label,
+          resolving: false,
+        });
+      })
+      .catch((err: unknown) => {
+        if ((err as Error).name === 'AbortError') return;
+        // Network error or non-OK response — clear rates, stop spinner
+        setResult((prev) => ({ ...prev, resolving: false, rates: null }));
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [zip, apiUrl]);
+
+  return result;
+}

--- a/packages/ui/src/state/locationState.ts
+++ b/packages/ui/src/state/locationState.ts
@@ -30,7 +30,8 @@ export const DEFAULT_LOCATION: LocationState = {
   label: '',
 };
 
-const STORAGE_KEY = 'rpe_location';
+/** Exported so tests and other modules can reference the key without duplicating the string. */
+export const STORAGE_KEY = 'rpe_location';
 
 // ─── Persistence ──────────────────────────────────────────────────────────────
 
@@ -47,6 +48,9 @@ export function loadLocation(): LocationState {
     const zip = typeof parsed.zip === 'string' ? parsed.zip.trim() : '';
     const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode.trim().toUpperCase() : '';
     const label = typeof parsed.label === 'string' ? parsed.label.trim() : '';
+    // Guard: if a non-empty zip survived the parse but is not a valid ZIP5, discard the entry.
+    // This protects against corrupted/legacy storage that would propagate an invalid ZIP downstream.
+    if (zip && !isValidZip5(zip)) return DEFAULT_LOCATION;
     return { zip, stateCode, label };
   } catch {
     return DEFAULT_LOCATION;
@@ -59,9 +63,13 @@ export function loadLocation(): LocationState {
  */
 export function saveLocation(loc: LocationState): void {
   try {
+    const zip = loc.zip.trim();
+    // Guard: never persist an invalid ZIP — callers should always pass a valid ZIP5 or ''.
+    // This prevents bypassing UI validation from entraining corrupt data in localStorage.
+    if (zip && !isValidZip5(zip)) return;
     // Normalise before persisting so stored payload is always clean
     const normalized: LocationState = {
-      zip: loc.zip.trim(),
+      zip,
       stateCode: loc.stateCode.trim().toUpperCase(),
       label: loc.label.trim(),
     };

--- a/packages/ui/src/state/locationState.ts
+++ b/packages/ui/src/state/locationState.ts
@@ -43,9 +43,10 @@ export function loadLocation(): LocationState {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_LOCATION;
     const parsed = JSON.parse(raw) as Partial<LocationState>;
-    const zip = typeof parsed.zip === 'string' ? parsed.zip : '';
-    const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode : '';
-    const label = typeof parsed.label === 'string' ? parsed.label : '';
+    // Normalise on load: trim whitespace, uppercase stateCode
+    const zip = typeof parsed.zip === 'string' ? parsed.zip.trim() : '';
+    const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode.trim().toUpperCase() : '';
+    const label = typeof parsed.label === 'string' ? parsed.label.trim() : '';
     return { zip, stateCode, label };
   } catch {
     return DEFAULT_LOCATION;
@@ -58,7 +59,13 @@ export function loadLocation(): LocationState {
  */
 export function saveLocation(loc: LocationState): void {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(loc));
+    // Normalise before persisting so stored payload is always clean
+    const normalized: LocationState = {
+      zip: loc.zip.trim(),
+      stateCode: loc.stateCode.trim().toUpperCase(),
+      label: loc.label.trim(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
   } catch {
     // ignore
   }

--- a/packages/ui/src/state/locationState.ts
+++ b/packages/ui/src/state/locationState.ts
@@ -33,6 +33,21 @@ export const DEFAULT_LOCATION: LocationState = {
 /** Exported so tests and other modules can reference the key without duplicating the string. */
 export const STORAGE_KEY = 'rpe:location:v1';
 
+// ─── Normalisation ────────────────────────────────────────────────────────────
+
+/**
+ * Normalise a (possibly partial/untrusted) location: trim all fields, uppercase
+ * stateCode. Single source of truth for the load and save paths so the
+ * round-trip invariant can't drift.
+ */
+function normalizeLocation(loc: Partial<LocationState>): LocationState {
+  return {
+    zip: typeof loc.zip === 'string' ? loc.zip.trim() : '',
+    stateCode: typeof loc.stateCode === 'string' ? loc.stateCode.trim().toUpperCase() : '',
+    label: typeof loc.label === 'string' ? loc.label.trim() : '',
+  };
+}
+
 // ─── Persistence ──────────────────────────────────────────────────────────────
 
 /**
@@ -43,15 +58,11 @@ export function loadLocation(): LocationState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return DEFAULT_LOCATION;
-    const parsed = JSON.parse(raw) as Partial<LocationState>;
-    // Normalise on load: trim whitespace, uppercase stateCode
-    const zip = typeof parsed.zip === 'string' ? parsed.zip.trim() : '';
-    const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode.trim().toUpperCase() : '';
-    const label = typeof parsed.label === 'string' ? parsed.label.trim() : '';
+    const normalized = normalizeLocation(JSON.parse(raw) as Partial<LocationState>);
     // Guard: if a non-empty zip survived the parse but is not a valid ZIP5, discard the entry.
     // This protects against corrupted/legacy storage that would propagate an invalid ZIP downstream.
-    if (zip && !isValidZip5(zip)) return DEFAULT_LOCATION;
-    return { zip, stateCode, label };
+    if (normalized.zip && !isValidZip5(normalized.zip)) return DEFAULT_LOCATION;
+    return normalized;
   } catch {
     return DEFAULT_LOCATION;
   }
@@ -63,16 +74,10 @@ export function loadLocation(): LocationState {
  */
 export function saveLocation(loc: LocationState): void {
   try {
-    const zip = loc.zip.trim();
+    const normalized = normalizeLocation(loc);
     // Guard: never persist an invalid ZIP — callers should always pass a valid ZIP5 or ''.
     // This prevents bypassing UI validation from entraining corrupt data in localStorage.
-    if (zip && !isValidZip5(zip)) return;
-    // Normalise before persisting so stored payload is always clean
-    const normalized: LocationState = {
-      zip,
-      stateCode: loc.stateCode.trim().toUpperCase(),
-      label: loc.label.trim(),
-    };
+    if (normalized.zip && !isValidZip5(normalized.zip)) return;
     localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
   } catch {
     // ignore
@@ -95,4 +100,26 @@ export function clearLocationStorage(): void {
 /** Returns true if the value is a valid 5-digit US ZIP code. */
 export function isValidZip5(value: string): boolean {
   return /^\d{5}$/.test(value.trim());
+}
+
+/**
+ * Extract a ZIP5 from free-form location input.
+ *
+ * Accepts plain ZIP5 ("78701"), ZIP+4 ("78701-1234", the +4 is dropped),
+ * or "City, ST XXXXX" / "City, ST XXXXX-XXXX" (the trailing ZIP5 is extracted).
+ * Returns '' when no unambiguous ZIP5 is present — an all-digit input of the
+ * wrong length ("123456") or a trailing run longer than 5 digits is rejected
+ * rather than silently truncated.
+ */
+export function extractZip(value: string): string {
+  const trimmed = value.trim();
+  // All-digit input: require exactly 5 — never silently truncate "123456" → "23456"
+  if (/^\d+$/.test(trimmed)) {
+    return /^\d{5}$/.test(trimmed) ? trimmed : '';
+  }
+  // ZIP+4 or "City, ST XXXXX[-XXXX]": trailing ZIP5 (optionally +4, which is
+  // dropped) must start the string or be preceded by a non-digit — never
+  // extract a ZIP from a longer digit run ("City, ST 123456" → '')
+  const match = trimmed.match(/(?:^|[^\d])(\d{5})(?:-\d{4})?$/);
+  return match ? (match[1] ?? '') : '';
 }

--- a/packages/ui/src/state/locationState.ts
+++ b/packages/ui/src/state/locationState.ts
@@ -1,0 +1,83 @@
+/**
+ * E9 — Location state for regional assumption defaults (RPE-64)
+ *
+ * Stores the user's chosen location (ZIP5) and the resolved region info
+ * returned by apps/api /region. Persisted to localStorage so the last-used
+ * location survives page reloads.
+ *
+ * Resolution lifecycle:
+ *   1. User enters ZIP5 → { zip, stateCode: '', label: '' }  (unresolved)
+ *   2. useLocationDefaults resolves → { zip, stateCode: 'TX', label: 'TX · 78701' }
+ *   3. User clears → DEFAULT_LOCATION
+ *
+ * The stateCode and label fields are derived from the apps/api /region response
+ * and are cached here for display purposes. They are never trusted for data
+ * lookup — the API always re-resolves from the zip.
+ */
+
+export interface LocationState {
+  /** Raw ZIP5 string (e.g. '78701'). Empty string means no location set. */
+  zip: string;
+  /** 2-letter US state code returned by the region API. Empty until resolved. */
+  stateCode: string;
+  /** Human-readable label for display (e.g. 'TX · 78701'). Empty until resolved. */
+  label: string;
+}
+
+export const DEFAULT_LOCATION: LocationState = {
+  zip: '',
+  stateCode: '',
+  label: '',
+};
+
+const STORAGE_KEY = 'rpe_location';
+
+// ─── Persistence ──────────────────────────────────────────────────────────────
+
+/**
+ * Load the persisted location from localStorage.
+ * Returns DEFAULT_LOCATION if nothing is stored or parsing fails.
+ */
+export function loadLocation(): LocationState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_LOCATION;
+    const parsed = JSON.parse(raw) as Partial<LocationState>;
+    const zip = typeof parsed.zip === 'string' ? parsed.zip : '';
+    const stateCode = typeof parsed.stateCode === 'string' ? parsed.stateCode : '';
+    const label = typeof parsed.label === 'string' ? parsed.label : '';
+    return { zip, stateCode, label };
+  } catch {
+    return DEFAULT_LOCATION;
+  }
+}
+
+/**
+ * Persist the location to localStorage.
+ * Silently ignores storage errors (private browsing, quota exceeded, etc.).
+ */
+export function saveLocation(loc: LocationState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(loc));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Remove the persisted location from localStorage.
+ */
+export function clearLocationStorage(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/** Returns true if the value is a valid 5-digit US ZIP code. */
+export function isValidZip5(value: string): boolean {
+  return /^\d{5}$/.test(value.trim());
+}

--- a/packages/ui/src/state/locationState.ts
+++ b/packages/ui/src/state/locationState.ts
@@ -31,7 +31,7 @@ export const DEFAULT_LOCATION: LocationState = {
 };
 
 /** Exported so tests and other modules can reference the key without duplicating the string. */
-export const STORAGE_KEY = 'rpe_location';
+export const STORAGE_KEY = 'rpe:location:v1';
 
 // ─── Persistence ──────────────────────────────────────────────────────────────
 

--- a/packages/ui/src/state/simpleBaselines.ts
+++ b/packages/ui/src/state/simpleBaselines.ts
@@ -1,5 +1,6 @@
 /**
  * E8 — Baseline-assumptions module (RPE-58)
+ * E9 — Location-based overrides added in RPE-66
  *
  * Provides conservative national-average default values for the complex-tier
  * DealInputs fields hidden in simple mode (financing, variable/fixed expenses).
@@ -10,8 +11,9 @@
  *   - All baseline values are documented in BASELINE_DESCRIPTIONS.
  *   - Purchase-price-dependent baselines (closing costs, taxes, insurance) are
  *     recomputed each time the purchase price changes.
- *   - E9 (location defaults, RPE-56) will override these static values per region
- *     by replacing getSimpleBaselines() at the call sites in Evaluator.tsx.
+ *   - getSimpleBaselines() accepts an optional LocationRateOverrides argument that
+ *     replaces the static national-average tax, insurance, and vacancy values with
+ *     region-specific data from the useLocationDefaults hook (RPE-66).
  *   - applySimpleBaselines() is the evaluation path for simple mode ONLY.
  *     Calling it in complex mode is incorrect — complex mode passes inputs directly.
  */
@@ -47,6 +49,27 @@ export interface SimpleBaselineValues {
   };
 }
 
+// ─── Location rate overrides (RPE-66) ────────────────────────────────────────
+
+/**
+ * Region-specific rate overrides supplied by the useLocationDefaults hook.
+ * When provided to getSimpleBaselines(), these replace the static national-average
+ * tax, insurance, and vacancy rates with location-specific data.
+ *
+ * The interface is a structural subset of @rpe/region-defaults' RegionalRates,
+ * so RegionalRates satisfies this type without an explicit cast.
+ */
+export interface LocationRateOverrides {
+  /** 0–1 effective property tax rate (e.g. 0.018 for Texas). */
+  propertyTaxRate: number;
+  /** 0–1 annual insurance premium as % of purchase price. */
+  insuranceRate: number;
+  /** 0–1 vacancy rate (e.g. 0.068 for the national average). */
+  vacancyRate: number;
+  /** Human-readable source description (e.g. 'TX state averages (Census ACS / NAIC 2022)'). */
+  sourceLabel: string;
+}
+
 // ─── Core baseline function ──────────────────────────────────────────────────
 
 /**
@@ -54,9 +77,20 @@ export interface SimpleBaselineValues {
  *
  * Purchase-price-relative items (closing costs, taxes, insurance) are
  * re-derived on every call; all other values are static constants.
+ *
+ * @param purchasePrice  The property's purchase price.
+ * @param overrides      Optional location-based rate overrides (RPE-66).
+ *                       When provided, replace national-average tax, insurance,
+ *                       and vacancy with region-specific values.
  */
-export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues {
+export function getSimpleBaselines(
+  purchasePrice: number,
+  overrides?: LocationRateOverrides,
+): SimpleBaselineValues {
   const pp = purchasePrice > 0 ? purchasePrice : 0;
+  const taxRate = overrides?.propertyTaxRate ?? 0.012;
+  const insuranceRate = overrides?.insuranceRate ?? 0.005;
+  const vacancyPct = overrides ? parseFloat((overrides.vacancyRate * 100).toFixed(1)) : 5;
   return {
     // ── Financing ──────────────────────────────────────────────────────────
     interestRate: 7.0,
@@ -68,8 +102,7 @@ export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues 
 
     // ── Income ────────────────────────────────────────────────────────────
     otherIncome: 0,
-    /** 5 % vacancy — conservative national average for stabilised SFR / small multifamily. */
-    vacancyPct: 5,
+    vacancyPct,
 
     // ── Expense settings ──────────────────────────────────────────────────
     capExInNOI: true,
@@ -86,10 +119,8 @@ export function getSimpleBaselines(purchasePrice: number): SimpleBaselineValues 
       miscPct: 1,
 
       // ── Fixed expenses (purchase-price-relative heuristics) ─────────────
-      /** Property taxes: ~1.2 % of purchase price annually (national effective rate). */
-      taxes: { amount: Math.round(pp * 0.012), period: 'annual' },
-      /** Insurance: ~0.5 % of purchase price annually (homeowners / landlord policy). */
-      insurance: { amount: Math.round(pp * 0.005), period: 'annual' },
+      taxes: { amount: Math.round(pp * taxRate), period: 'annual' },
+      insurance: { amount: Math.round(pp * insuranceRate), period: 'annual' },
       /** HOA: $0 — assumed single-family or self-managed; user adjusts if needed. */
       hoa: { amount: 0, period: 'monthly' },
       /** Other fixed expense: $0 — no supplemental fixed costs assumed. */
@@ -153,8 +184,11 @@ export const BASELINE_DESCRIPTIONS = {
  * @param inputs  Current scenario inputs (from the reducer).
  * @returns       A new DealInputs object safe to pass directly to evaluate().
  */
-export function applySimpleBaselines(inputs: DealInputs): DealInputs {
-  const b = getSimpleBaselines(inputs.purchasePrice);
+export function applySimpleBaselines(
+  inputs: DealInputs,
+  overrides?: LocationRateOverrides,
+): DealInputs {
+  const b = getSimpleBaselines(inputs.purchasePrice, overrides);
   return {
     // ── Baseline fields (complex-tier) ────────────────────────────────────
     ...b,

--- a/packages/ui/src/state/simpleBaselines.ts
+++ b/packages/ui/src/state/simpleBaselines.ts
@@ -12,7 +12,7 @@
  *   - Purchase-price-dependent baselines (closing costs, taxes, insurance) are
  *     recomputed each time the purchase price changes.
  *   - getSimpleBaselines() accepts an optional LocationRateOverrides argument that
- *     replaces the static national-average tax, insurance, and vacancy values with
+ *     replaces the static national-average tax and insurance values with
  *     region-specific data from the useLocationDefaults hook (RPE-66).
  *   - applySimpleBaselines() is the evaluation path for simple mode ONLY.
  *     Calling it in complex mode is incorrect — complex mode passes inputs directly.
@@ -54,7 +54,12 @@ export interface SimpleBaselineValues {
 /**
  * Region-specific rate overrides supplied by the useLocationDefaults hook.
  * When provided to getSimpleBaselines(), these replace the static national-average
- * tax, insurance, and vacancy rates with location-specific data.
+ * tax and insurance rates with location-specific data.
+ *
+ * Vacancy is deliberately NOT part of this contract: vacancyPct is a visible,
+ * user-controlled simple-tier field, so applySimpleBaselines always takes it
+ * from the user's inputs — a location-based vacancy override would never reach
+ * evaluation.
  *
  * The interface is a structural subset of @rpe/region-defaults' RegionalRates,
  * so RegionalRates satisfies this type without an explicit cast.
@@ -64,8 +69,6 @@ export interface LocationRateOverrides {
   propertyTaxRate: number;
   /** 0–1 annual insurance premium as % of purchase price. */
   insuranceRate: number;
-  /** 0–1 vacancy rate (e.g. 0.068 for the national average). */
-  vacancyRate: number;
   /** Human-readable source description (e.g. 'TX state averages (Census ACS / NAIC 2022)'). */
   sourceLabel: string;
 }
@@ -80,8 +83,8 @@ export interface LocationRateOverrides {
  *
  * @param purchasePrice  The property's purchase price.
  * @param overrides      Optional location-based rate overrides (RPE-66).
- *                       When provided, replace national-average tax, insurance,
- *                       and vacancy with region-specific values.
+ *                       When provided, replace national-average tax and
+ *                       insurance with region-specific values.
  */
 export function getSimpleBaselines(
   purchasePrice: number,
@@ -90,7 +93,6 @@ export function getSimpleBaselines(
   const pp = purchasePrice > 0 ? purchasePrice : 0;
   const taxRate = overrides?.propertyTaxRate ?? 0.012;
   const insuranceRate = overrides?.insuranceRate ?? 0.005;
-  const vacancyPct = overrides ? parseFloat((overrides.vacancyRate * 100).toFixed(1)) : 5;
   return {
     // ── Financing ──────────────────────────────────────────────────────────
     interestRate: 7.0,
@@ -102,7 +104,8 @@ export function getSimpleBaselines(
 
     // ── Income ────────────────────────────────────────────────────────────
     otherIncome: 0,
-    vacancyPct,
+    /** 5 % vacancy — conservative national average; the visible field the user controls. */
+    vacancyPct: 5,
 
     // ── Expense settings ──────────────────────────────────────────────────
     capExInNOI: true,

--- a/packages/ui/tests/locationState.test.ts
+++ b/packages/ui/tests/locationState.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  type LocationState,
+  DEFAULT_LOCATION,
+  loadLocation,
+  saveLocation,
+  clearLocationStorage,
+  isValidZip5,
+} from '../src/state/locationState';
+
+// ─── localStorage mock ────────────────────────────────────────────────────────
+
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => { store[key] = value; },
+  removeItem: (key: string) => { delete store[key]; },
+};
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+beforeEach(() => {
+  // Clear the store before each test
+  Object.keys(store).forEach((k) => { delete store[k]; });
+});
+
+// ─── isValidZip5 ──────────────────────────────────────────────────────────────
+
+describe('isValidZip5', () => {
+  it('accepts a 5-digit string', () => {
+    expect(isValidZip5('78701')).toBe(true);
+    expect(isValidZip5('00001')).toBe(true);
+    expect(isValidZip5('99999')).toBe(true);
+  });
+
+  it('rejects non-5-digit strings', () => {
+    expect(isValidZip5('')).toBe(false);
+    expect(isValidZip5('1234')).toBe(false);
+    expect(isValidZip5('123456')).toBe(false);
+    expect(isValidZip5('7870a')).toBe(false);
+    expect(isValidZip5('ABCDE')).toBe(false);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidZip5('  78701  ')).toBe(true);
+  });
+
+  it('rejects strings with only whitespace', () => {
+    expect(isValidZip5('     ')).toBe(false);
+  });
+});
+
+// ─── loadLocation ─────────────────────────────────────────────────────────────
+
+describe('loadLocation', () => {
+  it('returns DEFAULT_LOCATION when nothing is stored', () => {
+    expect(loadLocation()).toEqual(DEFAULT_LOCATION);
+  });
+
+  it('returns stored location', () => {
+    const loc: LocationState = { zip: '78701', stateCode: 'TX', label: 'TX · 78701' };
+    store['rpe_location'] = JSON.stringify(loc);
+    expect(loadLocation()).toEqual(loc);
+  });
+
+  it('returns DEFAULT_LOCATION when stored value is invalid JSON', () => {
+    store['rpe_location'] = '{not json}';
+    expect(loadLocation()).toEqual(DEFAULT_LOCATION);
+  });
+
+  it('coerces missing fields to empty strings', () => {
+    store['rpe_location'] = JSON.stringify({ zip: '78701' });
+    expect(loadLocation()).toEqual({ zip: '78701', stateCode: '', label: '' });
+  });
+
+  it('coerces non-string fields to empty strings', () => {
+    store['rpe_location'] = JSON.stringify({ zip: 12345, stateCode: null, label: 99 });
+    expect(loadLocation()).toEqual({ zip: '', stateCode: '', label: '' });
+  });
+});
+
+// ─── saveLocation ─────────────────────────────────────────────────────────────
+
+describe('saveLocation', () => {
+  it('persists a location to localStorage', () => {
+    const loc: LocationState = { zip: '90210', stateCode: 'CA', label: 'CA · 90210' };
+    saveLocation(loc);
+    expect(store['rpe_location']).toBe(JSON.stringify(loc));
+  });
+
+  it('does not throw when localStorage throws', () => {
+    const throwingMock = {
+      getItem: () => null,
+      setItem: () => { throw new Error('quota exceeded'); },
+      removeItem: () => {},
+    };
+    vi.stubGlobal('localStorage', throwingMock);
+    expect(() => saveLocation({ zip: '12345', stateCode: '', label: '' })).not.toThrow();
+    // Restore
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+});
+
+// ─── clearLocationStorage ─────────────────────────────────────────────────────
+
+describe('clearLocationStorage', () => {
+  it('removes the stored location', () => {
+    store['rpe_location'] = JSON.stringify({ zip: '78701', stateCode: 'TX', label: '' });
+    clearLocationStorage();
+    expect(store['rpe_location']).toBeUndefined();
+  });
+
+  it('does not throw when key is absent', () => {
+    expect(() => clearLocationStorage()).not.toThrow();
+  });
+});

--- a/packages/ui/tests/locationState.test.ts
+++ b/packages/ui/tests/locationState.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   type LocationState,
   DEFAULT_LOCATION,
+  STORAGE_KEY,
   loadLocation,
   saveLocation,
   clearLocationStorage,
@@ -85,6 +86,12 @@ describe('loadLocation', () => {
     store['rpe_location'] = JSON.stringify({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
     expect(loadLocation()).toEqual({ zip: '78701', stateCode: 'TX', label: 'TX · 78701' });
   });
+
+  it('returns DEFAULT_LOCATION when stored zip is non-empty but not a valid ZIP5', () => {
+    // A corrupt/legacy entry with an invalid ZIP should be discarded entirely
+    store[STORAGE_KEY] = JSON.stringify({ zip: '1234', stateCode: 'TX', label: '' });
+    expect(loadLocation()).toEqual(DEFAULT_LOCATION);
+  });
 });
 
 // ─── saveLocation ─────────────────────────────────────────────────────────────
@@ -111,6 +118,12 @@ describe('saveLocation', () => {
     vi.stubGlobal('localStorage', throwingMock);
     expect(() => saveLocation({ zip: '12345', stateCode: '', label: '' })).not.toThrow();
     // afterEach will unstubAllGlobals; no manual restore needed
+  });
+
+  it('does not persist when zip is non-empty but not a valid ZIP5', () => {
+    // Guard: callers that bypass UI validation should not corrupt localStorage
+    saveLocation({ zip: '1234', stateCode: 'TX', label: '' });
+    expect(store[STORAGE_KEY]).toBeUndefined();
   });
 });
 

--- a/packages/ui/tests/locationState.test.ts
+++ b/packages/ui/tests/locationState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   type LocationState,
   DEFAULT_LOCATION,
@@ -17,11 +17,14 @@ const localStorageMock = {
   removeItem: (key: string) => { delete store[key]; },
 };
 
-vi.stubGlobal('localStorage', localStorageMock);
-
 beforeEach(() => {
-  // Clear the store before each test
+  vi.stubGlobal('localStorage', localStorageMock);
+  // Reset store before each test so tests are order-independent
   Object.keys(store).forEach((k) => { delete store[k]; });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 // ─── isValidZip5 ──────────────────────────────────────────────────────────────
@@ -77,6 +80,11 @@ describe('loadLocation', () => {
     store['rpe_location'] = JSON.stringify({ zip: 12345, stateCode: null, label: 99 });
     expect(loadLocation()).toEqual({ zip: '', stateCode: '', label: '' });
   });
+
+  it('trims whitespace and uppercases stateCode on load', () => {
+    store['rpe_location'] = JSON.stringify({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
+    expect(loadLocation()).toEqual({ zip: '78701', stateCode: 'TX', label: 'TX · 78701' });
+  });
 });
 
 // ─── saveLocation ─────────────────────────────────────────────────────────────
@@ -88,6 +96,12 @@ describe('saveLocation', () => {
     expect(store['rpe_location']).toBe(JSON.stringify(loc));
   });
 
+  it('normalises whitespace and casing before persisting', () => {
+    saveLocation({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
+    const stored = JSON.parse(store['rpe_location']!) as LocationState;
+    expect(stored).toEqual({ zip: '78701', stateCode: 'TX', label: 'TX · 78701' });
+  });
+
   it('does not throw when localStorage throws', () => {
     const throwingMock = {
       getItem: () => null,
@@ -96,8 +110,7 @@ describe('saveLocation', () => {
     };
     vi.stubGlobal('localStorage', throwingMock);
     expect(() => saveLocation({ zip: '12345', stateCode: '', label: '' })).not.toThrow();
-    // Restore
-    vi.stubGlobal('localStorage', localStorageMock);
+    // afterEach will unstubAllGlobals; no manual restore needed
   });
 });
 

--- a/packages/ui/tests/locationState.test.ts
+++ b/packages/ui/tests/locationState.test.ts
@@ -63,27 +63,27 @@ describe('loadLocation', () => {
 
   it('returns stored location', () => {
     const loc: LocationState = { zip: '78701', stateCode: 'TX', label: 'TX · 78701' };
-    store['rpe_location'] = JSON.stringify(loc);
+    store[STORAGE_KEY] = JSON.stringify(loc);
     expect(loadLocation()).toEqual(loc);
   });
 
   it('returns DEFAULT_LOCATION when stored value is invalid JSON', () => {
-    store['rpe_location'] = '{not json}';
+    store[STORAGE_KEY] = '{not json}';
     expect(loadLocation()).toEqual(DEFAULT_LOCATION);
   });
 
   it('coerces missing fields to empty strings', () => {
-    store['rpe_location'] = JSON.stringify({ zip: '78701' });
+    store[STORAGE_KEY] = JSON.stringify({ zip: '78701' });
     expect(loadLocation()).toEqual({ zip: '78701', stateCode: '', label: '' });
   });
 
   it('coerces non-string fields to empty strings', () => {
-    store['rpe_location'] = JSON.stringify({ zip: 12345, stateCode: null, label: 99 });
+    store[STORAGE_KEY] = JSON.stringify({ zip: 12345, stateCode: null, label: 99 });
     expect(loadLocation()).toEqual({ zip: '', stateCode: '', label: '' });
   });
 
   it('trims whitespace and uppercases stateCode on load', () => {
-    store['rpe_location'] = JSON.stringify({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
+    store[STORAGE_KEY] = JSON.stringify({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
     expect(loadLocation()).toEqual({ zip: '78701', stateCode: 'TX', label: 'TX · 78701' });
   });
 
@@ -100,12 +100,12 @@ describe('saveLocation', () => {
   it('persists a location to localStorage', () => {
     const loc: LocationState = { zip: '90210', stateCode: 'CA', label: 'CA · 90210' };
     saveLocation(loc);
-    expect(store['rpe_location']).toBe(JSON.stringify(loc));
+    expect(store[STORAGE_KEY]).toBe(JSON.stringify(loc));
   });
 
   it('normalises whitespace and casing before persisting', () => {
     saveLocation({ zip: ' 78701 ', stateCode: 'tx', label: ' TX · 78701 ' });
-    const stored = JSON.parse(store['rpe_location']!) as LocationState;
+    const stored = JSON.parse(store[STORAGE_KEY]!) as LocationState;
     expect(stored).toEqual({ zip: '78701', stateCode: 'TX', label: 'TX · 78701' });
   });
 
@@ -131,9 +131,9 @@ describe('saveLocation', () => {
 
 describe('clearLocationStorage', () => {
   it('removes the stored location', () => {
-    store['rpe_location'] = JSON.stringify({ zip: '78701', stateCode: 'TX', label: '' });
+    store[STORAGE_KEY] = JSON.stringify({ zip: '78701', stateCode: 'TX', label: '' });
     clearLocationStorage();
-    expect(store['rpe_location']).toBeUndefined();
+    expect(store[STORAGE_KEY]).toBeUndefined();
   });
 
   it('does not throw when key is absent', () => {

--- a/packages/ui/tests/locationState.test.ts
+++ b/packages/ui/tests/locationState.test.ts
@@ -7,6 +7,7 @@ import {
   saveLocation,
   clearLocationStorage,
   isValidZip5,
+  extractZip,
 } from '../src/state/locationState';
 
 // ─── localStorage mock ────────────────────────────────────────────────────────
@@ -51,6 +52,43 @@ describe('isValidZip5', () => {
 
   it('rejects strings with only whitespace', () => {
     expect(isValidZip5('     ')).toBe(false);
+  });
+});
+
+// ─── extractZip ───────────────────────────────────────────────────────────────
+
+describe('extractZip', () => {
+  it('accepts a plain ZIP5', () => {
+    expect(extractZip('78701')).toBe('78701');
+    expect(extractZip('  78701  ')).toBe('78701');
+  });
+
+  it('rejects all-digit input of the wrong length (no silent truncation)', () => {
+    expect(extractZip('1234')).toBe('');
+    expect(extractZip('123456')).toBe('');
+  });
+
+  it('extracts the ZIP5 prefix from ZIP+4', () => {
+    expect(extractZip('78701-1234')).toBe('78701');
+    expect(extractZip('  78701-1234  ')).toBe('78701');
+  });
+
+  it('rejects a malformed +4 suffix', () => {
+    expect(extractZip('78701-12')).toBe('');
+  });
+
+  it('extracts a trailing ZIP5 from "City, ST XXXXX" input', () => {
+    expect(extractZip('Austin, TX 78701')).toBe('78701');
+    expect(extractZip('Austin, TX 78701-1234')).toBe('78701');
+  });
+
+  it('never extracts a ZIP from a longer trailing digit run', () => {
+    expect(extractZip('City, ST 123456')).toBe('');
+  });
+
+  it('returns empty string when no ZIP is present', () => {
+    expect(extractZip('')).toBe('');
+    expect(extractZip('Austin, TX')).toBe('');
   });
 });
 

--- a/packages/ui/tests/simpleBaselines.test.ts
+++ b/packages/ui/tests/simpleBaselines.test.ts
@@ -129,6 +129,17 @@ describe('getSimpleBaselines — with LocationRateOverrides', () => {
     expect(b.expenses.insurance.amount).toBe(Math.round(300_000 * 0.005)); // 1500 (national 0.5 %)
     expect(b.vacancyPct).toBe(5);
   });
+
+  it('honours a zero override rate (falsy-zero guard — ?? not ||)', () => {
+    const b = getSimpleBaselines(300_000, {
+      propertyTaxRate: 0,
+      insuranceRate: 0,
+      sourceLabel: 'Hypothetical zero-rate region',
+    });
+    // 0 is a valid rate and must NOT fall back to national defaults
+    expect(b.expenses.taxes.amount).toBe(0);
+    expect(b.expenses.insurance.amount).toBe(0);
+  });
 });
 
 // ─── applySimpleBaselines ─────────────────────────────────────────────────────

--- a/packages/ui/tests/simpleBaselines.test.ts
+++ b/packages/ui/tests/simpleBaselines.test.ts
@@ -15,6 +15,7 @@ import {
   getSimpleBaselines,
   applySimpleBaselines,
   BASELINE_DESCRIPTIONS,
+  type LocationRateOverrides,
 } from '../src/state/simpleBaselines';
 import { DEFAULT_INPUTS } from '../src/state/defaultInputs';
 import type { DealInputs } from '@rpe/engine';
@@ -88,6 +89,49 @@ describe('getSimpleBaselines', () => {
   });
 });
 
+// ─── getSimpleBaselines — with LocationRateOverrides ────────────────────────
+
+describe('getSimpleBaselines — with LocationRateOverrides', () => {
+  const TX_OVERRIDES: LocationRateOverrides = {
+    propertyTaxRate: 0.018,
+    insuranceRate: 0.0123,
+    vacancyRate: 0.08,
+    sourceLabel: 'TX state averages',
+  };
+
+  it('uses override propertyTaxRate for taxes amount', () => {
+    const b = getSimpleBaselines(300_000, TX_OVERRIDES);
+    expect(b.expenses.taxes.amount).toBe(Math.round(300_000 * 0.018)); // 5400
+    expect(b.expenses.taxes.period).toBe('annual');
+  });
+
+  it('uses override insuranceRate for insurance amount', () => {
+    const b = getSimpleBaselines(300_000, TX_OVERRIDES);
+    expect(b.expenses.insurance.amount).toBe(Math.round(300_000 * 0.0123)); // 3690
+    expect(b.expenses.insurance.period).toBe('annual');
+  });
+
+  it('converts override vacancyRate (0–1) to vacancyPct (%)', () => {
+    const b = getSimpleBaselines(300_000, TX_OVERRIDES);
+    expect(b.vacancyPct).toBe(8.0);
+  });
+
+  it('overrides do not affect static fields', () => {
+    const b = getSimpleBaselines(300_000, TX_OVERRIDES);
+    expect(b.interestRate).toBe(7.0);
+    expect(b.loanTermYears).toBe(30);
+    expect(b.expenses.capExPct).toBe(5);
+    expect(b.expenses.mgmtPct).toBe(10);
+  });
+
+  it('falls back to national rates when overrides is undefined', () => {
+    const b = getSimpleBaselines(300_000, undefined);
+    expect(b.expenses.taxes.amount).toBe(Math.round(300_000 * 0.012)); // 3600 (national 1.2 %)
+    expect(b.expenses.insurance.amount).toBe(Math.round(300_000 * 0.005)); // 1500 (national 0.5 %)
+    expect(b.vacancyPct).toBe(5);
+  });
+});
+
 // ─── applySimpleBaselines ─────────────────────────────────────────────────────
 
 describe('applySimpleBaselines', () => {
@@ -157,6 +201,41 @@ describe('applySimpleBaselines', () => {
     expect(r.expenses).toBeDefined();
     expect(r.expenses.taxes).toBeDefined();
     expect(r.expenses.insurance).toBeDefined();
+  });
+});
+
+// ─── applySimpleBaselines — with LocationRateOverrides ───────────────────────
+
+describe('applySimpleBaselines — with LocationRateOverrides', () => {
+  const TX_OVERRIDES: LocationRateOverrides = {
+    propertyTaxRate: 0.018,
+    insuranceRate: 0.0123,
+    vacancyRate: 0.08,
+    sourceLabel: 'TX state averages',
+  };
+
+  const inputs = { ...DEFAULT_INPUTS, purchasePrice: 300_000, vacancyPct: 6 };
+
+  it('override tax rate flows through to result expenses', () => {
+    const r = applySimpleBaselines(inputs, TX_OVERRIDES);
+    expect(r.expenses.taxes.amount).toBe(Math.round(300_000 * 0.018)); // 5400
+  });
+
+  it('override insurance rate flows through to result expenses', () => {
+    const r = applySimpleBaselines(inputs, TX_OVERRIDES);
+    expect(r.expenses.insurance.amount).toBe(Math.round(300_000 * 0.0123)); // 3690
+  });
+
+  it("user's visible vacancyPct takes precedence over override vacancyRate", () => {
+    // vacancyPct is a simple-tier field — the user owns it; override.vacancyRate is baseline only
+    const r = applySimpleBaselines(inputs, TX_OVERRIDES);
+    expect(r.vacancyPct).toBe(6); // from inputs, not 8 from TX_OVERRIDES.vacancyRate
+  });
+
+  it('without overrides uses national-average tax and insurance', () => {
+    const r = applySimpleBaselines(inputs);
+    expect(r.expenses.taxes.amount).toBe(Math.round(300_000 * 0.012)); // 3600
+    expect(r.expenses.insurance.amount).toBe(Math.round(300_000 * 0.005)); // 1500
   });
 });
 

--- a/packages/ui/tests/simpleBaselines.test.ts
+++ b/packages/ui/tests/simpleBaselines.test.ts
@@ -95,7 +95,6 @@ describe('getSimpleBaselines — with LocationRateOverrides', () => {
   const TX_OVERRIDES: LocationRateOverrides = {
     propertyTaxRate: 0.018,
     insuranceRate: 0.0123,
-    vacancyRate: 0.08,
     sourceLabel: 'TX state averages',
   };
 
@@ -111,9 +110,9 @@ describe('getSimpleBaselines — with LocationRateOverrides', () => {
     expect(b.expenses.insurance.period).toBe('annual');
   });
 
-  it('converts override vacancyRate (0–1) to vacancyPct (%)', () => {
+  it('vacancyPct stays at the 5 % baseline regardless of overrides (user-controlled field)', () => {
     const b = getSimpleBaselines(300_000, TX_OVERRIDES);
-    expect(b.vacancyPct).toBe(8.0);
+    expect(b.vacancyPct).toBe(5);
   });
 
   it('overrides do not affect static fields', () => {
@@ -210,7 +209,6 @@ describe('applySimpleBaselines — with LocationRateOverrides', () => {
   const TX_OVERRIDES: LocationRateOverrides = {
     propertyTaxRate: 0.018,
     insuranceRate: 0.0123,
-    vacancyRate: 0.08,
     sourceLabel: 'TX state averages',
   };
 
@@ -226,10 +224,11 @@ describe('applySimpleBaselines — with LocationRateOverrides', () => {
     expect(r.expenses.insurance.amount).toBe(Math.round(300_000 * 0.0123)); // 3690
   });
 
-  it("user's visible vacancyPct takes precedence over override vacancyRate", () => {
-    // vacancyPct is a simple-tier field — the user owns it; override.vacancyRate is baseline only
+  it("user's visible vacancyPct is used regardless of overrides", () => {
+    // vacancyPct is a simple-tier field the user owns — overrides carry no
+    // vacancy data (see LocationRateOverrides docs)
     const r = applySimpleBaselines(inputs, TX_OVERRIDES);
-    expect(r.vacancyPct).toBe(6); // from inputs, not 8 from TX_OVERRIDES.vacancyRate
+    expect(r.vacancyPct).toBe(6);
   });
 
   it('without overrides uses national-average tax and insurance', () => {

--- a/packages/ui/tests/useLocationDefaults.test.ts
+++ b/packages/ui/tests/useLocationDefaults.test.ts
@@ -1,0 +1,188 @@
+/**
+ * RPE-66: useLocationDefaults hook tests
+ *
+ * Mocks globalThis.fetch via vi.spyOn so real network calls are never made.
+ * Uses @testing-library/react's renderHook.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useLocationDefaults } from '../src/hooks/useLocationDefaults';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const API_URL = 'http://localhost:3001';
+
+function makeMockRegionResponse(overrides: Partial<{
+  stateCode: string;
+  label: string;
+  propertyTaxRate: number;
+  insuranceRate: number;
+  vacancyRate: number;
+  appreciationRate: number;
+  rentGrowthRate: number;
+  resolvedLevel: string;
+  sourceLabel: string;
+}> = {}) {
+  return {
+    zip: '78701',
+    stateCode: 'TX',
+    label: 'Austin, TX (78701)',
+    propertyTaxRate: 0.018,
+    insuranceRate: 0.0123,
+    vacancyRate: 0.068,
+    appreciationRate: 0.04,
+    rentGrowthRate: 0.035,
+    resolvedLevel: 'state',
+    sourceLabel: 'TX state averages (Census ACS / NAIC 2022)',
+    rent: { studio: 1050, oneBed: 1230, twoBed: 1500, threeBed: 1900, fourBed: 2200 },
+    ...overrides,
+  };
+}
+
+function mockFetchOk(data: unknown) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as unknown as Response);
+}
+
+function mockFetchError(status = 500) {
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: 'error' }),
+  } as unknown as Response);
+}
+
+function mockFetchNetworkError() {
+  vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network failure'));
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useLocationDefaults', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts with empty state when zip is empty and makes no fetch call', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const { result } = renderHook(() =>
+      useLocationDefaults('', API_URL),
+    );
+    expect(result.current.rates).toBeNull();
+    expect(result.current.stateCode).toBe('');
+    expect(result.current.label).toBe('');
+    expect(result.current.resolving).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets resolving=true immediately when zip is provided', () => {
+    mockFetchOk(makeMockRegionResponse());
+    const { result } = renderHook(() =>
+      useLocationDefaults('78701', API_URL),
+    );
+    // Synchronously after mount, resolving should be true (async effect)
+    // The fetch mock is async so we can check resolving before it settles
+    expect(result.current.resolving).toBe(true);
+  });
+
+  it('populates rates, stateCode and label on successful API response', async () => {
+    mockFetchOk(makeMockRegionResponse());
+    const { result } = renderHook(() =>
+      useLocationDefaults('78701', API_URL),
+    );
+
+    await waitFor(() => {
+      expect(result.current.resolving).toBe(false);
+    });
+
+    expect(result.current.stateCode).toBe('TX');
+    expect(result.current.label).toBe('Austin, TX (78701)');
+    expect(result.current.rates).not.toBeNull();
+    expect(result.current.rates?.propertyTaxRate).toBeCloseTo(0.018, 3);
+    expect(result.current.rates?.insuranceRate).toBeCloseTo(0.0123, 3);
+    expect(result.current.rates?.vacancyRate).toBeCloseTo(0.068, 3);
+    expect(result.current.rates?.sourceLabel).toBe('TX state averages (Census ACS / NAIC 2022)');
+  });
+
+  it('passes the correct URL to fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(makeMockRegionResponse()),
+    } as unknown as Response);
+
+    const { result } = renderHook(() =>
+      useLocationDefaults('78701', API_URL),
+    );
+    await waitFor(() => expect(result.current.resolving).toBe(false));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${API_URL}/region?zip=78701`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('resets to empty state when zip changes to empty', async () => {
+    mockFetchOk(makeMockRegionResponse());
+    const { result, rerender } = renderHook(
+      ({ zip }) => useLocationDefaults(zip, API_URL),
+      { initialProps: { zip: '78701' } },
+    );
+
+    await waitFor(() => expect(result.current.stateCode).toBe('TX'));
+
+    act(() => { rerender({ zip: '' }); });
+
+    expect(result.current.rates).toBeNull();
+    expect(result.current.stateCode).toBe('');
+    expect(result.current.resolving).toBe(false);
+  });
+
+  it('degrades gracefully on HTTP error response', async () => {
+    mockFetchError(404);
+    const { result } = renderHook(() =>
+      useLocationDefaults('99999', API_URL),
+    );
+
+    await waitFor(() => expect(result.current.resolving).toBe(false));
+
+    expect(result.current.rates).toBeNull();
+    expect(result.current.stateCode).toBe('');
+  });
+
+  it('degrades gracefully on network error', async () => {
+    mockFetchNetworkError();
+    const { result } = renderHook(() =>
+      useLocationDefaults('12345', API_URL),
+    );
+
+    await waitFor(() => expect(result.current.resolving).toBe(false));
+
+    expect(result.current.rates).toBeNull();
+  });
+
+  it('includes national rates when resolvedLevel is "national"', async () => {
+    mockFetchOk(makeMockRegionResponse({
+      stateCode: '',
+      label: '00000',
+      resolvedLevel: 'national',
+      sourceLabel: 'National averages',
+      propertyTaxRate: 0.0112,
+      insuranceRate: 0.0066,
+    }));
+    const { result } = renderHook(() =>
+      useLocationDefaults('00000', API_URL),
+    );
+
+    await waitFor(() => expect(result.current.resolving).toBe(false));
+
+    expect(result.current.rates?.resolvedLevel).toBe('national');
+    expect(result.current.rates?.sourceLabel).toBe('National averages');
+  });
+});

--- a/packages/ui/tests/useLocationDefaults.test.ts
+++ b/packages/ui/tests/useLocationDefaults.test.ts
@@ -214,9 +214,10 @@ describe('useLocationDefaults', () => {
     expect(result.current.rates).toBeNull();
     expect(result.current.stateCode).toBe('');
     expect(result.current.label).toBe('');
+    expect(result.current.failed).toBe(true);
   });
 
-  it('degrades gracefully on HTTP error response', async () => {
+  it('degrades gracefully on HTTP error response and sets failed', async () => {
     mockFetchError(404);
     const { result } = renderHook(() =>
       useLocationDefaults('99999', API_URL),
@@ -226,9 +227,10 @@ describe('useLocationDefaults', () => {
 
     expect(result.current.rates).toBeNull();
     expect(result.current.stateCode).toBe('');
+    expect(result.current.failed).toBe(true);
   });
 
-  it('degrades gracefully on network error', async () => {
+  it('degrades gracefully on network error and sets failed', async () => {
     mockFetchNetworkError();
     const { result } = renderHook(() =>
       useLocationDefaults('12345', API_URL),
@@ -237,6 +239,31 @@ describe('useLocationDefaults', () => {
     await waitFor(() => expect(result.current.resolving).toBe(false));
 
     expect(result.current.rates).toBeNull();
+    expect(result.current.failed).toBe(true);
+  });
+
+  it('clears failed when a new fetch starts and on success', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('Network failure'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(makeMockRegionResponse()),
+      } as unknown as Response);
+
+    const { result, rerender } = renderHook(
+      ({ zip }) => useLocationDefaults(zip, API_URL),
+      { initialProps: { zip: '78701' } },
+    );
+    await waitFor(() => expect(result.current.failed).toBe(true));
+
+    act(() => { rerender({ zip: '90001' }); });
+    // failed clears synchronously when the new fetch starts
+    expect(result.current.failed).toBe(false);
+    expect(result.current.resolving).toBe(true);
+
+    await waitFor(() => expect(result.current.stateCode).toBe('TX'));
+    expect(result.current.failed).toBe(false);
   });
 
   it('includes national rates when resolvedLevel is "national"', async () => {

--- a/packages/ui/tests/useLocationDefaults.test.ts
+++ b/packages/ui/tests/useLocationDefaults.test.ts
@@ -144,6 +144,78 @@ describe('useLocationDefaults', () => {
     expect(result.current.resolving).toBe(false);
   });
 
+  it('clears prior resolved values immediately on zip→zip change and refetches', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(makeMockRegionResponse()),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(makeMockRegionResponse({
+          stateCode: 'CA',
+          label: 'Los Angeles, CA (90001)',
+          propertyTaxRate: 0.0075,
+          sourceLabel: 'CA state averages (Census ACS / NAIC 2022)',
+        })),
+      } as unknown as Response);
+
+    const { result, rerender } = renderHook(
+      ({ zip }) => useLocationDefaults(zip, API_URL),
+      { initialProps: { zip: '78701' } },
+    );
+
+    await waitFor(() => expect(result.current.stateCode).toBe('TX'));
+
+    act(() => { rerender({ zip: '90001' }); });
+
+    // Stale TX values must be cleared synchronously — never leak the previous
+    // location's stateCode/label/rates while the new fetch is in flight
+    expect(result.current.stateCode).toBe('');
+    expect(result.current.label).toBe('');
+    expect(result.current.rates).toBeNull();
+    expect(result.current.resolving).toBe(true);
+
+    await waitFor(() => expect(result.current.stateCode).toBe('CA'));
+    expect(result.current.label).toBe('Los Angeles, CA (90001)');
+    expect(result.current.rates?.propertyTaxRate).toBeCloseTo(0.0075, 4);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      `${API_URL}/region?zip=90001`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it('fully resets stateCode and label (not just rates) on fetch error', async () => {
+    // First resolve successfully, then fail on a new zip — no stale TX metadata may survive
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(makeMockRegionResponse()),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'boom' }),
+      } as unknown as Response);
+
+    const { result, rerender } = renderHook(
+      ({ zip }) => useLocationDefaults(zip, API_URL),
+      { initialProps: { zip: '78701' } },
+    );
+    await waitFor(() => expect(result.current.stateCode).toBe('TX'));
+
+    act(() => { rerender({ zip: '90001' }); });
+    await waitFor(() => expect(result.current.resolving).toBe(false));
+
+    expect(result.current.rates).toBeNull();
+    expect(result.current.stateCode).toBe('');
+    expect(result.current.label).toBe('');
+  });
+
   it('degrades gracefully on HTTP error response', async () => {
     mockFetchError(404);
     const { result } = renderHook(() =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@rpe/engine':
         specifier: workspace:*
         version: link:../engine
+      '@rpe/region-defaults':
+        specifier: workspace:*
+        version: link:../region-defaults
       react:
         specifier: ^18.0.0
         version: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,12 @@ importers:
       '@rpe/engine':
         specifier: workspace:*
         version: link:../../packages/engine
+      '@rpe/region-defaults':
+        specifier: workspace:*
+        version: link:../../packages/region-defaults
+      '@rpe/rentcast':
+        specifier: workspace:*
+        version: link:../../packages/rentcast
     devDependencies:
       '@types/node':
         specifier: ^20.0.0
@@ -157,6 +163,12 @@ importers:
         version: 6.4.2(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)
 
   packages/engine:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
+  packages/region-defaults:
     devDependencies:
       typescript:
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary
- 10 new tests in `simpleBaselines.test.ts` covering the `LocationRateOverrides` paths added in RPE-66: TX override rates flow through `getSimpleBaselines`/`applySimpleBaselines`, static fields unaffected, national fallback without overrides, user-owned `vacancyPct` precedence, and a falsy-zero guard (a 0 rate must not fall back to national — `??` not `||`)

## Review
Copilot is unavailable (timed out mid-epic); this branch went through the strict self-review loop instead — diff reviewed directly (test-only, 89 lines), one gap found and fixed (falsy-zero guard).

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 632 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)