### PR TITLE
RPE-49: comps & history — fetchPropertyContext + POST /property/context

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,6 +45,11 @@ import { evaluate } from '@rpe/engine';
 import type { DealInputs, EvalOptions } from '@rpe/engine';
 import { handleGeocode, type GeocodeDeps, type GeocodeSuccessBody } from './routes/geocode.js';
 import { handleProperty, type PropertyDeps, type PropertySuccessBody } from './routes/property.js';
+import {
+  handlePropertyContext,
+  type PropertyContextDeps,
+  type ContextSuccessBody,
+} from './routes/propertyContext.js';
 import { handleRegion } from './routes/region.js';
 import { RateLimiter, TtlCache } from './services/guardrails.js';
 
@@ -372,6 +377,15 @@ export function createApp(config: AppConfig = {}) {
     ),
   };
 
+  // Comps/history share the /property limiter — one provider-call budget
+  // per client across both endpoints (RPE-49)
+  const propertyContextDeps: PropertyContextDeps = {
+    cache: new TtlCache<ContextSuccessBody>(
+      config.property?.cacheTtlMs ?? envInt('RPE_PROPERTY_CACHE_TTL_MS', 24 * 60 * 60 * 1000),
+    ),
+    limiter: propertyDeps.limiter,
+  };
+
   // Address geometry does not move — geocode answers cache on the same
   // TTL knob as property lookups (RPE-46)
   const geocodeDeps: GeocodeDeps = {
@@ -404,6 +418,8 @@ export function createApp(config: AppConfig = {}) {
     const asyncHandler =
       url === '/evaluate' || url === '/evaluate/'
         ? () => handleEvaluate(req, res)
+        : url === '/property/context' || url === '/property/context/'
+        ? () => handlePropertyContext(req, res, json, readBody, propertyContextDeps)
         : url === '/property' || url === '/property/'
         ? () => handleProperty(req, res, json, readBody, propertyDeps)
         : url === '/region' || url === '/region/'
@@ -435,6 +451,7 @@ if (resolve(process.argv[1] ?? '') === __filename) {
     console.log('  GET  /health');
     console.log('  POST /evaluate');
     console.log('  POST /property');
+    console.log('  POST /property/context');
     console.log('  GET  /region?zip=XXXXX');
     console.log('  GET  /geocode?q=<address>');
   });

--- a/apps/api/src/routes/propertyContext.ts
+++ b/apps/api/src/routes/propertyContext.ts
@@ -1,0 +1,131 @@
+/**
+ * POST /property/context — comps & history proxy route (RPE-49)
+ *
+ * Receives { address: string, apiKey: string } and returns:
+ *   200 { context: PropertyContext, cached: boolean }
+ *
+ * Read-only supporting data (rent/sale comps, tax history, price
+ * history) — surfaced next to the deal, never auto-applied to inputs.
+ *
+ * Shares the SAME cost guardrails as /property: its own TTL cache
+ * (key-scoped normalized address), and the same per-IP limiter instance
+ * so property + context lookups draw from one provider-call budget.
+ * Error envelope matches /property (PropertyErrorCode).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { fetchPropertyContext, RentCastError, type RentCastErrorCode } from '@rpe/rentcast';
+import type { PropertyContext } from '@rpe/rentcast';
+import type { PropertyErrorCode } from './property.js';
+import { clientIp, scopeKey, type RateLimiter, type TtlCache } from '../services/guardrails.js';
+
+type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
+type ReadBodyFn = (req: IncomingMessage) => Promise<string>;
+
+export interface ContextSuccessBody {
+  context: PropertyContext;
+  cached: boolean;
+}
+
+export interface PropertyContextDeps {
+  cache: TtlCache<ContextSuccessBody>;
+  /** Shared with /property — one provider-call budget per client. */
+  limiter: RateLimiter;
+}
+
+export async function handlePropertyContext(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: JsonFn,
+  readBody: ReadBodyFn,
+  deps: PropertyContextDeps,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed — use POST', code: 'method_not_allowed' });
+    return;
+  }
+
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to read request body';
+    const tooLarge = msg === 'Payload too large';
+    json(res, tooLarge ? 413 : 400, {
+      error: msg,
+      code: tooLarge ? 'payload_too_large' : 'bad_request',
+    });
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    json(res, 400, { error: 'Invalid JSON', code: 'bad_request' });
+    return;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    json(res, 400, {
+      error: 'Request body must be { address: string, apiKey: string }',
+      code: 'bad_request',
+    });
+    return;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (!Object.hasOwn(obj, 'address') || typeof obj['address'] !== 'string' || obj['address'].trim() === '') {
+    json(res, 400, { error: 'address is required and must be a non-empty string', code: 'bad_request' });
+    return;
+  }
+  if (!Object.hasOwn(obj, 'apiKey') || typeof obj['apiKey'] !== 'string' || obj['apiKey'].trim() === '') {
+    json(res, 400, { error: 'apiKey is required and must be a non-empty string', code: 'bad_request' });
+    return;
+  }
+
+  const address = obj['address'].trim();
+  const apiKey  = obj['apiKey'].trim();
+
+  const cacheKey = scopeKey(apiKey, address);
+  const hit = deps.cache.get(cacheKey);
+  if (hit !== undefined) {
+    json(res, 200, { ...hit, cached: true });
+    return;
+  }
+
+  const decision = deps.limiter.check(clientIp(req));
+  if (!decision.allowed) {
+    json(res, 429, {
+      error: 'Too many lookups from this client — try again later.',
+      code: 'proxy_rate_limit',
+      retryAfterSec: decision.retryAfterSec,
+    });
+    return;
+  }
+
+  try {
+    const context = await fetchPropertyContext(address, apiKey);
+    const success: ContextSuccessBody = { context, cached: false };
+    deps.cache.set(cacheKey, success);
+    json(res, 200, success);
+  } catch (err) {
+    if (err instanceof RentCastError) {
+      const statusMap: Record<RentCastErrorCode, number> = {
+        bad_key: 401, not_found: 404, rate_limit: 429, unknown: 502,
+      };
+      const codeMap: Record<RentCastErrorCode, PropertyErrorCode> = {
+        bad_key: 'bad_key', not_found: 'not_found', rate_limit: 'rate_limit', unknown: 'upstream_error',
+      };
+      const clientMessages: Record<RentCastErrorCode, string> = {
+        bad_key:    'Invalid or expired API key.',
+        not_found:  'Property not found for this address.',
+        rate_limit: 'Rate limit reached. Check your RentCast plan.',
+        unknown:    'RentCast context lookup failed.',
+      };
+      json(res, statusMap[err.code], { error: clientMessages[err.code], code: codeMap[err.code] });
+      return;
+    }
+    console.error('Property context error for address:', address, err instanceof Error ? err.stack : String(err));
+    json(res, 500, { error: 'Internal server error', code: 'internal' });
+  }
+}

--- a/apps/api/tests/propertyContext.test.ts
+++ b/apps/api/tests/propertyContext.test.ts
@@ -1,0 +1,135 @@
+/**
+ * RPE-49: POST /property/context route tests.
+ *
+ * Mocks @rpe/rentcast (service-module pattern) so local-server fetches
+ * stay real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { fetchPropertyContext, RentCastError } from '@rpe/rentcast';
+
+vi.mock('@rpe/rentcast', () => ({
+  fetchPropertyData: vi.fn(),
+  fetchPropertyContext: vi.fn(),
+  RentCastError: class RentCastError extends Error {
+    constructor(public code: string, message: string) { super(message); this.name = 'RentCastError'; }
+  },
+}));
+
+const mockContext = vi.mocked(fetchPropertyContext);
+
+const CONTEXT = {
+  rentComps: [{ address: '127 Main St', price: 2_100, distanceMiles: 0.2, sqft: 1_450, bedrooms: 3 }],
+  saleComps: [{ address: '125 Main St', price: 350_000, distanceMiles: 0.3, sqft: 1_510, bedrooms: 3 }],
+  taxHistory: [{ year: 2023, total: 4_210 }],
+  priceHistory: [{ date: '2018-05-12', event: 'Sale', price: 265_000 }],
+};
+
+const VALID_BODY = { address: '123 Main St, Austin TX', apiKey: 'rc_key' };
+
+function startServer(config?: Parameters<typeof createApp>[0]): Promise<{ server: Server; base: string }> {
+  return new Promise((resolve, reject) => {
+    const server = createApp(config ?? { property: { cacheTtlMs: 60_000, rpm: 1000, dailyCap: 10000 } });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const addr = server.address() as { port: number };
+      resolve({ server, base: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+function post(base: string, body: unknown) {
+  return fetch(`${base}/property/context`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /property/context', () => {
+  let server: Server | undefined;
+  let base: string;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const s = await startServer();
+    server = s.server;
+    base = s.base;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it('returns the normalized context', async () => {
+    mockContext.mockResolvedValue(CONTEXT);
+    const res = await post(base, VALID_BODY);
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body['cached']).toBe(false);
+    expect(body['context']).toEqual(CONTEXT);
+    expect(mockContext).toHaveBeenCalledWith(VALID_BODY.address, VALID_BODY.apiKey);
+  });
+
+  it('serves repeats from cache without another provider call', async () => {
+    mockContext.mockResolvedValue(CONTEXT);
+    await post(base, VALID_BODY);
+    const second = await (await post(base, VALID_BODY)).json() as Record<string, unknown>;
+    expect(second['cached']).toBe(true);
+    expect(mockContext).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the provider-call budget with /property', async () => {
+    // rpm=1 across BOTH endpoints: a /property/context call exhausts it
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    const s = await startServer({ property: { cacheTtlMs: 0, rpm: 1, dailyCap: 1000 } });
+    server = s.server;
+    mockContext.mockResolvedValue(CONTEXT);
+
+    expect((await post(s.base, VALID_BODY)).status).toBe(200);
+    const limited = await post(s.base, VALID_BODY);
+    expect(limited.status).toBe(429);
+    const body = await limited.json() as Record<string, unknown>;
+    expect(body['code']).toBe('proxy_rate_limit');
+  });
+
+  it('returns 400 for a missing address or apiKey', async () => {
+    expect((await post(base, { apiKey: 'k' })).status).toBe(400);
+    expect((await post(base, { address: '123 Main St' })).status).toBe(400);
+    expect(mockContext).not.toHaveBeenCalled();
+  });
+
+  it('returns 405 for non-POST', async () => {
+    const res = await fetch(`${base}/property/context`);
+    expect(res.status).toBe(405);
+  });
+
+  it('maps RentCastError codes to the typed envelope', async () => {
+    mockContext.mockRejectedValue(new RentCastError('rate_limit', 'upstream limit'));
+    const res = await post(base, VALID_BODY);
+    expect(res.status).toBe(429);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['code']).toBe('rate_limit');
+    expect(String(body['error'])).not.toContain('rc_key');
+  });
+
+  it('does not cache failures', async () => {
+    mockContext
+      .mockRejectedValueOnce(new RentCastError('unknown', 'boom'))
+      .mockResolvedValueOnce(CONTEXT);
+
+    expect((await post(base, VALID_BODY)).status).toBe(502);
+    const second = await (await post(base, VALID_BODY)).json() as Record<string, unknown>;
+    expect(second['cached']).toBe(false);
+    expect(mockContext).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/rentcast/src/client.ts
+++ b/packages/rentcast/src/client.ts
@@ -1,23 +1,5 @@
-import { RentCastError, type PropertyData, type RentCastErrorCode } from './types';
-
-const BASE = 'https://api.rentcast.io/v1';
-
-function statusToCode(status: number): RentCastErrorCode {
-  if (status === 401 || status === 403) return 'bad_key';
-  if (status === 404) return 'not_found';
-  if (status === 429) return 'rate_limit';
-  return 'unknown';
-}
-
-async function rcGet(path: string, apiKey: string): Promise<unknown> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
-  });
-  if (!res.ok) {
-    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path.split('?')[0]}`);
-  }
-  return res.json() as Promise<unknown>;
-}
+import { RentCastError, type PropertyData } from './types';
+import { rcGet } from './http';
 
 function ensureRentCastError(reason: unknown): RentCastError {
   if (reason instanceof RentCastError) return reason;

--- a/packages/rentcast/src/context.ts
+++ b/packages/rentcast/src/context.ts
@@ -1,0 +1,150 @@
+/**
+ * E7 — supporting context: comps & history (RPE-49)
+ *
+ * Fetches and normalizes read-only supporting data for a deal: rent
+ * comps, sale comps, tax history, and price history. Everything here is
+ * best-effort — each upstream piece that fails or is missing yields an
+ * empty array; the call as a whole throws only when ALL THREE upstream
+ * requests fail (nothing useful to show).
+ *
+ * This data is surfaced next to the deal as context and used to judge
+ * confidence — it is never auto-applied to inputs.
+ *
+ * FIELD NAME VERIFICATION: comparables/history field names follow
+ * https://developers.rentcast.io/reference — verify against a live call
+ * before relying on them in production.
+ */
+
+import { RentCastError } from './types';
+import { rcGet } from './http';
+
+const COMP_COUNT = 5;
+
+export interface CompRecord {
+  address: string | null;
+  /** Sale price for sale comps; monthly rent for rent comps. */
+  price: number;
+  distanceMiles: number | null;
+  sqft: number | null;
+  bedrooms: number | null;
+}
+
+export interface TaxYearRecord {
+  year: number;
+  total: number;
+}
+
+export interface PriceEventRecord {
+  /** ISO-ish date string as provided by the API. */
+  date: string;
+  event: string | null;
+  price: number;
+}
+
+export interface PropertyContext {
+  rentComps: CompRecord[];
+  saleComps: CompRecord[];
+  taxHistory: TaxYearRecord[];
+  priceHistory: PriceEventRecord[];
+}
+
+// ─── Normalizers (defensive against shape drift) ──────────────────────────────
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+/** AVM responses carry `comparables: [{ formattedAddress, price, distance, squareFootage, bedrooms }]`. */
+function extractComps(avmResponse: unknown): CompRecord[] {
+  const root = asRecord(avmResponse);
+  const comparables = root?.['comparables'];
+  if (!Array.isArray(comparables)) return [];
+  const comps: CompRecord[] = [];
+  for (const raw of comparables) {
+    const c = asRecord(raw);
+    if (c === null) continue;
+    const price = num(c['price']);
+    if (price === null || price <= 0) continue;
+    comps.push({
+      address: str(c['formattedAddress']) ?? str(c['addressLine1']),
+      price,
+      distanceMiles: num(c['distance']),
+      sqft: num(c['squareFootage']),
+      bedrooms: num(c['bedrooms']),
+    });
+  }
+  return comps;
+}
+
+/** /properties propertyTaxes: { "2023": { total: 4210 }, ... } → sorted oldest→newest. */
+function extractTaxHistory(propertiesResponse: unknown): TaxYearRecord[] {
+  const first = Array.isArray(propertiesResponse) ? asRecord(propertiesResponse[0]) : null;
+  const taxes = asRecord(first?.['propertyTaxes']);
+  if (taxes === null) return [];
+  const records: TaxYearRecord[] = [];
+  for (const [yearKey, entry] of Object.entries(taxes)) {
+    const year = Number(yearKey);
+    const total = num(asRecord(entry)?.['total']);
+    if (Number.isInteger(year) && total !== null) records.push({ year, total });
+  }
+  return records.sort((a, b) => a.year - b.year);
+}
+
+/** /properties history: { "2021-06-01": { event: 'Sale', price: 300000 }, ... } → sorted by date. */
+function extractPriceHistory(propertiesResponse: unknown): PriceEventRecord[] {
+  const first = Array.isArray(propertiesResponse) ? asRecord(propertiesResponse[0]) : null;
+  const history = asRecord(first?.['history']);
+  if (history === null) return [];
+  const events: PriceEventRecord[] = [];
+  for (const [date, entry] of Object.entries(history)) {
+    const e = asRecord(entry);
+    const price = num(e?.['price']);
+    if (price === null) continue;
+    events.push({ date, event: str(e?.['event']), price });
+  }
+  return events.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+// ─── Entry point ──────────────────────────────────────────────────────────────
+
+/**
+ * Fetch comps + history for an address. Partial results are normal;
+ * throws (first failure's RentCastError) only when all three upstream
+ * calls fail.
+ */
+export async function fetchPropertyContext(
+  address: string,
+  apiKey: string,
+): Promise<PropertyContext> {
+  const encoded = encodeURIComponent(address);
+
+  const [value, rent, props] = await Promise.allSettled([
+    rcGet(`/avm/value?address=${encoded}&compCount=${COMP_COUNT}`, apiKey),
+    rcGet(`/avm/rent/long-term?address=${encoded}&compCount=${COMP_COUNT}`, apiKey),
+    rcGet(`/properties?address=${encoded}&limit=1`, apiKey),
+  ]);
+
+  if (value.status === 'rejected' && rent.status === 'rejected' && props.status === 'rejected') {
+    const reason = value.reason;
+    throw reason instanceof RentCastError
+      ? reason
+      : new RentCastError('unknown', 'RentCast context fetch failed');
+  }
+
+  return {
+    saleComps: value.status === 'fulfilled' ? extractComps(value.value) : [],
+    rentComps: rent.status === 'fulfilled' ? extractComps(rent.value) : [],
+    taxHistory: props.status === 'fulfilled' ? extractTaxHistory(props.value) : [],
+    priceHistory: props.status === 'fulfilled' ? extractPriceHistory(props.value) : [],
+  };
+}

--- a/packages/rentcast/src/http.ts
+++ b/packages/rentcast/src/http.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared RentCast HTTP plumbing (internal — not exported from the package).
+ */
+
+import { RentCastError, type RentCastErrorCode } from './types';
+
+export const BASE = 'https://api.rentcast.io/v1';
+
+export function statusToCode(status: number): RentCastErrorCode {
+  if (status === 401 || status === 403) return 'bad_key';
+  if (status === 404) return 'not_found';
+  if (status === 429) return 'rate_limit';
+  return 'unknown';
+}
+
+export async function rcGet(path: string, apiKey: string): Promise<unknown> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { 'X-Api-Key': apiKey, Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    throw new RentCastError(statusToCode(res.status), `RentCast ${res.status}: ${path.split('?')[0]}`);
+  }
+  return res.json() as Promise<unknown>;
+}

--- a/packages/rentcast/src/index.ts
+++ b/packages/rentcast/src/index.ts
@@ -1,3 +1,10 @@
 export { fetchPropertyData } from './client';
+export { fetchPropertyContext } from './context';
+export type {
+  CompRecord,
+  PriceEventRecord,
+  PropertyContext,
+  TaxYearRecord,
+} from './context';
 export { RentCastError } from './types';
 export type { PropertyData, RentCastErrorCode } from './types';

--- a/packages/rentcast/tests/context.test.ts
+++ b/packages/rentcast/tests/context.test.ts
@@ -1,0 +1,139 @@
+/**
+ * RPE-49: fetchPropertyContext tests — comps & history normalization.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchPropertyContext, RentCastError } from '../src/index';
+
+function mockOk(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function mockErr(status: number): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message: `HTTP ${status}` }),
+  } as unknown as Response;
+}
+
+const VALUE_RESPONSE = {
+  price: 342_000,
+  comparables: [
+    { formattedAddress: '125 Main St, Austin, TX', price: 350_000, distance: 0.3, squareFootage: 1_510, bedrooms: 3 },
+    { formattedAddress: '12 Oak Dr, Austin, TX', price: 332_500, distance: 0.8, squareFootage: 1_420, bedrooms: 3 },
+    { price: -5 }, // implausible — dropped
+    'garbage',     // malformed — dropped
+  ],
+};
+
+const RENT_RESPONSE = {
+  rent: 2_150,
+  comparables: [
+    { formattedAddress: '127 Main St, Austin, TX', price: 2_100, distance: 0.2, squareFootage: 1_450, bedrooms: 3 },
+  ],
+};
+
+const PROPERTIES_RESPONSE = [
+  {
+    squareFootage: 1_480,
+    propertyTaxes: {
+      '2022': { total: 3_980 },
+      '2023': { total: 4_210 },
+      '2021': { total: 3_750 },
+      bogus: { total: 1 }, // non-year key — dropped
+    },
+    history: {
+      '2018-05-12': { event: 'Sale', price: 265_000 },
+      '2009-03-02': { event: 'Sale', price: 187_000 },
+      '2018-01-01': { price: 259_000 }, // no event label — kept, event null
+      '2020-01-01': { event: 'Listing' }, // no price — dropped
+    },
+  },
+];
+
+describe('fetchPropertyContext', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes comps, tax history (sorted), and price history (sorted)', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockOk(VALUE_RESPONSE))
+      .mockResolvedValueOnce(mockOk(RENT_RESPONSE))
+      .mockResolvedValueOnce(mockOk(PROPERTIES_RESPONSE));
+
+    const ctx = await fetchPropertyContext('123 Main St, Austin TX', 'rc_key');
+
+    expect(ctx.saleComps).toHaveLength(2);
+    expect(ctx.saleComps[0]).toEqual({
+      address: '125 Main St, Austin, TX',
+      price: 350_000,
+      distanceMiles: 0.3,
+      sqft: 1_510,
+      bedrooms: 3,
+    });
+    expect(ctx.rentComps).toHaveLength(1);
+    expect(ctx.rentComps[0]?.price).toBe(2_100);
+
+    expect(ctx.taxHistory).toEqual([
+      { year: 2021, total: 3_750 },
+      { year: 2022, total: 3_980 },
+      { year: 2023, total: 4_210 },
+    ]);
+    expect(ctx.priceHistory.map((e) => e.date)).toEqual(['2009-03-02', '2018-01-01', '2018-05-12']);
+    expect(ctx.priceHistory[1]).toEqual({ date: '2018-01-01', event: null, price: 259_000 });
+  });
+
+  it('requests comps from both AVM endpoints', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockOk({}));
+    await fetchPropertyContext('123 Main St', 'rc_key');
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/avm/value') && u.includes('compCount=5'))).toBe(true);
+    expect(urls.some((u) => u.includes('/avm/rent/long-term') && u.includes('compCount=5'))).toBe(true);
+  });
+
+  it('degrades to empty arrays for individual upstream failures', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockErr(500))                  // value fails
+      .mockResolvedValueOnce(mockOk(RENT_RESPONSE))         // rent ok
+      .mockResolvedValueOnce(mockErr(404));                 // properties 404
+
+    const ctx = await fetchPropertyContext('123 Main St', 'rc_key');
+
+    expect(ctx.saleComps).toEqual([]);
+    expect(ctx.rentComps).toHaveLength(1);
+    expect(ctx.taxHistory).toEqual([]);
+    expect(ctx.priceHistory).toEqual([]);
+  });
+
+  it('throws the first RentCastError only when all three calls fail', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockErr(401))
+      .mockResolvedValueOnce(mockErr(401))
+      .mockResolvedValueOnce(mockErr(401));
+
+    await expect(fetchPropertyContext('123 Main St', 'rc_key')).rejects.toMatchObject({
+      name: 'RentCastError',
+      code: 'bad_key',
+    });
+  });
+
+  it('tolerates AVM responses without comparables', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockOk({ price: 342_000 }))
+      .mockResolvedValueOnce(mockOk({ rent: 2_150 }))
+      .mockResolvedValueOnce(mockOk([{}]));
+
+    const ctx = await fetchPropertyContext('123 Main St', 'rc_key');
+    expect(ctx).toEqual({ saleComps: [], rentComps: [], taxHistory: [], priceHistory: [] });
+  });
+
+  it('exports RentCastError consistently for instanceof checks', () => {
+    expect(new RentCastError('unknown', 'x')).toBeInstanceOf(Error);
+  });
+});


### PR DESCRIPTION
## Summary
- `@rpe/rentcast` `fetchPropertyContext()`: rent/sale comps (AVM `comparables`, compCount=5), tax history (sorted by year), price history (sorted by date) — defensively normalized; each piece degrades to an empty array, throwing only when all three upstream calls fail
- `POST /property/context`: cached (key-scoped normalized address) and cost-gated — **shares the /property limiter instance**, so property + context lookups draw one provider-call budget per client; same typed error envelope
- Read-only supporting context per the ticket — never auto-applied to inputs
- 13 new tests; shared `rcGet`/`statusToCode` extracted to `http.ts` (DRY, self-review round 1)

## Review
Copilot unavailable; strict self-review loop — round 1: HTTP-plumbing duplication extracted; round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 767 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)