### PR TITLE
RPE-52: paste-listing-text parser — client-side double fallback

### DIFF
--- a/packages/property/src/index.ts
+++ b/packages/property/src/index.ts
@@ -27,3 +27,6 @@ export {
   ProviderError,
   type RentCastProxyOptions,
 } from './providers/rentcastProxy';
+
+export { parseListingText } from './pasteText';
+export { createPasteTextProvider } from './providers/pasteTextProvider';

--- a/packages/property/src/pasteText.ts
+++ b/packages/property/src/pasteText.ts
@@ -1,0 +1,123 @@
+/**
+ * E7 — paste-listing-text parser (RPE-52)
+ *
+ * Parses listing text the user copied from any site into a partial
+ * PropertyLookup via labeled-number heuristics. Zero keys, zero cost,
+ * zero ToS exposure — the double fallback when the licensed API and the
+ * (flagged) scrape tier produce nothing.
+ *
+ * Heuristics, not extraction: everything is tagged source 'paste' at
+ * 'low' confidence except explicitly labeled dollar amounts ('medium'),
+ * and the whole result is meant to flow through the same review panel
+ * as every other lookup.
+ */
+
+import type { LookupConfidence, LookupField, PropertyLookup } from './types';
+
+const SOURCE = 'paste';
+
+function field(value: number, confidence: LookupConfidence): LookupField {
+  return { value, source: SOURCE, confidence };
+}
+
+/** "342,000" / "342000" / "1.2M" / "950k" → number (null when unparseable). */
+function parseAmount(raw: string): number | null {
+  const cleaned = raw.replace(/[,$\s]/g, '').toLowerCase();
+  const m = cleaned.match(/^(\d+(?:\.\d+)?)([km])?$/);
+  if (!m || m[1] === undefined) return null;
+  const base = Number(m[1]);
+  if (!Number.isFinite(base)) return null;
+  const mult = m[2] === 'm' ? 1_000_000 : m[2] === 'k' ? 1_000 : 1;
+  return base * mult;
+}
+
+const AMOUNT = String.raw`\$?\s*([\d,]+(?:\.\d+)?\s*[kKmM]?)`;
+
+/** First capture of the first pattern that matches — patterns are tried in order. */
+function firstMatch(text: string, patterns: RegExp[]): number | null {
+  for (const pattern of patterns) {
+    const m = text.match(pattern);
+    if (m?.[1] !== undefined) {
+      const value = parseAmount(m[1]);
+      if (value !== null && value > 0) return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse pasted listing text into a partial PropertyLookup.
+ *
+ * Fields it hunts for: list price, monthly rent, annual taxes, beds,
+ * baths, sqft, year built. Anything it can't find is simply absent —
+ * the resolver and review panel handle partial results.
+ */
+export function parseListingText(text: string): PropertyLookup {
+  const lookup: PropertyLookup = {};
+  if (text.trim() === '') return lookup;
+
+  // Normalize whitespace; keep newlines as plain spaces — labels and
+  // values frequently end up on separate lines when copied
+  const t = text.replace(/\s+/g, ' ');
+
+  // ── Price ─────────────────────────────────────────────────────────────
+  // Labeled price ("List price: $342,000", "asking $342K") is medium
+  // confidence; a bare leading "$342,000" (how Zillow/Redfin copies open)
+  // is low.
+  const labeledPrice = firstMatch(t, [
+    new RegExp(String.raw`(?:list(?:ed)?\s*(?:price|at)|asking(?:\s*price)?|price[d]?(?:\s*at)?)\s*[:\-]?\s*${AMOUNT}`, 'i'),
+    new RegExp(String.raw`${AMOUNT}\s*(?:list\s*price|asking)`, 'i'),
+  ]);
+  const barePrice = labeledPrice === null
+    ? firstMatch(t, [new RegExp(String.raw`\$\s*([\d,]{6,}(?:\.\d+)?|[\d.]+\s*[mM]|\d{3,}\s*[kK])`)])
+    : null;
+  const price = labeledPrice ?? barePrice;
+  if (price !== null && price >= 10_000) {
+    lookup.purchasePrice = field(price, labeledPrice !== null ? 'medium' : 'low');
+  }
+
+  // ── Rent ──────────────────────────────────────────────────────────────
+  const rent = firstMatch(t, [
+    new RegExp(String.raw`(?:rent(?:\s*estimate|\s*zestimate)?|estimated\s*rent)\s*[:\-]?\s*${AMOUNT}(?:\s*/\s*mo|\s*per\s*month|\s*monthly)?`, 'i'),
+    new RegExp(String.raw`${AMOUNT}\s*(?:/\s*mo\b|per\s*month)`, 'i'),
+  ]);
+  if (rent !== null && rent >= 100 && rent <= 50_000) {
+    lookup.grossRent = field(rent, 'medium');
+  }
+
+  // ── Annual taxes ──────────────────────────────────────────────────────
+  const taxes = firstMatch(t, [
+    new RegExp(String.raw`(?:annual\s*tax(?:es)?|property\s*tax(?:es)?|tax(?:es)?)\s*(?:amount|bill)?\s*(?:\(\d{4}\))?\s*[:\-]?\s*${AMOUNT}(?:\s*/\s*yr|\s*per\s*year|\s*annually)?`, 'i'),
+  ]);
+  if (taxes !== null && taxes >= 50 && taxes <= 500_000) {
+    lookup.annualTaxes = field(taxes, 'medium');
+  }
+
+  // ── Beds / baths ──────────────────────────────────────────────────────
+  const beds = t.match(/(\d{1,2})\s*(?:bds?|beds?|bedrooms?)\b/i);
+  if (beds?.[1] !== undefined) {
+    const n = Number(beds[1]);
+    if (n >= 1 && n <= 20) lookup.bedrooms = field(n, 'low');
+  }
+  const baths = t.match(/(\d{1,2}(?:\.\d)?)\s*(?:ba(?:ths?)?|bathrooms?)\b/i);
+  if (baths?.[1] !== undefined) {
+    const n = Number(baths[1]);
+    if (n >= 0.5 && n <= 20) lookup.bathrooms = field(n, 'low');
+  }
+
+  // ── Sqft ──────────────────────────────────────────────────────────────
+  const sqft = t.match(/([\d,]{3,6})\s*(?:sq\.?\s*ft\.?|sqft|square\s*feet)\b/i);
+  if (sqft?.[1] !== undefined) {
+    const n = parseAmount(sqft[1]);
+    if (n !== null && n >= 100 && n <= 100_000) lookup.sqft = field(n, 'low');
+  }
+
+  // ── Year built ────────────────────────────────────────────────────────
+  const year = t.match(/(?:built\s*(?:in)?|year\s*built)\s*[:-]?\s*(\d{4})\b/i);
+  if (year?.[1] !== undefined) {
+    const n = Number(year[1]);
+    if (n >= 1700 && n <= 2100) lookup.yearBuilt = field(n, 'low');
+  }
+
+  return lookup;
+}

--- a/packages/property/src/providers/pasteTextProvider.ts
+++ b/packages/property/src/providers/pasteTextProvider.ts
@@ -1,0 +1,23 @@
+/**
+ * E7 — paste-tier PropertyProvider (RPE-52)
+ *
+ * Wraps parseListingText() as the last tier of the resolver chain. Pure
+ * and synchronous under the hood; only fires when the request actually
+ * carries pasted text.
+ */
+
+import type { LookupRequest, PropertyLookup, PropertyProvider } from '../types';
+import { parseListingText } from '../pasteText';
+
+export function createPasteTextProvider(): PropertyProvider {
+  return {
+    id: 'paste',
+    tier: 'paste',
+    supports(request: LookupRequest): boolean {
+      return (request.pastedText?.trim() ?? '') !== '';
+    },
+    async lookup(request: LookupRequest): Promise<PropertyLookup> {
+      return parseListingText(request.pastedText ?? '');
+    },
+  };
+}

--- a/packages/property/tests/pasteText.test.ts
+++ b/packages/property/tests/pasteText.test.ts
@@ -1,0 +1,105 @@
+/**
+ * RPE-52: paste-listing-text parser tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseListingText, createPasteTextProvider, resolveProperty } from '../src/index';
+
+const ZILLOW_STYLE = `
+$342,000
+3 bd | 2 ba | 1,480 sqft
+123 Main St, Austin, TX 78701
+Built in 1987
+Rent Zestimate: $2,150/mo
+Annual tax amount: $4,210
+`;
+
+describe('parseListingText', () => {
+  it('parses a Zillow-style copied listing', () => {
+    const lookup = parseListingText(ZILLOW_STYLE);
+    expect(lookup.purchasePrice?.value).toBe(342_000);
+    expect(lookup.bedrooms?.value).toBe(3);
+    expect(lookup.bathrooms?.value).toBe(2);
+    expect(lookup.sqft?.value).toBe(1_480);
+    expect(lookup.yearBuilt?.value).toBe(1987);
+    expect(lookup.grossRent?.value).toBe(2_150);
+    expect(lookup.annualTaxes?.value).toBe(4_210);
+  });
+
+  it('tags labeled dollar amounts medium and bare/structural finds low', () => {
+    const lookup = parseListingText(ZILLOW_STYLE);
+    expect(lookup.purchasePrice?.confidence).toBe('low'); // bare leading $
+    expect(lookup.grossRent?.confidence).toBe('medium');
+    expect(lookup.annualTaxes?.confidence).toBe('medium');
+    expect(lookup.bedrooms?.confidence).toBe('low');
+    expect(Object.values(lookup).every((f) => f?.source === 'paste')).toBe(true);
+  });
+
+  it('parses a labeled list price at medium confidence', () => {
+    const lookup = parseListingText('List price: $950K · charming duplex');
+    expect(lookup.purchasePrice).toEqual({ value: 950_000, source: 'paste', confidence: 'medium' });
+  });
+
+  it('handles K/M suffixes and decimal millions', () => {
+    expect(parseListingText('asking $1.2M').purchasePrice?.value).toBe(1_200_000);
+    expect(parseListingText('priced at 425k').purchasePrice?.value).toBe(425_000);
+  });
+
+  it('parses rent from a per-month amount without a label', () => {
+    const lookup = parseListingText('Great cash flow at $1,850/mo with long-term tenants');
+    expect(lookup.grossRent?.value).toBe(1_850);
+  });
+
+  it('parses half baths', () => {
+    expect(parseListingText('2 bd 1.5 ba cottage').bathrooms?.value).toBe(1.5);
+  });
+
+  it('rejects implausible values instead of guessing', () => {
+    const lookup = parseListingText('99 beds 99 baths $5 price 50 sqft built in 1492');
+    expect(lookup.purchasePrice).toBeUndefined(); // $5 below price floor
+    expect(lookup.bedrooms).toBeUndefined();      // 99 beyond cap
+    expect(lookup.sqft).toBeUndefined();          // 50 below floor
+    expect(lookup.yearBuilt).toBeUndefined();     // 1492 before floor
+  });
+
+  it('returns an empty lookup for empty or unrelated text', () => {
+    expect(parseListingText('')).toEqual({});
+    expect(parseListingText('hello world, nothing to see')).toEqual({});
+  });
+
+  it('survives values split across lines', () => {
+    const lookup = parseListingText('Property taxes\n$3,900\nList price\n$280,000');
+    expect(lookup.annualTaxes?.value).toBe(3_900);
+    expect(lookup.purchasePrice?.value).toBe(280_000);
+  });
+});
+
+describe('createPasteTextProvider', () => {
+  it('is the paste tier and only supports requests with pasted text', () => {
+    const p = createPasteTextProvider();
+    expect(p.tier).toBe('paste');
+    expect(p.supports({ pastedText: ZILLOW_STYLE })).toBe(true);
+    expect(p.supports({ pastedText: '   ' })).toBe(false);
+    expect(p.supports({ address: '123 Main St' })).toBe(false);
+  });
+
+  it('acts as the final tier through resolveProperty', async () => {
+    const failingApi = {
+      id: 'rentcast',
+      tier: 'api' as const,
+      supports: () => true,
+      lookup: async () => {
+        throw new Error('proxy down');
+      },
+    };
+
+    const resolved = await resolveProperty(
+      { address: '123 Main St', pastedText: ZILLOW_STYLE },
+      [failingApi, createPasteTextProvider()],
+    );
+
+    expect(resolved.acceptable).toBe(true);
+    expect(resolved.lookup.purchasePrice?.source).toBe('paste');
+    expect(resolved.attempts.map((a) => a.status)).toEqual(['error', 'ok']);
+  });
+});


### PR DESCRIPTION
## Summary
- `parseListingText()` in `@rpe/property`: labeled-number heuristics extracting price, rent, annual taxes, beds/baths, sqft, and year built from listing text the user copied from any site — zero keys, zero cost, zero ToS exposure
- Confidence model: explicitly labeled dollar amounts → `medium`; bare/structural finds → `low`; implausible values (e.g. $5 price, 99 beds, year 1492) are dropped, never guessed
- `createPasteTextProvider()` — the final (`paste`) tier of the RPE-44 resolver chain; verified end-to-end: api tier fails → paste tier resolves acceptably
- 11 new tests including a realistic Zillow-style copied block and line-split label/value pairs

## Review
Copilot unavailable; strict self-review loop — the suite caught a tax-label gap ("Annual tax **amount**") pre-commit; adversarial pass confirmed value floors/caps prevent cross-field mismatches. Rounds clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 744 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)