### PR TITLE
RPE-72: cache /region responses in localStorage (30-day TTL)

### DIFF
--- a/packages/ui/src/hooks/useLocationDefaults.ts
+++ b/packages/ui/src/hooks/useLocationDefaults.ts
@@ -7,15 +7,19 @@
  *
  * Lifecycle:
  *   1. zip='' → no fetch; all fields empty/null, resolving=false
- *   2. zip changes → in-flight request cancelled; prior resolved values
- *      cleared immediately (no stale leak); resolving=true
- *   3. API succeeds → rates/stateCode/label populated; resolving=false
- *   4. API fails → full reset to empty (caller degrades gracefully)
+ *   2. zip changes → in-flight request cancelled; a fresh cache entry
+ *      (30-day TTL, see regionCache) resolves synchronously with no fetch;
+ *      otherwise prior resolved values are cleared immediately (no stale
+ *      leak) and resolving=true
+ *   3. API succeeds → rates/stateCode/label populated, cached; resolving=false
+ *   4. API fails → full reset to empty (caller degrades gracefully);
+ *      failures are never cached
  */
 
 import { useState, useEffect, useRef } from 'react';
 import type { RegionLevel } from '@rpe/region-defaults';
 import type { LocationRateOverrides } from '../state/simpleBaselines';
+import { readRegionCache, writeRegionCache } from '../state/regionCache';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,9 +57,10 @@ export interface LocationDefaultsResult {
   failed: boolean;
 }
 
-// ─── Internal API response type ───────────────────────────────────────────────
+// ─── API response type ────────────────────────────────────────────────────────
 
-interface RegionApiResponse {
+/** Raw /region response shape — also the unit cached by regionCache. */
+export interface RegionApiResponse {
   zip: string;
   stateCode: string;
   label: string;
@@ -83,6 +88,26 @@ const EMPTY: LocationDefaultsResult = {
   failed: false,
 };
 
+/** Map a /region response (live or cached) to the hook's resolved state. */
+function toResolvedResult(data: RegionApiResponse): LocationDefaultsResult {
+  return {
+    rates: {
+      propertyTaxRate: data.propertyTaxRate,
+      insuranceRate: data.insuranceRate,
+      vacancyRate: data.vacancyRate,
+      appreciationRate: data.appreciationRate,
+      rentGrowthRate: data.rentGrowthRate,
+      resolvedLevel: data.resolvedLevel,
+      sourceLabel: data.sourceLabel,
+      rent: data.rent,
+    },
+    stateCode: data.stateCode,
+    label: data.label,
+    resolving: false,
+    failed: false,
+  };
+}
+
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 /**
@@ -105,6 +130,14 @@ export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaul
 
     // Cancel any previous in-flight request
     abortRef.current?.abort();
+
+    // Fresh cache entry → resolve synchronously, no network call
+    const cached = readRegionCache(zip);
+    if (cached) {
+      setResult(toResolvedResult(cached));
+      return;
+    }
+
     const controller = new AbortController();
     abortRef.current = controller;
 
@@ -122,23 +155,8 @@ export function useLocationDefaults(zip: string, apiUrl: string): LocationDefaul
       })
       .then((data) => {
         if (controller.signal.aborted) return;
-        const rates: RegionDefaults = {
-          propertyTaxRate: data.propertyTaxRate,
-          insuranceRate: data.insuranceRate,
-          vacancyRate: data.vacancyRate,
-          appreciationRate: data.appreciationRate,
-          rentGrowthRate: data.rentGrowthRate,
-          resolvedLevel: data.resolvedLevel,
-          sourceLabel: data.sourceLabel,
-          rent: data.rent,
-        };
-        setResult({
-          rates,
-          stateCode: data.stateCode,
-          label: data.label,
-          resolving: false,
-          failed: false,
-        });
+        writeRegionCache(zip, data);
+        setResult(toResolvedResult(data));
       })
       .catch(() => {
         // Guard on the signal (covers both abort rejections AND late

--- a/packages/ui/src/state/regionCache.ts
+++ b/packages/ui/src/state/regionCache.ts
@@ -1,0 +1,83 @@
+/**
+ * E9 — 30-day localStorage cache for /region lookups (RPE-72)
+ *
+ * Key: `rpe_region_${zip}` (per the E9 plan). Entries are wrapped in a
+ * versioned envelope so a future shape change can invalidate old entries
+ * by bumping CACHE_VERSION instead of migrating them.
+ *
+ * Regional averages move on an annual publication cadence (Census ACS,
+ * NAIC, HUD FMR), so a 30-day TTL is conservative.
+ *
+ * All storage access is wrapped in try/catch: private browsing, quota
+ * exhaustion, or SSR must degrade to a cache miss, never an exception.
+ */
+
+import type { RegionApiResponse } from '../hooks/useLocationDefaults';
+
+export const REGION_CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+const CACHE_VERSION = 1;
+
+interface CacheEnvelope {
+  v: number;
+  ts: number;
+  data: RegionApiResponse;
+}
+
+export function regionCacheKey(zip: string): string {
+  return `rpe_region_${zip}`;
+}
+
+function isRegionApiResponse(value: unknown): value is RegionApiResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.stateCode === 'string' &&
+    typeof v.label === 'string' &&
+    typeof v.sourceLabel === 'string' &&
+    typeof v.resolvedLevel === 'string' &&
+    typeof v.propertyTaxRate === 'number' &&
+    typeof v.insuranceRate === 'number' &&
+    typeof v.vacancyRate === 'number' &&
+    typeof v.appreciationRate === 'number' &&
+    typeof v.rentGrowthRate === 'number' &&
+    (v.rent === null || typeof v.rent === 'object')
+  );
+}
+
+/**
+ * Read a cached /region response for a ZIP. Returns null on miss, expiry,
+ * version mismatch, corrupted JSON, foreign shape, or unavailable storage —
+ * every null is safe to treat as "fetch it".
+ */
+export function readRegionCache(zip: string): RegionApiResponse | null {
+  try {
+    const raw = localStorage.getItem(regionCacheKey(zip));
+    if (raw === null) return null;
+    const envelope = JSON.parse(raw) as Partial<CacheEnvelope>;
+    if (
+      envelope === null ||
+      typeof envelope !== 'object' ||
+      envelope.v !== CACHE_VERSION ||
+      typeof envelope.ts !== 'number'
+    ) {
+      return null;
+    }
+    if (Date.now() - envelope.ts > REGION_CACHE_TTL_MS) return null;
+    if (!isRegionApiResponse(envelope.data)) return null;
+    return envelope.data;
+  } catch {
+    // Corrupted JSON or storage unavailable (private browsing, SSR)
+    return null;
+  }
+}
+
+/** Cache a successful /region response. Failures are silently ignored. */
+export function writeRegionCache(zip: string, data: RegionApiResponse): void {
+  const envelope: CacheEnvelope = { v: CACHE_VERSION, ts: Date.now(), data };
+  try {
+    localStorage.setItem(regionCacheKey(zip), JSON.stringify(envelope));
+  } catch {
+    // Storage quota exceeded or unavailable — caching is best-effort
+  }
+}

--- a/packages/ui/src/state/regionCache.ts
+++ b/packages/ui/src/state/regionCache.ts
@@ -41,7 +41,7 @@ function isRegionApiResponse(value: unknown): value is RegionApiResponse {
     typeof v.vacancyRate === 'number' &&
     typeof v.appreciationRate === 'number' &&
     typeof v.rentGrowthRate === 'number' &&
-    (v.rent === null || typeof v.rent === 'object')
+    (v.rent === null || (typeof v.rent === 'object' && !Array.isArray(v.rent)))
   );
 }
 

--- a/packages/ui/tests/regionCache.test.ts
+++ b/packages/ui/tests/regionCache.test.ts
@@ -1,0 +1,138 @@
+/**
+ * RPE-72: regionCache tests — 30-day localStorage cache for /region responses.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  readRegionCache,
+  writeRegionCache,
+  regionCacheKey,
+  REGION_CACHE_TTL_MS,
+} from '../src/state/regionCache';
+import type { RegionApiResponse } from '../src/hooks/useLocationDefaults';
+
+function makeResponse(overrides: Partial<RegionApiResponse> = {}): RegionApiResponse {
+  return {
+    zip: '78701',
+    stateCode: 'TX',
+    label: 'Austin, TX (78701)',
+    propertyTaxRate: 0.018,
+    insuranceRate: 0.0123,
+    vacancyRate: 0.068,
+    appreciationRate: 0.04,
+    rentGrowthRate: 0.035,
+    resolvedLevel: 'state',
+    sourceLabel: 'TX state averages (Census ACS / NAIC 2022)',
+    rent: { studio: 1050, oneBed: 1230, twoBed: 1500, threeBed: 1900, fourBed: 2200 },
+    ...overrides,
+  };
+}
+
+describe('regionCache', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uses the rpe_region_${zip} key from the E9 plan', () => {
+    expect(regionCacheKey('78701')).toBe('rpe_region_78701');
+  });
+
+  it('returns null on a cold cache', () => {
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('round-trips a written response', () => {
+    const data = makeResponse();
+    writeRegionCache('78701', data);
+    expect(readRegionCache('78701')).toEqual(data);
+  });
+
+  it('scopes entries by zip', () => {
+    writeRegionCache('78701', makeResponse());
+    expect(readRegionCache('90001')).toBeNull();
+  });
+
+  it('round-trips a null rent block', () => {
+    const data = makeResponse({ rent: null });
+    writeRegionCache('78701', data);
+    expect(readRegionCache('78701')?.rent).toBeNull();
+  });
+
+  it('expires entries older than 30 days', () => {
+    writeRegionCache('78701', makeResponse());
+    const raw = JSON.parse(localStorage.getItem(regionCacheKey('78701'))!);
+    raw.ts = Date.now() - REGION_CACHE_TTL_MS - 1;
+    localStorage.setItem(regionCacheKey('78701'), JSON.stringify(raw));
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('keeps entries younger than 30 days', () => {
+    writeRegionCache('78701', makeResponse());
+    const raw = JSON.parse(localStorage.getItem(regionCacheKey('78701'))!);
+    raw.ts = Date.now() - REGION_CACHE_TTL_MS + 60_000;
+    localStorage.setItem(regionCacheKey('78701'), JSON.stringify(raw));
+    expect(readRegionCache('78701')).not.toBeNull();
+  });
+
+  it('ignores corrupted JSON', () => {
+    localStorage.setItem(regionCacheKey('78701'), '{not json');
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('ignores a version mismatch', () => {
+    writeRegionCache('78701', makeResponse());
+    const raw = JSON.parse(localStorage.getItem(regionCacheKey('78701'))!);
+    raw.v = 999;
+    localStorage.setItem(regionCacheKey('78701'), JSON.stringify(raw));
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('ignores an envelope with a missing timestamp', () => {
+    localStorage.setItem(
+      regionCacheKey('78701'),
+      JSON.stringify({ v: 1, data: makeResponse() }),
+    );
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('ignores foreign-shape data inside a valid envelope', () => {
+    localStorage.setItem(
+      regionCacheKey('78701'),
+      JSON.stringify({ v: 1, ts: Date.now(), data: { hello: 'world' } }),
+    );
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('ignores data with a non-numeric rate', () => {
+    const data = makeResponse();
+    localStorage.setItem(
+      regionCacheKey('78701'),
+      JSON.stringify({
+        v: 1,
+        ts: Date.now(),
+        data: { ...data, propertyTaxRate: '0.018' },
+      }),
+    );
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('treats a throwing localStorage.getItem as a miss', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
+  it('swallows a throwing localStorage.setItem (quota exceeded)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    expect(() => writeRegionCache('78701', makeResponse())).not.toThrow();
+  });
+});

--- a/packages/ui/tests/regionCache.test.ts
+++ b/packages/ui/tests/regionCache.test.ts
@@ -122,6 +122,15 @@ describe('regionCache', () => {
     expect(readRegionCache('78701')).toBeNull();
   });
 
+  it('ignores data where rent is an array (typeof object, wrong shape)', () => {
+    const data = makeResponse();
+    localStorage.setItem(
+      regionCacheKey('78701'),
+      JSON.stringify({ v: 1, ts: Date.now(), data: { ...data, rent: [1050, 1230] } }),
+    );
+    expect(readRegionCache('78701')).toBeNull();
+  });
+
   it('treats a throwing localStorage.getItem as a miss', () => {
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
       throw new Error('SecurityError');

--- a/packages/ui/tests/useLocationDefaults.test.ts
+++ b/packages/ui/tests/useLocationDefaults.test.ts
@@ -67,6 +67,8 @@ function mockFetchNetworkError() {
 describe('useLocationDefaults', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // The hook caches successful lookups (RPE-72) — isolate every test
+    localStorage.clear();
   });
 
   it('starts with empty state when zip is empty and makes no fetch call', () => {
@@ -262,6 +264,60 @@ describe('useLocationDefaults', () => {
     expect(result.current.failed).toBe(false);
     expect(result.current.resolving).toBe(true);
 
+    await waitFor(() => expect(result.current.stateCode).toBe('TX'));
+    expect(result.current.failed).toBe(false);
+  });
+
+  it('serves a second lookup of the same zip from cache without fetching (RPE-72)', async () => {
+    mockFetchOk(makeMockRegionResponse());
+    const first = renderHook(() => useLocationDefaults('78701', API_URL));
+    await waitFor(() => expect(first.result.current.stateCode).toBe('TX'));
+    first.unmount();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    const second = renderHook(() => useLocationDefaults('78701', API_URL));
+    // Cache hit resolves synchronously — no loading flicker, no fetch
+    expect(second.result.current.resolving).toBe(false);
+    expect(second.result.current.stateCode).toBe('TX');
+    expect(second.result.current.rates?.propertyTaxRate).toBeCloseTo(0.018, 3);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when the cached entry is expired (RPE-72)', async () => {
+    mockFetchOk(makeMockRegionResponse());
+    const first = renderHook(() => useLocationDefaults('78701', API_URL));
+    await waitFor(() => expect(first.result.current.stateCode).toBe('TX'));
+    first.unmount();
+
+    // Age the entry past the 30-day TTL
+    const key = 'rpe_region_78701';
+    const envelope = JSON.parse(localStorage.getItem(key)!);
+    envelope.ts = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(key, JSON.stringify(envelope));
+
+    const second = renderHook(() => useLocationDefaults('78701', API_URL));
+    expect(second.result.current.resolving).toBe(true);
+    await waitFor(() => expect(second.result.current.stateCode).toBe('TX'));
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed lookups (RPE-72)', async () => {
+    mockFetchError(500);
+    const first = renderHook(() => useLocationDefaults('78701', API_URL));
+    await waitFor(() => expect(first.result.current.failed).toBe(true));
+    first.unmount();
+    expect(localStorage.getItem('rpe_region_78701')).toBeNull();
+  });
+
+  it('falls back to fetch when localStorage throws (RPE-72)', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    mockFetchOk(makeMockRegionResponse());
+    const { result } = renderHook(() => useLocationDefaults('78701', API_URL));
     await waitFor(() => expect(result.current.stateCode).toBe('TX'));
     expect(result.current.failed).toBe(false);
   });


### PR DESCRIPTION
## Summary
- New `packages/ui/src/state/regionCache.ts`: versioned envelope under `rpe_region_${zip}`, 30-day TTL; corrupted JSON, version mismatch, missing timestamp, foreign shape, or throwing storage all degrade to a cache miss
- `useLocationDefaults`: fresh cache hit resolves synchronously with no fetch or loading flicker; successful fetches write the cache; failures are never cached
- 15 new cache-module tests + 4 hook integration tests (cache hit avoids fetch, expired entry refetches, failures uncached, storage exceptions fall back to fetch)

Closes the E9 plan gap flagged at epic close — limits HUD/API traffic for repeat ZIP lookups.

## Review
Copilot unavailable; strict self-review loop run instead. Round 1 found one real issue (array-shaped `rent` passed validation since `typeof [] === 'object'`) — fixed with test. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 651 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)