### PR TITLE
RPE-44: @rpe/property — provider abstraction + tiered resolver

### DIFF
--- a/packages/property/package.json
+++ b/packages/property/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@rpe/property",
+  "version": "1.4.0",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/property/src/index.ts
+++ b/packages/property/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  TIER_ORDER,
+  type LookupTier,
+  type LookupConfidence,
+  type LookupField,
+  type LookupFieldKey,
+  type PropertyLookup,
+  type LookupRequest,
+  type PropertyProvider,
+  type ProviderAttempt,
+  type ResolvedProperty,
+  type ResolveOptions,
+} from './types';
+
+export { resolveProperty, hasPriceOrRent } from './resolveProperty';

--- a/packages/property/src/index.ts
+++ b/packages/property/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  LOOKUP_FIELD_KEYS,
   TIER_ORDER,
   type LookupTier,
   type LookupConfidence,

--- a/packages/property/src/resolveProperty.ts
+++ b/packages/property/src/resolveProperty.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+  LOOKUP_FIELD_KEYS,
   TIER_ORDER,
   type LookupFieldKey,
   type LookupTier,
@@ -31,15 +32,7 @@ export function hasPriceOrRent(lookup: PropertyLookup): boolean {
 
 /** All keys a provider may legitimately contribute — foreign keys from
  * untyped providers (wild scrape/paste parsers) are dropped on merge. */
-const KNOWN_KEYS: ReadonlySet<string> = new Set<LookupFieldKey>([
-  'purchasePrice',
-  'grossRent',
-  'sqft',
-  'units',
-  'annualTaxes',
-  'annualInsurance',
-  'yearBuilt',
-]);
+const KNOWN_KEYS: ReadonlySet<string> = new Set(LOOKUP_FIELD_KEYS);
 
 /**
  * Sort providers into tier precedence, preserving the caller's relative

--- a/packages/property/src/resolveProperty.ts
+++ b/packages/property/src/resolveProperty.ts
@@ -15,6 +15,7 @@
 import {
   TIER_ORDER,
   type LookupFieldKey,
+  type LookupTier,
   type LookupRequest,
   type PropertyLookup,
   type PropertyProvider,
@@ -28,14 +29,29 @@ export function hasPriceOrRent(lookup: PropertyLookup): boolean {
   return lookup.purchasePrice !== undefined || lookup.grossRent !== undefined;
 }
 
+/** All keys a provider may legitimately contribute — foreign keys from
+ * untyped providers (wild scrape/paste parsers) are dropped on merge. */
+const KNOWN_KEYS: ReadonlySet<string> = new Set<LookupFieldKey>([
+  'purchasePrice',
+  'grossRent',
+  'sqft',
+  'units',
+  'annualTaxes',
+  'annualInsurance',
+  'yearBuilt',
+]);
+
 /**
  * Sort providers into tier precedence, preserving the caller's relative
- * order within each tier (stable sort).
+ * order within each tier (stable sort). An unrecognised tier (possible
+ * from untyped JS callers) runs last, never ahead of trusted tiers.
  */
 function inTierOrder(providers: readonly PropertyProvider[]): PropertyProvider[] {
-  return [...providers].sort(
-    (a, b) => TIER_ORDER.indexOf(a.tier) - TIER_ORDER.indexOf(b.tier),
-  );
+  const rank = (tier: LookupTier): number => {
+    const idx = TIER_ORDER.indexOf(tier);
+    return idx === -1 ? TIER_ORDER.length : idx;
+  };
+  return [...providers].sort((a, b) => rank(a.tier) - rank(b.tier));
 }
 
 function errorMessage(err: unknown): string {
@@ -46,9 +62,10 @@ function errorMessage(err: unknown): string {
  * Resolve a property through the tiered provider chain.
  *
  * Pure orchestration: no network of its own, no retries, no timeouts —
- * those belong to the individual providers. Always resolves (never
- * rejects); total failure surfaces as an empty lookup with
- * acceptable=false and per-provider error attempts.
+ * those belong to the individual providers. Never rejects on provider
+ * failure; total failure surfaces as an empty lookup with
+ * acceptable=false and per-provider error attempts. (A throwing custom
+ * accept predicate is a caller bug and propagates — fail fast.)
  */
 export async function resolveProperty(
   request: LookupRequest,
@@ -58,6 +75,12 @@ export async function resolveProperty(
   const acceptable = options.acceptable ?? hasPriceOrRent;
   const lookup: PropertyLookup = {};
   const attempts: ProviderAttempt[] = [];
+
+  // Already acceptable with nothing looked up (custom predicate) — no
+  // provider should fire
+  if (acceptable(lookup)) {
+    return { lookup, attempts, acceptable: true };
+  }
 
   for (const provider of inTierOrder(providers)) {
     let supported: boolean;
@@ -88,12 +111,14 @@ export async function resolveProperty(
     try {
       const result = await provider.lookup(request);
       const contributed: LookupFieldKey[] = [];
-      for (const key of Object.keys(result) as LookupFieldKey[]) {
-        const field = result[key];
+      for (const key of Object.keys(result)) {
+        if (!KNOWN_KEYS.has(key)) continue; // foreign key from a wild provider
+        const fieldKey = key as LookupFieldKey;
+        const field = result[fieldKey];
         if (field === undefined) continue;
-        if (lookup[key] !== undefined) continue; // earlier tier wins
-        lookup[key] = field;
-        contributed.push(key);
+        if (lookup[fieldKey] !== undefined) continue; // earlier tier wins
+        lookup[fieldKey] = field;
+        contributed.push(fieldKey);
       }
       attempts.push({
         providerId: provider.id,

--- a/packages/property/src/resolveProperty.ts
+++ b/packages/property/src/resolveProperty.ts
@@ -1,0 +1,121 @@
+/**
+ * E7 — tiered property resolver (RPE-44)
+ *
+ * Runs injected providers in tier order (api → scrape → paste), merging
+ * each provider's fields into an accumulated PropertyLookup. A field set
+ * by an earlier (more trusted) tier is never overwritten by a later one.
+ * The chain stops as soon as the merged result satisfies the accept
+ * predicate; provider failures are recorded and the chain continues.
+ *
+ * Providers run sequentially, never in parallel — later tiers cost money,
+ * carry ToS risk, or need user input, so they must not fire when an
+ * earlier tier already produced an acceptable result.
+ */
+
+import {
+  TIER_ORDER,
+  type LookupFieldKey,
+  type LookupRequest,
+  type PropertyLookup,
+  type PropertyProvider,
+  type ProviderAttempt,
+  type ResolveOptions,
+  type ResolvedProperty,
+} from './types';
+
+/** Default accept predicate — see ResolveOptions.acceptable. */
+export function hasPriceOrRent(lookup: PropertyLookup): boolean {
+  return lookup.purchasePrice !== undefined || lookup.grossRent !== undefined;
+}
+
+/**
+ * Sort providers into tier precedence, preserving the caller's relative
+ * order within each tier (stable sort).
+ */
+function inTierOrder(providers: readonly PropertyProvider[]): PropertyProvider[] {
+  return [...providers].sort(
+    (a, b) => TIER_ORDER.indexOf(a.tier) - TIER_ORDER.indexOf(b.tier),
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Resolve a property through the tiered provider chain.
+ *
+ * Pure orchestration: no network of its own, no retries, no timeouts —
+ * those belong to the individual providers. Always resolves (never
+ * rejects); total failure surfaces as an empty lookup with
+ * acceptable=false and per-provider error attempts.
+ */
+export async function resolveProperty(
+  request: LookupRequest,
+  providers: readonly PropertyProvider[],
+  options: ResolveOptions = {},
+): Promise<ResolvedProperty> {
+  const acceptable = options.acceptable ?? hasPriceOrRent;
+  const lookup: PropertyLookup = {};
+  const attempts: ProviderAttempt[] = [];
+
+  for (const provider of inTierOrder(providers)) {
+    let supported: boolean;
+    try {
+      supported = provider.supports(request);
+    } catch (err) {
+      // A broken supports() must not kill the chain — treat as unsupported
+      attempts.push({
+        providerId: provider.id,
+        tier: provider.tier,
+        status: 'error',
+        contributed: [],
+        error: errorMessage(err),
+      });
+      continue;
+    }
+
+    if (!supported) {
+      attempts.push({
+        providerId: provider.id,
+        tier: provider.tier,
+        status: 'skipped',
+        contributed: [],
+      });
+      continue;
+    }
+
+    try {
+      const result = await provider.lookup(request);
+      const contributed: LookupFieldKey[] = [];
+      for (const key of Object.keys(result) as LookupFieldKey[]) {
+        const field = result[key];
+        if (field === undefined) continue;
+        if (lookup[key] !== undefined) continue; // earlier tier wins
+        lookup[key] = field;
+        contributed.push(key);
+      }
+      attempts.push({
+        providerId: provider.id,
+        tier: provider.tier,
+        status: 'ok',
+        contributed,
+      });
+    } catch (err) {
+      attempts.push({
+        providerId: provider.id,
+        tier: provider.tier,
+        status: 'error',
+        contributed: [],
+        error: errorMessage(err),
+      });
+      continue;
+    }
+
+    if (acceptable(lookup)) {
+      return { lookup, attempts, acceptable: true };
+    }
+  }
+
+  return { lookup, attempts, acceptable: acceptable(lookup) };
+}

--- a/packages/property/src/types.ts
+++ b/packages/property/src/types.ts
@@ -1,0 +1,121 @@
+/**
+ * E7 — property lookup types (RPE-44)
+ *
+ * Framework-agnostic types for the tiered property-lookup chain:
+ * licensed API → scrape fallback → paste-text. Every looked-up field
+ * carries provenance (which provider, at what confidence) so the UI can
+ * badge values and flag low-confidence ones for review.
+ *
+ * This package is pure: no network, no React. Providers are injected
+ * into resolveProperty(); concrete integrations (RentCast, scrapers,
+ * paste parsers) live in their own packages/stories.
+ */
+
+// ─── Tiers and provenance ─────────────────────────────────────────────────────
+
+/**
+ * Lookup tiers, in fallback order. The resolver always exhausts cheaper,
+ * licensed tiers before riskier/noisier ones.
+ */
+export type LookupTier = 'api' | 'scrape' | 'paste';
+
+/** Tier precedence used by resolveProperty — index 0 runs first. */
+export const TIER_ORDER: readonly LookupTier[] = ['api', 'scrape', 'paste'];
+
+/**
+ * Per-field confidence. 'low' values should be surfaced as "needs review"
+ * by the mapping/UI layers.
+ */
+export type LookupConfidence = 'high' | 'medium' | 'low';
+
+/** A single looked-up value plus where it came from. */
+export interface LookupField {
+  value: number;
+  /** Provider id that produced the value (e.g. 'rentcast'). */
+  source: string;
+  confidence: LookupConfidence;
+}
+
+// ─── Lookup result ────────────────────────────────────────────────────────────
+
+/**
+ * Field keys a lookup can populate. Names align with DealInputs
+ * (purchasePrice, grossRent, sqft, units) and with the flat annualTaxes /
+ * annualInsurance amounts that the mapping story (RPE-50) converts into
+ * DealInputs.expenses entries.
+ */
+export type LookupFieldKey =
+  | 'purchasePrice'
+  | 'grossRent'
+  | 'sqft'
+  | 'units'
+  | 'annualTaxes'
+  | 'annualInsurance'
+  | 'yearBuilt';
+
+/**
+ * A partial, provenance-tagged set of deal inputs — the result of one
+ * provider lookup or of the merged tiered chain.
+ */
+export type PropertyLookup = Partial<Record<LookupFieldKey, LookupField>>;
+
+// ─── Provider contract ────────────────────────────────────────────────────────
+
+/**
+ * Input to a lookup. Exactly one of the fields is typically set; providers
+ * declare what they can handle via supports().
+ */
+export interface LookupRequest {
+  /** Free-text street address. */
+  address?: string;
+  /** Listing URL (Zillow/Redfin/…); parsed by URL-aware providers. */
+  url?: string;
+  /** Raw listing text pasted by the user. */
+  pastedText?: string;
+}
+
+/** A pluggable property-data source. */
+export interface PropertyProvider {
+  /** Stable identifier, used as LookupField.source (e.g. 'rentcast'). */
+  id: string;
+  tier: LookupTier;
+  /** Whether this provider can act on the given request at all. */
+  supports(request: LookupRequest): boolean;
+  /**
+   * Perform the lookup. Resolves to a (possibly empty) PropertyLookup;
+   * rejects on provider failure — the resolver records the error and
+   * continues down the chain.
+   */
+  lookup(request: LookupRequest): Promise<PropertyLookup>;
+}
+
+// ─── Resolver result ──────────────────────────────────────────────────────────
+
+/** Outcome of one provider in the chain, for diagnostics and UI messaging. */
+export interface ProviderAttempt {
+  providerId: string;
+  tier: LookupTier;
+  status: 'ok' | 'error' | 'skipped';
+  /** Field keys this provider contributed to the merged result. */
+  contributed: LookupFieldKey[];
+  /** Present when status is 'error'. */
+  error?: string;
+}
+
+/** Merged result of the tiered chain plus a per-provider audit trail. */
+export interface ResolvedProperty {
+  lookup: PropertyLookup;
+  attempts: ProviderAttempt[];
+  /** True when the accept predicate was satisfied. */
+  acceptable: boolean;
+}
+
+/** Options for resolveProperty. */
+export interface ResolveOptions {
+  /**
+   * Predicate deciding when the merged lookup is good enough to stop the
+   * chain. Default: a purchase price or a gross rent is present — without
+   * at least one of those the evaluator has nothing useful to prefill.
+   */
+  acceptable?: (lookup: PropertyLookup) => boolean;
+}

--- a/packages/property/src/types.ts
+++ b/packages/property/src/types.ts
@@ -42,16 +42,20 @@ export interface LookupField {
  * Field keys a lookup can populate. Names align with DealInputs
  * (purchasePrice, grossRent, sqft, units) and with the flat annualTaxes /
  * annualInsurance amounts that the mapping story (RPE-50) converts into
- * DealInputs.expenses entries.
+ * DealInputs.expenses entries. Single source of truth — the resolver's
+ * foreign-key filter derives from this array.
  */
-export type LookupFieldKey =
-  | 'purchasePrice'
-  | 'grossRent'
-  | 'sqft'
-  | 'units'
-  | 'annualTaxes'
-  | 'annualInsurance'
-  | 'yearBuilt';
+export const LOOKUP_FIELD_KEYS = [
+  'purchasePrice',
+  'grossRent',
+  'sqft',
+  'units',
+  'annualTaxes',
+  'annualInsurance',
+  'yearBuilt',
+] as const;
+
+export type LookupFieldKey = (typeof LOOKUP_FIELD_KEYS)[number];
 
 /**
  * A partial, provenance-tagged set of deal inputs — the result of one

--- a/packages/property/tests/resolveProperty.test.ts
+++ b/packages/property/tests/resolveProperty.test.ts
@@ -1,0 +1,336 @@
+/**
+ * RPE-44: tiered resolver tests — pure, no network, providers injected.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveProperty,
+  hasPriceOrRent,
+  TIER_ORDER,
+  type LookupField,
+  type LookupRequest,
+  type LookupTier,
+  type PropertyLookup,
+  type PropertyProvider,
+} from '../src/index';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const REQUEST: LookupRequest = { address: '123 Main St, Austin, TX 78701' };
+
+function field(value: number, source: string, confidence: LookupField['confidence'] = 'high'): LookupField {
+  return { value, source, confidence };
+}
+
+interface FakeProviderOpts {
+  id: string;
+  tier: LookupTier;
+  result?: PropertyLookup;
+  error?: Error;
+  supports?: boolean | (() => boolean);
+}
+
+function fakeProvider(opts: FakeProviderOpts): PropertyProvider & { lookupSpy: ReturnType<typeof vi.fn> } {
+  const lookupSpy = vi.fn(async (): Promise<PropertyLookup> => {
+    if (opts.error) throw opts.error;
+    return opts.result ?? {};
+  });
+  return {
+    id: opts.id,
+    tier: opts.tier,
+    supports:
+      typeof opts.supports === 'function'
+        ? opts.supports
+        : () => opts.supports !== false,
+    lookup: lookupSpy,
+    lookupSpy,
+  };
+}
+
+// ─── Tier ordering ───────────────────────────────────────────────────────────
+
+describe('resolveProperty — tier ordering', () => {
+  it('exports tiers in api → scrape → paste precedence', () => {
+    expect(TIER_ORDER).toEqual(['api', 'scrape', 'paste']);
+  });
+
+  it('runs api before scrape before paste regardless of array order', async () => {
+    const calls: string[] = [];
+    const make = (id: string, tier: LookupTier): PropertyProvider => ({
+      id,
+      tier,
+      supports: () => true,
+      lookup: async () => {
+        calls.push(id);
+        return {};
+      },
+    });
+
+    await resolveProperty(REQUEST, [
+      make('paste', 'paste'),
+      make('scrape', 'scrape'),
+      make('api', 'api'),
+    ]);
+
+    expect(calls).toEqual(['api', 'scrape', 'paste']);
+  });
+
+  it('preserves caller order within the same tier (stable sort)', async () => {
+    const calls: string[] = [];
+    const make = (id: string): PropertyProvider => ({
+      id,
+      tier: 'api',
+      supports: () => true,
+      lookup: async () => {
+        calls.push(id);
+        return {};
+      },
+    });
+
+    await resolveProperty(REQUEST, [make('first'), make('second'), make('third')]);
+
+    expect(calls).toEqual(['first', 'second', 'third']);
+  });
+
+  it('runs providers sequentially — a later provider never starts before an earlier one finishes', async () => {
+    const events: string[] = [];
+    const slow: PropertyProvider = {
+      id: 'slow-api',
+      tier: 'api',
+      supports: () => true,
+      lookup: async () => {
+        events.push('slow-start');
+        await new Promise((r) => setTimeout(r, 10));
+        events.push('slow-end');
+        return {};
+      },
+    };
+    const fast: PropertyProvider = {
+      id: 'fast-scrape',
+      tier: 'scrape',
+      supports: () => true,
+      lookup: async () => {
+        events.push('fast-start');
+        return {};
+      },
+    };
+
+    await resolveProperty(REQUEST, [fast, slow]);
+
+    expect(events).toEqual(['slow-start', 'slow-end', 'fast-start']);
+  });
+});
+
+// ─── Early exit and merging ──────────────────────────────────────────────────
+
+describe('resolveProperty — early exit and merging', () => {
+  it('stops the chain after the first acceptable result', async () => {
+    const api = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { purchasePrice: field(300000, 'rentcast') },
+    });
+    const scrape = fakeProvider({ id: 'zillow-scrape', tier: 'scrape' });
+
+    const resolved = await resolveProperty(REQUEST, [api, scrape]);
+
+    expect(resolved.acceptable).toBe(true);
+    expect(resolved.lookup.purchasePrice?.value).toBe(300000);
+    expect(scrape.lookupSpy).not.toHaveBeenCalled();
+    expect(resolved.attempts).toHaveLength(1);
+  });
+
+  it('falls through and merges fields when the first tier is not acceptable', async () => {
+    const api = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { sqft: field(1400, 'rentcast', 'medium') },
+    });
+    const scrape = fakeProvider({
+      id: 'zillow-scrape',
+      tier: 'scrape',
+      result: {
+        purchasePrice: field(310000, 'zillow-scrape', 'low'),
+        sqft: field(9999, 'zillow-scrape', 'low'),
+      },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [api, scrape]);
+
+    expect(resolved.acceptable).toBe(true);
+    // Field from the unacceptable-but-useful first tier is kept…
+    expect(resolved.lookup.sqft).toEqual(field(1400, 'rentcast', 'medium'));
+    // …and never overwritten by a later tier
+    expect(resolved.lookup.purchasePrice).toEqual(field(310000, 'zillow-scrape', 'low'));
+    expect(resolved.attempts[1].contributed).toEqual(['purchasePrice']);
+  });
+
+  it('keeps per-field provenance and confidence untouched through the merge', async () => {
+    const paste = fakeProvider({
+      id: 'paste-parser',
+      tier: 'paste',
+      result: { grossRent: field(2100, 'paste-parser', 'low') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [paste]);
+
+    expect(resolved.lookup.grossRent).toEqual({
+      value: 2100,
+      source: 'paste-parser',
+      confidence: 'low',
+    });
+  });
+
+  it('returns an ok attempt with empty contribution when all fields were already set', async () => {
+    const api1 = fakeProvider({
+      id: 'api-one',
+      tier: 'api',
+      result: { sqft: field(1400, 'api-one') },
+    });
+    const api2 = fakeProvider({
+      id: 'api-two',
+      tier: 'api',
+      result: { sqft: field(1500, 'api-two') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [api1, api2]);
+
+    expect(resolved.lookup.sqft?.source).toBe('api-one');
+    expect(resolved.attempts[1]).toMatchObject({ providerId: 'api-two', status: 'ok', contributed: [] });
+  });
+});
+
+// ─── Skipping and failure handling ───────────────────────────────────────────
+
+describe('resolveProperty — skipping and failures', () => {
+  it('skips providers whose supports() is false without calling lookup', async () => {
+    const urlOnly = fakeProvider({ id: 'url-parser', tier: 'api', supports: false });
+    const addressApi = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { grossRent: field(1900, 'rentcast') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [urlOnly, addressApi]);
+
+    expect(urlOnly.lookupSpy).not.toHaveBeenCalled();
+    expect(resolved.attempts[0]).toMatchObject({ providerId: 'url-parser', status: 'skipped' });
+    expect(resolved.acceptable).toBe(true);
+  });
+
+  it('records a provider error and continues down the chain', async () => {
+    const api = fakeProvider({ id: 'rentcast', tier: 'api', error: new Error('rate limited') });
+    const scrape = fakeProvider({
+      id: 'zillow-scrape',
+      tier: 'scrape',
+      result: { purchasePrice: field(295000, 'zillow-scrape', 'low') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [api, scrape]);
+
+    expect(resolved.attempts[0]).toMatchObject({
+      providerId: 'rentcast',
+      status: 'error',
+      error: 'rate limited',
+    });
+    expect(resolved.acceptable).toBe(true);
+    expect(resolved.lookup.purchasePrice?.value).toBe(295000);
+  });
+
+  it('treats a throwing supports() as an error and continues', async () => {
+    const broken: PropertyProvider = {
+      id: 'broken',
+      tier: 'api',
+      supports: () => {
+        throw new Error('boom');
+      },
+      lookup: async () => ({ purchasePrice: field(1, 'broken') }),
+    };
+    const ok = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { purchasePrice: field(300000, 'rentcast') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [broken, ok]);
+
+    expect(resolved.attempts[0]).toMatchObject({ providerId: 'broken', status: 'error', error: 'boom' });
+    expect(resolved.lookup.purchasePrice?.source).toBe('rentcast');
+  });
+
+  it('stringifies non-Error throws', async () => {
+    const api = fakeProvider({ id: 'rentcast', tier: 'api' });
+    api.lookup = async () => {
+      throw 'plain string failure';
+    };
+
+    const resolved = await resolveProperty(REQUEST, [api]);
+
+    expect(resolved.attempts[0].error).toBe('plain string failure');
+  });
+
+  it('returns an empty unacceptable result when every provider fails', async () => {
+    const api = fakeProvider({ id: 'rentcast', tier: 'api', error: new Error('down') });
+    const scrape = fakeProvider({ id: 'zillow-scrape', tier: 'scrape', error: new Error('blocked') });
+
+    const resolved = await resolveProperty(REQUEST, [api, scrape]);
+
+    expect(resolved.lookup).toEqual({});
+    expect(resolved.acceptable).toBe(false);
+    expect(resolved.attempts.map((a) => a.status)).toEqual(['error', 'error']);
+  });
+
+  it('handles an empty provider list', async () => {
+    const resolved = await resolveProperty(REQUEST, []);
+    expect(resolved).toEqual({ lookup: {}, attempts: [], acceptable: false });
+  });
+});
+
+// ─── Accept predicate ────────────────────────────────────────────────────────
+
+describe('resolveProperty — accept predicate', () => {
+  it('default predicate accepts price-only and rent-only lookups', () => {
+    expect(hasPriceOrRent({ purchasePrice: field(1, 'x') })).toBe(true);
+    expect(hasPriceOrRent({ grossRent: field(1, 'x') })).toBe(true);
+    expect(hasPriceOrRent({ sqft: field(1400, 'x') })).toBe(false);
+    expect(hasPriceOrRent({})).toBe(false);
+  });
+
+  it('honours a custom acceptable predicate', async () => {
+    const api = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { purchasePrice: field(300000, 'rentcast') },
+    });
+    const scrape = fakeProvider({
+      id: 'zillow-scrape',
+      tier: 'scrape',
+      result: { grossRent: field(2000, 'zillow-scrape', 'low') },
+    });
+
+    // Require BOTH price and rent — price alone must not stop the chain
+    const resolved = await resolveProperty(REQUEST, [api, scrape], {
+      acceptable: (l) => l.purchasePrice !== undefined && l.grossRent !== undefined,
+    });
+
+    expect(scrape.lookupSpy).toHaveBeenCalled();
+    expect(resolved.acceptable).toBe(true);
+    expect(resolved.lookup.purchasePrice?.source).toBe('rentcast');
+    expect(resolved.lookup.grossRent?.source).toBe('zillow-scrape');
+  });
+
+  it('reports acceptable=false when the chain ends below the custom bar', async () => {
+    const api = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { purchasePrice: field(300000, 'rentcast') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [api], {
+      acceptable: (l) => l.purchasePrice !== undefined && l.grossRent !== undefined,
+    });
+
+    expect(resolved.acceptable).toBe(false);
+    expect(resolved.lookup.purchasePrice?.value).toBe(300000);
+  });
+});

--- a/packages/property/tests/resolveProperty.test.ts
+++ b/packages/property/tests/resolveProperty.test.ts
@@ -92,6 +92,27 @@ describe('resolveProperty — tier ordering', () => {
     expect(calls).toEqual(['first', 'second', 'third']);
   });
 
+  it('runs an unrecognised tier last, never ahead of trusted tiers', async () => {
+    const calls: string[] = [];
+    const make = (id: string, tier: string): PropertyProvider => ({
+      id,
+      tier: tier as LookupTier,
+      supports: () => true,
+      lookup: async () => {
+        calls.push(id);
+        return {};
+      },
+    });
+
+    await resolveProperty(REQUEST, [
+      make('mystery', 'telepathy'),
+      make('paste', 'paste'),
+      make('api', 'api'),
+    ]);
+
+    expect(calls).toEqual(['api', 'paste', 'mystery']);
+  });
+
   it('runs providers sequentially — a later provider never starts before an earlier one finishes', async () => {
     const events: string[] = [];
     const slow: PropertyProvider = {
@@ -179,6 +200,23 @@ describe('resolveProperty — early exit and merging', () => {
       source: 'paste-parser',
       confidence: 'low',
     });
+  });
+
+  it('drops foreign keys returned by a wild provider', async () => {
+    const wild = fakeProvider({
+      id: 'paste-parser',
+      tier: 'paste',
+      result: {
+        grossRent: field(2000, 'paste-parser', 'low'),
+        hoaFee: field(150, 'paste-parser', 'low'),
+        listingAgent: field(0, 'paste-parser', 'low'),
+      } as PropertyLookup,
+    });
+
+    const resolved = await resolveProperty(REQUEST, [wild]);
+
+    expect(Object.keys(resolved.lookup)).toEqual(['grossRent']);
+    expect(resolved.attempts[0].contributed).toEqual(['grossRent']);
   });
 
   it('returns an ok attempt with empty contribution when all fields were already set', async () => {
@@ -317,6 +355,19 @@ describe('resolveProperty — accept predicate', () => {
     expect(resolved.acceptable).toBe(true);
     expect(resolved.lookup.purchasePrice?.source).toBe('rentcast');
     expect(resolved.lookup.grossRent?.source).toBe('zillow-scrape');
+  });
+
+  it('fires no provider when an empty lookup already satisfies a custom predicate', async () => {
+    const api = fakeProvider({
+      id: 'rentcast',
+      tier: 'api',
+      result: { purchasePrice: field(300000, 'rentcast') },
+    });
+
+    const resolved = await resolveProperty(REQUEST, [api], { acceptable: () => true });
+
+    expect(api.lookupSpy).not.toHaveBeenCalled();
+    expect(resolved).toEqual({ lookup: {}, attempts: [], acceptable: true });
   });
 
   it('reports acceptable=false when the chain ends below the custom bar', async () => {

--- a/packages/property/tsconfig.json
+++ b/packages/property/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "lib": ["ES2022"]
+  },
+  "include": ["src"],
+  "exclude": ["tests", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,12 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
 
+  packages/property:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   packages/region-defaults:
     devDependencies:
       typescript:


### PR DESCRIPTION
## Summary
- New pure `@rpe/property` package (engine-style, no React/network): `PropertyLookup` provenance types (per-field value/source/confidence), `PropertyProvider` interface, `LookupRequest` (address/url/pastedText)
- `resolveProperty()` tiered orchestrator: providers injected, run **sequentially** in `api → scrape → paste` order (stable within tier); fields merge first-tier-wins; chain stops at the first acceptable result (default: price or rent present); provider errors recorded in a per-attempt audit trail and never kill the chain
- 20 tests: tier ordering, sequential execution, early exit, merge provenance, skip/error handling, custom accept predicates

Foundation story for the remaining E7 work (RPE-45–54).

## Review
Copilot unavailable; strict self-review loop. Round 1: unknown tier sorted ahead of `api` (indexOf −1), foreign keys from wild providers merged unchecked, predicate not checked before the chain — all fixed with tests. Round 2: deduplicated the field-key list into one `LOOKUP_FIELD_KEYS` source. Round 3 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 671 tests passing (explicit exit codes checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)