### PR TITLE
RPE-51: scrape fallback — flag-gated, SSRF-contained, low-confidence

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -51,6 +51,7 @@ import {
   type ContextSuccessBody,
 } from './routes/propertyContext.js';
 import { handleRegion } from './routes/region.js';
+import { handleScrape, type ScrapeDeps, type ScrapeSuccessBody } from './routes/scrape.js';
 import { RateLimiter, TtlCache } from './services/guardrails.js';
 
 // Hoist __filename/__dirname for use in VERSION and the entry-point guard below.
@@ -357,6 +358,14 @@ export interface AppConfig {
     rpm?: number;
     dailyCap?: number;
   };
+  /** /scrape fallback (RPE-51). OFF unless RPE_SCRAPE_ENABLED=1/true —
+   * enabling in production is a product/legal call. Env: RPE_SCRAPE_RPM
+   * (default 5), RPE_SCRAPE_DAILY_CAP (default 50). */
+  scrape?: {
+    enabled?: boolean;
+    rpm?: number;
+    dailyCap?: number;
+  };
 }
 
 function envInt(name: string, fallback: number): number {
@@ -384,6 +393,19 @@ export function createApp(config: AppConfig = {}) {
       config.property?.cacheTtlMs ?? envInt('RPE_PROPERTY_CACHE_TTL_MS', 24 * 60 * 60 * 1000),
     ),
     limiter: propertyDeps.limiter,
+  };
+
+  const scrapeDeps: ScrapeDeps = {
+    enabled:
+      config.scrape?.enabled ??
+      ['1', 'true'].includes((process.env['RPE_SCRAPE_ENABLED'] ?? '').toLowerCase()),
+    cache: new TtlCache<ScrapeSuccessBody>(
+      config.property?.cacheTtlMs ?? envInt('RPE_PROPERTY_CACHE_TTL_MS', 24 * 60 * 60 * 1000),
+    ),
+    limiter: new RateLimiter(
+      config.scrape?.rpm ?? envInt('RPE_SCRAPE_RPM', 5),
+      config.scrape?.dailyCap ?? envInt('RPE_SCRAPE_DAILY_CAP', 50),
+    ),
   };
 
   // Address geometry does not move — geocode answers cache on the same
@@ -426,6 +448,8 @@ export function createApp(config: AppConfig = {}) {
         ? () => handleRegion(req, res, json)
         : url === '/geocode' || url === '/geocode/'
         ? () => handleGeocode(req, res, json, geocodeDeps)
+        : url === '/scrape' || url === '/scrape/'
+        ? () => handleScrape(req, res, json, readBody, scrapeDeps)
         : () => {
             json(res, 404, { error: `Unknown endpoint: ${url}` });
             return Promise.resolve();

--- a/apps/api/src/routes/scrape.ts
+++ b/apps/api/src/routes/scrape.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /scrape — flag-gated listing-page scrape fallback (RPE-51)
+ *
+ * OFF by default (RPE_SCRAPE_ENABLED). Scraping listing sites violates
+ * their ToS and is anti-bot-fragile — enabling this in production is a
+ * product/legal decision, not a technical one. The route exists so the
+ * tiered resolver has a complete chain when that call is made.
+ *
+ * Receives { url: string } and returns:
+ *   200 { lookup: PropertyLookup, cached: boolean }
+ *   403 { error, code: 'scrape_disabled' }   — flag off
+ *   400 { error, code: 'bad_request' }       — missing/invalid/non-allowlisted URL
+ *   429 { error, code: 'proxy_rate_limit' }
+ *   502 { error, code: 'upstream_error' }    — page unreachable/empty
+ *
+ * Containment:
+ *   - SSRF: only https URLs whose hostname is one of the five supported
+ *     listing hosts are ever fetched — never an open proxy
+ *   - every parsed field is forced to source 'scrape' / confidence 'low'
+ *     ("unverified source") regardless of what the heuristics report
+ *   - isolated path: nothing on /property depends on this route
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { parseListingText, type PropertyLookup } from '@rpe/property';
+import { fetchListingPageText, isAllowedListingUrl } from '../services/scrapePage.js';
+import { clientIp, type RateLimiter, type TtlCache } from '../services/guardrails.js';
+
+type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
+type ReadBodyFn = (req: IncomingMessage) => Promise<string>;
+
+export interface ScrapeSuccessBody {
+  lookup: PropertyLookup;
+  cached: boolean;
+}
+
+export interface ScrapeDeps {
+  enabled: boolean;
+  cache: TtlCache<ScrapeSuccessBody>;
+  limiter: RateLimiter;
+}
+
+/** Force every field to the unverified-source label, whatever the heuristics said. */
+function forceLowConfidence(lookup: PropertyLookup): PropertyLookup {
+  const result: PropertyLookup = {};
+  for (const [key, field] of Object.entries(lookup)) {
+    if (field === undefined) continue;
+    result[key as keyof PropertyLookup] = {
+      ...field,
+      source: 'scrape',
+      confidence: 'low',
+    };
+  }
+  return result;
+}
+
+export async function handleScrape(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: JsonFn,
+  readBody: ReadBodyFn,
+  deps: ScrapeDeps,
+): Promise<void> {
+  if (!deps.enabled) {
+    json(res, 403, {
+      error: 'Scrape fallback is disabled on this server.',
+      code: 'scrape_disabled',
+    });
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed — use POST', code: 'method_not_allowed' });
+    return;
+  }
+
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to read request body';
+    const tooLarge = msg === 'Payload too large';
+    json(res, tooLarge ? 413 : 400, { error: msg, code: tooLarge ? 'payload_too_large' : 'bad_request' });
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    json(res, 400, { error: 'Invalid JSON', code: 'bad_request' });
+    return;
+  }
+  const obj = (typeof parsed === 'object' && parsed !== null ? parsed : {}) as Record<string, unknown>;
+  const rawUrl = typeof obj['url'] === 'string' ? obj['url'].trim() : '';
+  if (rawUrl === '') {
+    json(res, 400, { error: 'url is required and must be a non-empty string', code: 'bad_request' });
+    return;
+  }
+
+  // SSRF containment: https + supported listing hosts only
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    json(res, 400, { error: 'url must be a valid absolute URL', code: 'bad_request' });
+    return;
+  }
+  if (!isAllowedListingUrl(url)) {
+    json(res, 400, {
+      error: 'url must be an https listing page on a supported host',
+      code: 'bad_request',
+    });
+    return;
+  }
+
+  const cacheKey = url.toString();
+  const hit = deps.cache.get(cacheKey);
+  if (hit !== undefined) {
+    json(res, 200, { ...hit, cached: true });
+    return;
+  }
+
+  const decision = deps.limiter.check(clientIp(req));
+  if (!decision.allowed) {
+    json(res, 429, {
+      error: 'Too many scrape requests from this client — try again later.',
+      code: 'proxy_rate_limit',
+      retryAfterSec: decision.retryAfterSec,
+    });
+    return;
+  }
+
+  const text = await fetchListingPageText(url.toString());
+  if (text === null || text === '') {
+    json(res, 502, { error: 'Listing page could not be fetched.', code: 'upstream_error' });
+    return;
+  }
+
+  const lookup = forceLowConfidence(parseListingText(text));
+  const success: ScrapeSuccessBody = { lookup, cached: false };
+  deps.cache.set(cacheKey, success);
+  json(res, 200, success);
+}

--- a/apps/api/src/services/scrapePage.ts
+++ b/apps/api/src/services/scrapePage.ts
@@ -1,0 +1,79 @@
+/**
+ * E7 — listing-page fetch + text extraction (RPE-51)
+ *
+ * Server-side, best-effort, ToS-caveated — only ever invoked behind the
+ * RPE_SCRAPE_ENABLED flag (OFF by default; enabling in production is a
+ * product/legal call, see the route).
+ *
+ * SSRF containment lives in the route (host allowlist); this service
+ * additionally enforces https and bounds size/time so a hostile or
+ * misbehaving page cannot wedge the proxy.
+ */
+
+const SCRAPE_TIMEOUT_MS = 10_000;
+const MAX_HTML_BYTES = 2 * 1024 * 1024; // 2 MB
+
+/** The only hosts this service will ever fetch — SSRF containment. */
+const ALLOWED_LISTING_HOSTS = [
+  /(^|\.)zillow\.com$/,
+  /(^|\.)redfin\.com$/,
+  /(^|\.)realtor\.com$/,
+  /(^|\.)trulia\.com$/,
+  /(^|\.)homes\.com$/,
+];
+
+/** True only for https URLs on a supported listing host. */
+export function isAllowedListingUrl(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase();
+  return url.protocol === 'https:' && ALLOWED_LISTING_HOSTS.some((p) => p.test(hostname));
+}
+
+/** Strip a fetched HTML document down to whitespace-collapsed text. */
+export function htmlToText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&#0?36;/g, '$')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#0?39;|&apos;/gi, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Fetch a listing page and return its text content, or null on any
+ * failure (timeout, HTTP error, non-https). Never throws.
+ */
+export async function fetchListingPageText(url: string): Promise<string | null> {
+  try {
+    const parsed = new URL(url);
+    if (!isAllowedListingUrl(parsed)) return null;
+    const res = await fetch(parsed.toString(), {
+      signal: AbortSignal.timeout(SCRAPE_TIMEOUT_MS),
+      headers: { Accept: 'text/html' },
+      redirect: 'follow',
+    });
+    // Redirects are followed — re-validate the FINAL url so an
+    // allowlisted page can never bounce this fetch to an internal or
+    // third-party address (SSRF via redirect)
+    if (res.url !== '' && !isAllowedListingUrl(new URL(res.url))) {
+      console.error('Scrape fetch redirected off-allowlist; dropping. Final host:', new URL(res.url).hostname);
+      return null;
+    }
+    if (!res.ok) {
+      console.error(`Scrape fetch HTTP ${res.status} for host:`, parsed.hostname);
+      return null;
+    }
+    const html = await res.text();
+    return htmlToText(html.slice(0, MAX_HTML_BYTES));
+  } catch (err) {
+    console.error('Scrape fetch failed:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}

--- a/apps/api/tests/scrape.test.ts
+++ b/apps/api/tests/scrape.test.ts
@@ -1,0 +1,183 @@
+/**
+ * RPE-51: POST /scrape route tests.
+ *
+ * Mocks the scrapePage service module so no listing site is ever hit;
+ * htmlToText is unit-tested with the real implementation in a separate
+ * import (it is pure).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { fetchListingPageText } from '../src/services/scrapePage.js';
+
+vi.mock('../src/services/scrapePage.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/services/scrapePage.js')>();
+  return { ...original, fetchListingPageText: vi.fn() };
+});
+
+const mockFetchPage = vi.mocked(fetchListingPageText);
+
+const LISTING_TEXT =
+  '$342,000 3 bd 2 ba 1,480 sqft 123 Main St Austin TX 78701 Built in 1987 Rent estimate: $2,150/mo';
+
+const ZILLOW_URL = 'https://www.zillow.com/homedetails/123-Main-St-Austin-TX-78701/29381742_zpid/';
+
+function startServer(config?: Parameters<typeof createApp>[0]): Promise<{ server: Server; base: string }> {
+  return new Promise((resolve, reject) => {
+    const server = createApp(config ?? { scrape: { enabled: true, rpm: 1000, dailyCap: 10000 } });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const addr = server.address() as { port: number };
+      resolve({ server, base: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+function post(base: string, body: unknown) {
+  return fetch(`${base}/scrape`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /scrape', () => {
+  let server: Server | undefined;
+  let base: string;
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const s = await startServer();
+    server = s.server;
+    base = s.base;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it('is disabled by default — 403 scrape_disabled without touching the page service', async () => {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    const s = await startServer({});
+    server = s.server;
+
+    const res = await post(s.base, { url: ZILLOW_URL });
+    expect(res.status).toBe(403);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['code']).toBe('scrape_disabled');
+    expect(mockFetchPage).not.toHaveBeenCalled();
+  });
+
+  it('parses the fetched page and forces source scrape / confidence low', async () => {
+    mockFetchPage.mockResolvedValue(LISTING_TEXT);
+
+    const res = await post(base, { url: ZILLOW_URL });
+    const body = await res.json() as { lookup: Record<string, { value: number; source: string; confidence: string }> };
+
+    expect(res.status).toBe(200);
+    expect(body.lookup['purchasePrice']?.value).toBe(342_000);
+    // grossRent parses as medium from the heuristics — the route must demote it
+    expect(Object.values(body.lookup).every((f) => f.source === 'scrape' && f.confidence === 'low')).toBe(true);
+  });
+
+  it('rejects non-allowlisted hosts and non-https URLs (SSRF containment)', async () => {
+    for (const url of [
+      'https://evil.example.com/homedetails/x/1_zpid/',
+      'https://zillow.com.evil.io/homedetails/x/1_zpid/',
+      'http://www.zillow.com/homedetails/x/1_zpid/',
+      'https://localhost:3001/admin',
+      'https://169.254.169.254/latest/meta-data/',
+      'not a url',
+    ]) {
+      const res = await post(base, { url });
+      expect(res.status, url).toBe(400);
+    }
+    expect(mockFetchPage).not.toHaveBeenCalled();
+  });
+
+  it('serves repeats from cache without re-fetching', async () => {
+    mockFetchPage.mockResolvedValue(LISTING_TEXT);
+    await post(base, { url: ZILLOW_URL });
+    const second = await (await post(base, { url: ZILLOW_URL })).json() as Record<string, unknown>;
+    expect(second['cached']).toBe(true);
+    expect(mockFetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('rate limits page-bound requests with the typed envelope', async () => {
+    await new Promise<void>((resolve, reject) => {
+      server?.close((err) => (err ? reject(err) : resolve()));
+    });
+    const s = await startServer({ property: { cacheTtlMs: 0 }, scrape: { enabled: true, rpm: 1, dailyCap: 100 } });
+    server = s.server;
+    mockFetchPage.mockResolvedValue(LISTING_TEXT);
+
+    expect((await post(s.base, { url: ZILLOW_URL })).status).toBe(200);
+    const limited = await post(s.base, { url: `${ZILLOW_URL}?x=2` });
+    expect(limited.status).toBe(429);
+    const body = await limited.json() as Record<string, unknown>;
+    expect(body['code']).toBe('proxy_rate_limit');
+  });
+
+  it('returns 502 and does not cache when the page cannot be fetched', async () => {
+    mockFetchPage.mockResolvedValueOnce(null).mockResolvedValueOnce(LISTING_TEXT);
+
+    expect((await post(base, { url: ZILLOW_URL })).status).toBe(502);
+    const second = await (await post(base, { url: ZILLOW_URL })).json() as Record<string, unknown>;
+    expect(second['cached']).toBe(false);
+    expect(mockFetchPage).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('fetchListingPageText — redirect SSRF containment', () => {
+  it('drops a response whose final URL left the allowlist', async () => {
+    const { fetchListingPageText: realFetchPage } = await vi.importActual<
+      typeof import('../src/services/scrapePage.js')
+    >('../src/services/scrapePage.js');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: 'https://internal.attacker.example/payload',
+      text: () => Promise.resolve('<html>$342,000</html>'),
+    } as unknown as Response);
+
+    const result = await realFetchPage('https://www.zillow.com/homedetails/x/1_zpid/');
+    expect(result).toBeNull();
+  });
+
+  it('accepts a redirect that stays on an allowlisted host', async () => {
+    const { fetchListingPageText: realFetchPage } = await vi.importActual<
+      typeof import('../src/services/scrapePage.js')
+    >('../src/services/scrapePage.js');
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: 'https://www.zillow.com/homedetails/x-renamed/1_zpid/',
+      text: () => Promise.resolve('<html>List price: $342,000</html>'),
+    } as unknown as Response);
+
+    const result = await realFetchPage('https://www.zillow.com/homedetails/x/1_zpid/');
+    expect(result).toContain('$342,000');
+  });
+});
+
+describe('htmlToText', () => {
+  it('strips scripts, styles, comments and tags; decodes common entities', async () => {
+    const { htmlToText } = await vi.importActual<typeof import('../src/services/scrapePage.js')>(
+      '../src/services/scrapePage.js',
+    );
+    const html = `
+      <html><head><style>.x{color:red}</style><script>var a=1;</script></head>
+      <body><!-- hidden --><h1>List price:</h1> <span>&#36;342,000</span>
+      <p>3&nbsp;bd &amp; 2 ba</p></body></html>`;
+    expect(htmlToText(html)).toBe('List price: $342,000 3 bd & 2 ba');
+  });
+});

--- a/packages/property/src/index.ts
+++ b/packages/property/src/index.ts
@@ -30,6 +30,7 @@ export {
 
 export { parseListingText } from './pasteText';
 export { createPasteTextProvider } from './providers/pasteTextProvider';
+export { createScrapeProxyProvider, type ScrapeProxyOptions } from './providers/scrapeProxy';
 
 export {
   mapLookupToDealInputs,

--- a/packages/property/src/providers/scrapeProxy.ts
+++ b/packages/property/src/providers/scrapeProxy.ts
@@ -1,0 +1,78 @@
+/**
+ * E7 — scrape-tier PropertyProvider (RPE-51)
+ *
+ * Calls the flag-gated POST /scrape proxy. Doubly gated: the provider is
+ * constructed with enabled=false by default (supports() refuses), and
+ * the server returns 403 scrape_disabled unless its own flag is on.
+ * Results arrive pre-labeled source 'scrape' / confidence 'low'
+ * (unverified source) by the route.
+ */
+
+import type { LookupRequest, PropertyLookup, PropertyProvider } from '../types';
+import { ProviderError } from './rentcastProxy';
+
+export interface ScrapeProxyOptions {
+  apiUrl: string;
+  /** OFF by default — enabling scrape is a product/legal call. */
+  enabled?: boolean;
+}
+
+interface ScrapeSuccess {
+  lookup?: PropertyLookup;
+}
+
+interface ScrapeError {
+  error?: string;
+  code?: string;
+}
+
+export function createScrapeProxyProvider(options: ScrapeProxyOptions): PropertyProvider {
+  const base = options.apiUrl.replace(/\/+$/, '');
+  const enabled = options.enabled ?? false;
+  return {
+    id: 'scrape',
+    tier: 'scrape',
+    supports(request: LookupRequest): boolean {
+      return enabled && (request.url?.trim() ?? '') !== '';
+    },
+    async lookup(request: LookupRequest): Promise<PropertyLookup> {
+      const url = request.url?.trim() ?? '';
+      if (!enabled || url === '') {
+        throw new ProviderError('bad_request', 'scrape provider disabled or no url');
+      }
+
+      let res: Response;
+      try {
+        res = await fetch(`${base}/scrape`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url }),
+        });
+      } catch (err) {
+        throw new ProviderError(
+          'network_error',
+          err instanceof Error ? err.message : 'scrape proxy unreachable',
+        );
+      }
+
+      if (!res.ok) {
+        let code = 'upstream_error';
+        let message = `scrape proxy HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as ScrapeError;
+          if (typeof body.code === 'string' && body.code !== '') code = body.code;
+          if (typeof body.error === 'string' && body.error !== '') message = body.error;
+        } catch {
+          // non-JSON error body
+        }
+        throw new ProviderError(code, message);
+      }
+
+      const body = (await res.json()) as ScrapeSuccess;
+      if (typeof body.lookup !== 'object' || body.lookup === null) {
+        throw new ProviderError('bad_response', 'scrape proxy returned no lookup');
+      }
+      return body.lookup;
+    },
+  };
+}

--- a/packages/property/tests/scrapeProxy.test.ts
+++ b/packages/property/tests/scrapeProxy.test.ts
@@ -1,0 +1,62 @@
+/**
+ * RPE-51: scrape-tier provider tests — global fetch spied (no local server).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createScrapeProxyProvider, type PropertyLookup } from '../src/index';
+
+const LOOKUP: PropertyLookup = {
+  purchasePrice: { value: 342_000, source: 'scrape', confidence: 'low' },
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+const URL_REQ = { url: 'https://www.zillow.com/homedetails/x/1_zpid/' };
+
+describe('createScrapeProxyProvider', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is disabled by default — supports() refuses even with a url', () => {
+    const p = createScrapeProxyProvider({ apiUrl: 'http://localhost:3001' });
+    expect(p.tier).toBe('scrape');
+    expect(p.supports(URL_REQ)).toBe(false);
+  });
+
+  it('supports url requests only when explicitly enabled', () => {
+    const p = createScrapeProxyProvider({ apiUrl: 'http://localhost:3001', enabled: true });
+    expect(p.supports(URL_REQ)).toBe(true);
+    expect(p.supports({ address: '123 Main St' })).toBe(false);
+  });
+
+  it('POSTs the url and returns the pre-labeled lookup', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(200, { lookup: LOOKUP, cached: false }),
+    );
+    const p = createScrapeProxyProvider({ apiUrl: 'http://localhost:3001/', enabled: true });
+
+    const result = await p.lookup(URL_REQ);
+
+    expect(result).toEqual(LOOKUP);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://localhost:3001/scrape',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('carries the scrape_disabled code through ProviderError', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(403, { error: 'Scrape fallback is disabled on this server.', code: 'scrape_disabled' }),
+    );
+    const p = createScrapeProxyProvider({ apiUrl: 'http://localhost:3001', enabled: true });
+
+    await expect(p.lookup(URL_REQ)).rejects.toMatchObject({ code: 'scrape_disabled' });
+  });
+});


### PR DESCRIPTION
## Summary
- `POST /scrape` (apps/api): OFF by default behind `RPE_SCRAPE_ENABLED` — 403 `scrape_disabled` otherwise; enabling in production is a product/legal decision per the ticket
- SSRF containment: https-only + five listing hosts only, and the **final post-redirect URL is re-validated** so an allowlisted page can never bounce the fetch to an internal/third-party address; 2 MB body cap, 10 s timeout
- Every parsed field forced to `source: 'scrape'` / `confidence: 'low'` ("unverified source") regardless of heuristic output — reuses RPE-52's `parseListingText` on stripped HTML
- Own tight guardrails (`RPE_SCRAPE_RPM=5`, `_DAILY_CAP=50`) + TTL cache; fully isolated from the primary `/property` path
- `createScrapeProxyProvider()` — scrape-tier provider, **doubly gated** (constructor `enabled:false` default + server flag)
- 13 new tests incl. host-allowlist battery (metadata IP, lookalike hosts, http) and redirect-SSRF cases

## Review
Copilot unavailable; strict self-review loop. Round 1 caught the redirect-SSRF residual (`redirect: 'follow'` + no final-URL check) — fixed with tests. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 780 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)