### PR TITLE
RPE-53: import UI — paste bar + review/override panel

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@rpe/engine": "workspace:*",
+    "@rpe/property": "workspace:*",
     "@rpe/region-defaults": "workspace:*"
   },
   "devDependencies": {

--- a/packages/ui/src/components/AutofillBar.tsx
+++ b/packages/ui/src/components/AutofillBar.tsx
@@ -1,6 +1,15 @@
+/**
+ * E7 — import bar (RPE-43d, extended into the paste/import bar in RPE-53)
+ *
+ * Accepts a street address OR a listing URL, with a collapsible
+ * "paste listing text" area as the zero-key fallback. Paste-only imports
+ * work without a RentCast key (local heuristics), so the bar stays
+ * functional even before Settings are configured.
+ */
+
 import { useState } from 'react';
 import { useAutofill } from '../hooks/useAutofill';
-import { AutofillPreviewPopover } from './AutofillPreviewPopover';
+import { AutofillPreviewPopover, type CurrentFormValues } from './AutofillPreviewPopover';
 import type { Dispatch } from 'react';
 import type { DealAction } from '../state/dealReducer';
 
@@ -8,90 +17,122 @@ interface AutofillBarProps {
   dispatch: Dispatch<DealAction>;
   apiKey: string | null;
   apiUrl?: string;
-  currentValues?: {
-    purchasePrice?: number | null;
-    grossRent?: number | null;
-    sqft?: number | null;
-    units?: number | null;
-    annualTaxes?: number | null;
-  };
+  /** Scrape tier opt-in — OFF by default (RPE-51 product/legal gate). */
+  scrapeEnabled?: boolean;
+  currentValues?: CurrentFormValues;
 }
 
-/**
- * Persistent address input bar rendered above the Acquisition section.
- * Wraps useAutofill — handles all four states: idle, loading, error, preview.
- *
- * When apiKey is null (user hasn't connected RentCast), shows a prompt
- * directing them to ⚙ Settings instead of the input.
- */
-export function AutofillBar({ dispatch, apiKey, apiUrl, currentValues }: AutofillBarProps) {
-  const [address, setAddress] = useState('');
-  const { status, previewData, errorMessage, trigger, apply, dismiss } = useAutofill({ dispatch, apiKey, apiUrl });
+export function AutofillBar({ dispatch, apiKey, apiUrl, scrapeEnabled, currentValues }: AutofillBarProps) {
+  const [input, setInput] = useState('');
+  const [pasteOpen, setPasteOpen] = useState(false);
+  const [pastedText, setPastedText] = useState('');
+  const { status, preview, errorMessage, trigger, apply, dismiss } = useAutofill({
+    dispatch,
+    apiKey,
+    apiUrl,
+    scrapeEnabled,
+  });
 
-  if (!apiKey) {
-    return (
-      <div className="px-5 py-3 border-b border-border bg-raised/50">
-        <p className="text-xs text-lo italic">
-          Connect RentCast in{' '}
-          <span className="text-mid not-italic">⚙ Settings</span>{' '}
-          to enable address autofill.
-        </p>
-      </div>
-    );
-  }
+  const busy = status === 'loading' || status === 'preview';
+  const canTrigger = input.trim() !== '' || pastedText.trim() !== '';
 
   const handleTrigger = () => {
-    if (address.trim()) trigger(address);
+    if (canTrigger) void trigger(input, pastedText);
+  };
+
+  const reset = () => {
+    setInput('');
+    setPastedText('');
+    setPasteOpen(false);
   };
 
   return (
     <div className="px-5 py-3 border-b border-border space-y-2">
       {/* Label */}
-      <p className="text-xs uppercase tracking-widest text-lo">⚡ Autofill from address</p>
+      <p className="text-xs uppercase tracking-widest text-lo">⚡ Import from address, listing URL, or pasted text</p>
+
+      {!apiKey && (
+        <p className="text-xs text-lo italic">
+          Connect RentCast in <span className="text-mid not-italic">⚙ Settings</span> for full
+          lookups — or paste the listing text below.
+        </p>
+      )}
 
       {/* Input row */}
       <div className="flex gap-2">
         <input
           type="text"
-          value={address}
-          onChange={(e) => setAddress(e.target.value)}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') handleTrigger(); }}
-          placeholder="123 Main St, Austin TX 78701"
-          disabled={status === 'loading' || status === 'preview'}
+          placeholder="123 Main St, Austin TX — or a Zillow/Redfin/… listing URL"
+          disabled={busy}
           className="
             flex-1 rounded border border-border bg-base px-3 py-1.5
             text-xs text-hi placeholder:text-lo
             focus:border-accent focus:outline-none
             disabled:opacity-50
           "
-          aria-label="Property address for autofill"
+          aria-label="Property address or listing URL for import"
         />
         <button
           type="button"
+          onClick={() => setPasteOpen((open) => !open)}
+          disabled={busy}
+          aria-expanded={pasteOpen}
+          className="
+            rounded border border-border px-3 py-1.5 text-xs text-mid
+            hover:border-accent hover:text-accent transition-colors
+            disabled:opacity-40
+          "
+        >
+          {pasteOpen ? 'Hide paste' : 'Paste text'}
+        </button>
+        <button
+          type="button"
           onClick={handleTrigger}
-          disabled={status === 'loading' || status === 'preview' || !address.trim()}
+          disabled={busy || !canTrigger}
           className="
             rounded border border-border px-3 py-1.5 text-xs text-mid uppercase tracking-widest
             hover:border-accent hover:text-accent transition-colors
             disabled:opacity-40 disabled:cursor-not-allowed
           "
-          aria-label={status === 'loading' ? 'Looking up property…' : 'Autofill from address'}
+          aria-label={status === 'loading' ? 'Importing property…' : 'Import property data'}
         >
-          {status === 'loading' ? '…' : 'Fill'}
+          {status === 'loading' ? '…' : 'Import'}
         </button>
       </div>
+
+      {/* Paste area */}
+      {pasteOpen && (
+        <textarea
+          value={pastedText}
+          onChange={(e) => setPastedText(e.target.value)}
+          placeholder="Paste the listing's copied text here — price, beds/baths, sqft, taxes are picked up automatically."
+          disabled={busy}
+          rows={4}
+          className="
+            w-full rounded border border-border bg-base px-3 py-1.5
+            text-xs text-hi placeholder:text-lo
+            focus:border-accent focus:outline-none
+            disabled:opacity-50
+          "
+          aria-label="Pasted listing text"
+        />
+      )}
 
       {/* Error message */}
       {status === 'error' && errorMessage && (
         <p className="text-xs text-red-400" role="alert">{errorMessage}</p>
       )}
 
-      {/* Preview popover */}
-      {status === 'preview' && previewData && (
+      {/* Review panel */}
+      {status === 'preview' && preview && (
         <AutofillPreviewPopover
-          data={previewData}
-          onApply={() => { apply(); setAddress(''); }}
-          onDismiss={() => { dismiss(); setAddress(''); }}
+          patches={preview.patches}
+          meta={preview.meta}
+          onApply={(selected) => { apply(selected); reset(); }}
+          onDismiss={() => { dismiss(); reset(); }}
           currentValues={currentValues}
         />
       )}

--- a/packages/ui/src/components/AutofillPreviewPopover.tsx
+++ b/packages/ui/src/components/AutofillPreviewPopover.tsx
@@ -1,6 +1,19 @@
-import { useEffect } from 'react';
+/**
+ * E7 — import review/override panel (RPE-53; evolved from the RPE-43d preview)
+ *
+ * Lists every patch the tiered import produced with its source badge,
+ * confidence chip, and an accept checkbox. Selection defaults encode the
+ * never-silently-overwrite contract:
+ *   - needs-review (low confidence) rows start UNCHECKED
+ *   - rows that would overwrite a non-empty, differing current value
+ *     start UNCHECKED (explicit confirm)
+ *   - everything else starts checked
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import type { DealInputPatch, DealPatchTarget, MappedLookup } from '@rpe/property';
 import { fmtCurrency } from '../utils/format';
-import type { PropertyData } from '../hooks/useAutofill';
+import { DEFAULT_INPUTS } from '../state/defaultInputs';
 
 export interface CurrentFormValues {
   purchasePrice?: number | null;
@@ -8,27 +21,75 @@ export interface CurrentFormValues {
   sqft?: number | null;
   units?: number | null;
   annualTaxes?: number | null;
+  annualInsurance?: number | null;
 }
 
 interface AutofillPreviewPopoverProps {
-  data: PropertyData;
-  onApply: () => void;
+  patches: DealInputPatch[];
+  meta: MappedLookup['meta'];
+  onApply: (selected: ReadonlySet<DealPatchTarget>) => void;
   onDismiss: () => void;
   currentValues?: CurrentFormValues;
 }
 
-interface DiffRow {
-  label: string;
-  currentValue: string;
-  value: string;
+const TARGET_LABELS: Record<DealPatchTarget, string> = {
+  purchasePrice: 'Purchase Price',
+  grossRent: 'Gross Rent (mo)',
+  sqft: 'Square Footage',
+  units: 'Units',
+  'expenses.taxes': 'Property Taxes (yr)',
+  'expenses.insurance': 'Insurance (yr)',
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  rentcast: 'RentCast',
+  scrape: 'Scraped — unverified',
+  paste: 'Pasted text',
+};
+
+function currentFor(target: DealPatchTarget, cur: CurrentFormValues): number | null | undefined {
+  switch (target) {
+    case 'purchasePrice': return cur.purchasePrice;
+    case 'grossRent': return cur.grossRent;
+    case 'sqft': return cur.sqft;
+    case 'units': return cur.units;
+    case 'expenses.taxes': return cur.annualTaxes;
+    case 'expenses.insurance': return cur.annualInsurance;
+  }
 }
 
-/**
- * Shows incoming RentCast values alongside current form values.
- * All non-null RentCast fields are listed (not filtered to changed-only).
- * Dismiss on Escape or Cancel; apply on Apply.
- */
-export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues }: AutofillPreviewPopoverProps) {
+/** App default for a target — a current value still at its default was
+ * never edited by the user, so importing over it is not an overwrite. */
+function defaultFor(target: DealPatchTarget): number | undefined {
+  switch (target) {
+    case 'purchasePrice': return DEFAULT_INPUTS.purchasePrice;
+    case 'grossRent': return DEFAULT_INPUTS.grossRent;
+    case 'sqft': return DEFAULT_INPUTS.sqft;
+    case 'units': return DEFAULT_INPUTS.units;
+    case 'expenses.taxes': return DEFAULT_INPUTS.expenses.taxes.amount;
+    case 'expenses.insurance': return DEFAULT_INPUTS.expenses.insurance?.amount;
+  }
+}
+
+function fmtValue(target: DealPatchTarget, amount: number): string {
+  if (target === 'sqft') return `${amount.toLocaleString()} sqft`;
+  if (target === 'units') return String(amount);
+  return fmtCurrency(amount);
+}
+
+function confidenceClasses(confidence: DealInputPatch['confidence']): string {
+  if (confidence === 'high') return 'text-green-400 border-green-400/40';
+  if (confidence === 'medium') return 'text-amber-300 border-amber-300/40';
+  return 'text-red-400 border-red-400/40';
+}
+
+export function AutofillPreviewPopover({
+  patches,
+  meta,
+  onApply,
+  onDismiss,
+  currentValues,
+}: AutofillPreviewPopoverProps) {
   // Dismiss on Escape
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -38,49 +99,100 @@ export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues
     return () => window.removeEventListener('keydown', handler);
   }, [onDismiss]);
 
-  const cur = currentValues ?? {};
-  const fmtCurrent = (v: number | null | undefined, fmt: (n: number) => string) =>
-    v != null ? fmt(v) : '—';
+  const cur = useMemo(() => currentValues ?? {}, [currentValues]);
 
-  const rows: DiffRow[] = [
-    { label: 'Purchase Price',    currentValue: fmtCurrent(cur.purchasePrice, fmtCurrency),     value: fmtCurrency(data.purchasePrice) },
-    { label: 'Gross Rent (mo)',   currentValue: fmtCurrent(cur.grossRent, fmtCurrency),         value: fmtCurrency(data.grossRent) },
-    ...(data.annualTaxes !== null
-      ? [{ label: 'Property Taxes (yr)', currentValue: fmtCurrent(cur.annualTaxes, fmtCurrency), value: fmtCurrency(data.annualTaxes) }]
-      : []),
-    ...(data.sqft !== null
-      ? [{ label: 'Square Footage', currentValue: fmtCurrent(cur.sqft, n => `${n.toLocaleString()} sqft`), value: `${data.sqft.toLocaleString()} sqft` }]
-      : []),
-    ...(data.units !== null
-      ? [{ label: 'Units', currentValue: fmtCurrent(cur.units, String), value: String(data.units) }]
-      : []),
-  ];
+  const defaultSelection = useMemo(() => {
+    const selected = new Set<DealPatchTarget>();
+    for (const patch of patches) {
+      if (patch.needsReview) continue; // low confidence — explicit opt-in
+      const existing = currentFor(patch.target, cur);
+      const userEdited =
+        existing != null && existing !== 0 &&
+        existing !== defaultFor(patch.target) && // untouched defaults are not edits
+        patch.value.amount !== existing;
+      if (userEdited) continue; // user typed a value here — confirm, never silent
+      selected.add(patch.target);
+    }
+    return selected;
+  }, [patches, cur]);
+
+  const [selected, setSelected] = useState<Set<DealPatchTarget>>(defaultSelection);
+
+  // A new import while the panel is open replaces the patches — re-derive
+  // the selection defaults rather than carrying stale choices over
+  useEffect(() => {
+    setSelected(defaultSelection);
+  }, [defaultSelection]);
+
+  const toggle = (target: DealPatchTarget) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(target)) next.delete(target);
+      else next.add(target);
+      return next;
+    });
+  };
+
+  const metaBits = [
+    meta.bedrooms !== undefined ? `${meta.bedrooms.value} bd` : null,
+    meta.bathrooms !== undefined ? `${meta.bathrooms.value} ba` : null,
+    meta.yearBuilt !== undefined ? `built ${meta.yearBuilt.value}` : null,
+  ].filter((b): b is string => b !== null);
 
   return (
     <div
       className="rounded border border-accent/50 bg-raised shadow-lg overflow-hidden"
       role="dialog"
-      aria-label="Autofill preview"
+      aria-label="Import review"
     >
       {/* Header */}
       <div className="flex items-center justify-between bg-accent/10 px-4 py-2 border-b border-border">
-        <span className="text-xs font-medium text-accent">⚡ RentCast found this property</span>
+        <span className="text-xs font-medium text-accent">⚡ Review imported values</span>
+        {metaBits.length > 0 && (
+          <span className="text-xs text-mid">{metaBits.join(' · ')}</span>
+        )}
       </div>
 
-      {/* Diff rows */}
+      {/* Patch rows */}
       <div>
-        {rows.map((row, i) => (
-          <div
-            key={row.label}
-            className={`grid grid-cols-[1fr_auto_auto] gap-3 items-center px-4 py-2 text-xs ${
-              i % 2 === 1 ? 'bg-base' : ''
-            }`}
-          >
-            <span className="text-mid">{row.label}</span>
-            <span className="text-lo line-through">{row.currentValue}</span>
-            <span className="text-green-400 font-medium">{row.value}</span>
-          </div>
-        ))}
+        {patches.map((patch, i) => {
+          const existing = currentFor(patch.target, cur);
+          const isOn = selected.has(patch.target);
+          return (
+            <label
+              key={patch.target}
+              className={`grid grid-cols-[auto_1fr_auto_auto_auto] gap-3 items-center px-4 py-2 text-xs cursor-pointer ${
+                i % 2 === 1 ? 'bg-base' : ''
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={isOn}
+                onChange={() => toggle(patch.target)}
+                aria-label={`Apply ${TARGET_LABELS[patch.target]}`}
+                className="accent-current"
+              />
+              <span className="text-mid">
+                {TARGET_LABELS[patch.target]}
+                <span
+                  className={`ml-2 rounded border px-1 py-px text-[10px] uppercase tracking-wide ${confidenceClasses(patch.confidence)}`}
+                  title={`Confidence: ${patch.confidence}`}
+                >
+                  {patch.needsReview ? 'needs review' : patch.confidence}
+                </span>
+              </span>
+              <span className="text-lo text-[10px] uppercase tracking-wide" title={`Source: ${patch.source}`}>
+                {SOURCE_LABELS[patch.source] ?? patch.source}
+              </span>
+              <span className="text-lo line-through">
+                {existing != null && existing !== 0 ? fmtValue(patch.target, existing) : '—'}
+              </span>
+              <span className={isOn ? 'text-green-400 font-medium' : 'text-lo'}>
+                {fmtValue(patch.target, patch.value.amount)}
+              </span>
+            </label>
+          );
+        })}
       </div>
 
       {/* Actions */}
@@ -97,13 +209,15 @@ export function AutofillPreviewPopover({ data, onApply, onDismiss, currentValues
         </button>
         <button
           type="button"
-          onClick={onApply}
+          onClick={() => onApply(selected)}
+          disabled={selected.size === 0}
           className="
             rounded bg-accent px-3 py-1 text-xs font-medium text-base
             hover:opacity-90 transition-opacity
+            disabled:opacity-40 disabled:cursor-not-allowed
           "
         >
-          Apply →
+          Apply {selected.size > 0 ? `${selected.size} ` : ''}→
         </button>
       </div>
     </div>

--- a/packages/ui/src/hooks/useAutofill.ts
+++ b/packages/ui/src/hooks/useAutofill.ts
@@ -1,126 +1,184 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+/**
+ * E7 — tiered property import hook (RPE-43d, rebuilt on the resolver in RPE-53)
+ *
+ * Accepts a street address OR a listing URL (parsed via parseListingUrl,
+ * never fetched) plus optional pasted listing text, runs the tiered
+ * provider chain (RentCast api → flagged scrape → paste heuristics), and
+ * maps the merged PropertyLookup into DealInputs PATCHES for the review
+ * panel. apply() dispatches only the targets the user accepted — the
+ * never-silently-overwrite contract lives in the panel + patch model.
+ *
+ * Paste-only imports work WITHOUT a RentCast key: the paste tier is
+ * local heuristics, zero network.
+ */
+
+import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import type { Dispatch } from 'react';
+import {
+  createPasteTextProvider,
+  createRentCastProxyProvider,
+  createScrapeProxyProvider,
+  mapLookupToDealInputs,
+  parseListingUrl,
+  resolveProperty,
+  type DealInputPatch,
+  type DealPatchTarget,
+  type LookupRequest,
+  type MappedLookup,
+  type ProviderAttempt,
+} from '@rpe/property';
 import type { DealAction } from '../state/dealReducer';
 
-export interface PropertyData {
-  purchasePrice: number;
-  grossRent: number;
-  sqft: number | null;
-  units: number | null;
-  annualTaxes: number | null;
-}
-
 type AutofillStatus = 'idle' | 'loading' | 'preview' | 'error';
+
+export interface ImportPreview {
+  patches: DealInputPatch[];
+  meta: MappedLookup['meta'];
+  attempts: ProviderAttempt[];
+}
 
 interface UseAutofillOptions {
   dispatch: Dispatch<DealAction>;
   apiKey: string | null;
   /** Base URL of apps/api, e.g. 'http://localhost:3001'. Defaults to 'http://localhost:3001'. */
   apiUrl?: string;
+  /** Scrape tier opt-in — OFF by default (ToS/product call, RPE-51). */
+  scrapeEnabled?: boolean;
 }
 
 export interface UseAutofillReturn {
   status: AutofillStatus;
-  previewData: PropertyData | null;
+  preview: ImportPreview | null;
   errorMessage: string | null;
-  trigger: (address: string) => Promise<void>;
-  apply: () => void;
+  /** input: address or listing URL; pastedText: copied listing text. */
+  trigger: (input: string, pastedText?: string) => Promise<void>;
+  /** Dispatch only the accepted targets into the deal form. */
+  apply: (selected: ReadonlySet<DealPatchTarget>) => void;
   dismiss: () => void;
 }
 
-function httpStatusToMessage(status: number): string {
-  if (status === 401) return 'Invalid API key — update it in ⚙ Settings.';
-  if (status === 404) return 'Property not found. Check the address and try again.';
-  if (status === 429) return 'Rate limit reached (50 req/mo on the free tier).';
-  return 'Lookup failed. Please try again.';
+function attemptsToMessage(attempts: ProviderAttempt[]): string {
+  const codes = attempts.filter((a) => a.status === 'error').map((a) => a.error ?? '');
+  const text = codes.join(' ');
+  if (text.includes('Invalid or expired API key')) return 'Invalid API key — update it in ⚙ Settings.';
+  if (text.includes('not found')) return 'Property not found. Check the address and try again.';
+  if (text.includes('Rate limit') || text.includes('Too many')) return 'Rate limit reached — try again later.';
+  if (attempts.every((a) => a.status === 'skipped')) {
+    return 'Nothing to import — connect RentCast in ⚙ Settings or paste the listing text.';
+  }
+  return 'Import found no usable data. Try pasting the listing text.';
 }
 
 export function useAutofill({
   dispatch,
   apiKey,
   apiUrl,
+  scrapeEnabled = false,
 }: UseAutofillOptions): UseAutofillReturn {
   const [status, setStatus]             = useState<AutofillStatus>('idle');
-  const [previewData, setPreviewData]   = useState<PropertyData | null>(null);
+  const [preview, setPreview]           = useState<ImportPreview | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const resolvedApiUrl = apiUrl ?? 'http://localhost:3001';
 
-  // Tracks the AbortController for the latest in-flight request so a new
-  // trigger() call can cancel a stale one and avoid out-of-order state updates.
-  const abortRef = useRef<AbortController | null>(null);
+  // resolveProperty has no abort signal — a monotonic request id makes
+  // stale completions no-ops (same guarantee the old AbortController gave).
+  const requestIdRef = useRef(0);
+  useEffect(() => () => { requestIdRef.current += 1; }, []);
 
-  // Abort any in-flight request on unmount to prevent state updates on an
-  // unmounted component.
-  useEffect(() => () => { abortRef.current?.abort(); }, []);
+  const apiKeyRef = useRef(apiKey);
+  apiKeyRef.current = apiKey;
 
-  const trigger = useCallback(
-    async (address: string) => {
-      if (!apiKey || !address.trim()) return;
-
-      // Cancel any in-flight request before starting a new one.
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
-
-      setStatus('loading');
-      setErrorMessage(null);
-      setPreviewData(null);
-
-      try {
-        const res = await fetch(`${resolvedApiUrl}/property`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ address: address.trim(), apiKey }),
-          signal: controller.signal,
-        });
-
-        if (controller.signal.aborted) return;
-
-        if (!res.ok) {
-          setStatus('error');
-          setErrorMessage(httpStatusToMessage(res.status));
-          return;
-        }
-
-        const body = (await res.json()) as { data: PropertyData };
-        if (controller.signal.aborted) return;
-        setPreviewData(body.data);
-        setStatus('preview');
-      } catch (e) {
-        if (e instanceof Error && e.name === 'AbortError') return;
-        setStatus('error');
-        setErrorMessage('Network error — check that apps/api is running.');
-      }
-    },
-    [apiKey, resolvedApiUrl],
+  const providers = useMemo(
+    () => [
+      createRentCastProxyProvider({ apiUrl: resolvedApiUrl, getApiKey: () => apiKeyRef.current }),
+      createScrapeProxyProvider({ apiUrl: resolvedApiUrl, enabled: scrapeEnabled }),
+      createPasteTextProvider(),
+    ],
+    [resolvedApiUrl, scrapeEnabled],
   );
 
-  const apply = useCallback(() => {
-    if (!previewData) return;
+  const trigger = useCallback(
+    async (input: string, pastedText?: string) => {
+      const trimmed = input.trim();
+      const pasted = pastedText?.trim() ?? '';
+      if (trimmed === '' && pasted === '') return;
 
-    dispatch({ type: 'SET_NUMBER', field: 'purchasePrice', value: previewData.purchasePrice });
-    dispatch({ type: 'SET_NUMBER', field: 'grossRent', value: previewData.grossRent });
+      const requestId = ++requestIdRef.current;
+      setStatus('loading');
+      setErrorMessage(null);
+      setPreview(null);
 
-    if (previewData.sqft !== null) {
-      dispatch({ type: 'SET_NUMBER', field: 'sqft', value: previewData.sqft });
-    }
-    if (previewData.units !== null) {
-      dispatch({ type: 'SET_NUMBER', field: 'units', value: previewData.units });
-    }
-    if (previewData.annualTaxes !== null) {
-      dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: previewData.annualTaxes, period: 'annual' });
-    }
+      // A listing URL becomes { url, address? } — the URL itself is only
+      // ever fetched by the (flagged) scrape tier; the parsed address
+      // feeds the licensed API tier.
+      const request: LookupRequest = {};
+      if (trimmed !== '') {
+        const parsedInput = parseListingUrl(trimmed);
+        if (parsedInput.kind === 'listing') {
+          request.url = trimmed;
+          if (parsedInput.listing.address !== null) request.address = parsedInput.listing.address;
+        } else {
+          request.address = parsedInput.address;
+        }
+      }
+      if (pasted !== '') request.pastedText = pasted;
 
-    setPreviewData(null);
-    setStatus('idle');
-  }, [dispatch, previewData]);
+      const resolved = await resolveProperty(request, providers);
+      if (requestId !== requestIdRef.current) return; // stale — superseded or unmounted
+
+      const mapped = mapLookupToDealInputs(resolved.lookup);
+      if (mapped.patches.length === 0) {
+        setStatus('error');
+        setErrorMessage(attemptsToMessage(resolved.attempts));
+        return;
+      }
+
+      setPreview({ patches: mapped.patches, meta: mapped.meta, attempts: resolved.attempts });
+      setStatus('preview');
+    },
+    [providers],
+  );
+
+  const apply = useCallback(
+    (selected: ReadonlySet<DealPatchTarget>) => {
+      if (!preview) return;
+
+      for (const patch of preview.patches) {
+        if (!selected.has(patch.target)) continue;
+        switch (patch.target) {
+          case 'purchasePrice':
+          case 'grossRent':
+          case 'sqft':
+          case 'units':
+            if (patch.value.kind === 'number') {
+              dispatch({ type: 'SET_NUMBER', field: patch.target, value: patch.value.amount });
+            }
+            break;
+          case 'expenses.taxes':
+            if (patch.value.kind === 'expense') {
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: patch.value.amount, period: 'annual' });
+            }
+            break;
+          case 'expenses.insurance':
+            if (patch.value.kind === 'expense') {
+              dispatch({ type: 'SET_EXPENSE_FIXED', field: 'insurance', amount: patch.value.amount, period: 'annual' });
+            }
+            break;
+        }
+      }
+
+      setPreview(null);
+      setStatus('idle');
+    },
+    [dispatch, preview],
+  );
 
   const dismiss = useCallback(() => {
-    setPreviewData(null);
+    setPreview(null);
     setErrorMessage(null);
     setStatus('idle');
   }, []);
 
-  return { status, previewData, errorMessage, trigger, apply, dismiss };
+  return { status, preview, errorMessage, trigger, apply, dismiss };
 }

--- a/packages/ui/tests/useAutofill.test.ts
+++ b/packages/ui/tests/useAutofill.test.ts
@@ -1,191 +1,208 @@
 /**
- * RPE-43d: useAutofill hook tests
+ * RPE-53: tiered import hook tests (rebuilt from the RPE-43d suite).
  *
- * Mocks fetch (the POST /property call) at globalThis level.
- * Uses @testing-library/react's renderHook.
+ * Mocks globalThis.fetch — the only network the providers reach.
  *
  * @vitest-environment jsdom
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useAutofill } from '../src/hooks/useAutofill';
+import type { DealAction } from '../src/state/dealReducer';
 
-// ─── Mock fetch ──────────────────────────────────────────────────────────────
+const API_URL = 'http://localhost:3001';
 
-const MOCK_DATA = {
-  purchasePrice: 342_000,
-  grossRent: 2_150,
-  sqft: 1_480,
-  units: 1,
-  annualTaxes: 4_210,
+const PROXY_LOOKUP = {
+  purchasePrice: { value: 342_000, source: 'rentcast', confidence: 'medium' },
+  grossRent:     { value: 2_150,   source: 'rentcast', confidence: 'medium' },
+  annualTaxes:   { value: 4_210,   source: 'rentcast', confidence: 'high' },
+  bedrooms:      { value: 3,       source: 'rentcast', confidence: 'high' },
 };
 
-function mockFetchOk(data: unknown) {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+const PASTED = '$280,000 2 bd 1 ba 900 sqft taxes: $2,100';
+
+function proxyOk(lookup: unknown): Response {
+  return {
     ok: true,
     status: 200,
-    json: () => Promise.resolve({ data }),
-  } as unknown as Response);
+    json: () => Promise.resolve({ data: {}, lookup, cached: false }),
+  } as unknown as Response;
 }
 
-function mockFetchError(status: number, error: string) {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+function proxyErr(status: number, code: string, error: string): Response {
+  return {
     ok: false,
     status,
-    json: () => Promise.resolve({ error }),
-  } as unknown as Response);
+    json: () => Promise.resolve({ error, code }),
+  } as unknown as Response;
 }
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
-
-describe('useAutofill', () => {
-  // Minimal dispatch spy
-  const dispatch = vi.fn();
+describe('useAutofill (tiered import)', () => {
+  let dispatched: DealAction[];
+  let dispatch: (a: DealAction) => void;
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    dispatch.mockClear();
+    dispatched = [];
+    dispatch = (a) => dispatched.push(a);
   });
 
-  it('starts in idle state', () => {
-    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+  it('imports from an address through the api tier into patches', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(proxyOk(PROXY_LOOKUP));
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('123 Main St, Austin TX'));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+
+    expect(fetchSpy).toHaveBeenCalledWith(`${API_URL}/property`, expect.anything());
+    const targets = result.current.preview?.patches.map((p) => p.target).sort();
+    expect(targets).toEqual(['expenses.taxes', 'grossRent', 'purchasePrice']);
+    expect(result.current.preview?.meta.bedrooms?.value).toBe(3);
+  });
+
+  it('parses a listing URL and feeds the extracted address to the api tier', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(proxyOk(PROXY_LOOKUP));
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
+
+    await act(() =>
+      result.current.trigger('https://www.zillow.com/homedetails/123-Main-St-Austin-TX-78701/29381742_zpid/'),
+    );
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+
+    const body = JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body)) as { address: string };
+    expect(body.address).toBe('123 Main St Austin TX 78701');
+  });
+
+  it('imports paste-only without an API key and with zero network', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: null, apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('', PASTED));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.preview?.patches.find((p) => p.target === 'purchasePrice')?.source).toBe('paste');
+  });
+
+  it('falls through to pasted text when the api tier fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      proxyErr(404, 'not_found', 'Property not found for this address.'),
+    );
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('123 Main St', PASTED));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+
+    expect(result.current.preview?.attempts.map((a) => a.status)).toEqual(['error', 'skipped', 'ok']);
+    expect(result.current.preview?.patches.find((p) => p.target === 'purchasePrice')?.value.amount).toBe(280_000);
+  });
+
+  it('reports a Settings/paste hint when nothing can run', async () => {
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: null, apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('123 Main St'));
+    await waitFor(() => expect(result.current.status).toBe('error'));
+
+    expect(result.current.errorMessage).toContain('⚙ Settings');
+  });
+
+  it('surfaces the api-tier failure message when there is no fallback data', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      proxyErr(401, 'bad_key', 'Invalid or expired API key.'),
+    );
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_bad', apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('123 Main St'));
+    await waitFor(() => expect(result.current.status).toBe('error'));
+
+    expect(result.current.errorMessage).toContain('Invalid API key');
+  });
+
+  it('apply() dispatches only the selected targets and resets', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(proxyOk(PROXY_LOOKUP));
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
+
+    await act(() => result.current.trigger('123 Main St'));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+
+    act(() => result.current.apply(new Set(['purchasePrice', 'expenses.taxes'])));
+
+    expect(dispatched).toEqual([
+      { type: 'SET_NUMBER', field: 'purchasePrice', value: 342_000 },
+      { type: 'SET_EXPENSE_FIXED', field: 'taxes', amount: 4_210, period: 'annual' },
+    ]);
     expect(result.current.status).toBe('idle');
-    expect(result.current.previewData).toBeNull();
-    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.preview).toBeNull();
   });
 
-  it('transitions idle → loading → preview on successful trigger', async () => {
-    mockFetchOk(MOCK_DATA);
-    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+  it('dismiss() clears preview and error state', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(proxyOk(PROXY_LOOKUP));
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
 
-    await act(async () => { await result.current.trigger('123 Main St'); });
+    await act(() => result.current.trigger('123 Main St'));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
 
-    expect(result.current.status).toBe('preview');
-    expect(result.current.previewData).toEqual(MOCK_DATA);
+    act(() => result.current.dismiss());
+    expect(result.current.status).toBe('idle');
+    expect(result.current.preview).toBeNull();
   });
 
-  it('transitions to error on 401 (bad_key)', async () => {
-    mockFetchError(401, 'Invalid API key');
-    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+  it('ignores a stale request superseded by a newer trigger', async () => {
+    let resolveFirst!: (r: Response) => void;
+    const firstGate = new Promise<Response>((r) => { resolveFirst = r; });
+    vi.spyOn(globalThis, 'fetch')
+      .mockReturnValueOnce(firstGate)
+      .mockResolvedValueOnce(proxyOk({
+        purchasePrice: { value: 999_999, source: 'rentcast', confidence: 'medium' },
+      }));
 
-    await act(async () => { await result.current.trigger('123 Main St'); });
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
 
-    expect(result.current.status).toBe('error');
-    expect(result.current.errorMessage).toMatch(/api key/i);
+    // First trigger hangs; second completes
+    act(() => { void result.current.trigger('1 First St'); });
+    await act(() => result.current.trigger('2 Second St'));
+    await waitFor(() => expect(result.current.status).toBe('preview'));
+    expect(result.current.preview?.patches[0]?.value.amount).toBe(999_999);
+
+    // Now the stale first request lands — it must not clobber the preview
+    resolveFirst(proxyOk(PROXY_LOOKUP));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.preview?.patches[0]?.value.amount).toBe(999_999);
   });
 
-  it('transitions to error on 404 (not_found)', async () => {
-    mockFetchError(404, 'Property not found');
-    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
+  it('does not call the scrape tier unless enabled', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      proxyErr(404, 'not_found', 'Property not found for this address.'),
+    );
+    const { result } = renderHook(() =>
+      useAutofill({ dispatch, apiKey: 'rc_key', apiUrl: API_URL }),
+    );
 
-    await act(async () => { await result.current.trigger('unknown address'); });
+    await act(() =>
+      result.current.trigger('https://www.zillow.com/homedetails/123-Main-St-Austin-TX-78701/1_zpid/'),
+    );
+    await waitFor(() => expect(result.current.status).toBe('error'));
 
-    expect(result.current.status).toBe('error');
-    expect(result.current.errorMessage).toMatch(/not found/i);
-  });
-
-  it('transitions to error on 429 (rate_limit)', async () => {
-    mockFetchError(429, 'Rate limit exceeded');
-    const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-
-    await act(async () => { await result.current.trigger('123 Main St'); });
-
-    expect(result.current.status).toBe('error');
-    expect(result.current.errorMessage).toMatch(/rate limit/i);
-  });
-
-  describe('apply()', () => {
-    it('dispatches SET_NUMBER for purchasePrice', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'purchasePrice', value: 342_000 });
-    });
-
-    it('dispatches SET_NUMBER for grossRent', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'grossRent', value: 2_150 });
-    });
-
-    it('dispatches SET_EXPENSE_FIXED for taxes when annualTaxes is non-null', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).toHaveBeenCalledWith({
-        type: 'SET_EXPENSE_FIXED',
-        field: 'taxes',
-        amount: 4_210,
-        period: 'annual',
-      });
-    });
-
-    it('dispatches SET_NUMBER for units when units is non-null', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'units', value: 1 });
-    });
-
-    it('dispatches SET_NUMBER for sqft when non-null', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).toHaveBeenCalledWith({ type: 'SET_NUMBER', field: 'sqft', value: 1_480 });
-    });
-
-    it('skips sqft dispatch when sqft is null', async () => {
-      mockFetchOk({ ...MOCK_DATA, sqft: null });
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).not.toHaveBeenCalledWith(
-        expect.objectContaining({ field: 'sqft' }),
-      );
-    });
-
-    it('skips taxes dispatch when annualTaxes is null', async () => {
-      mockFetchOk({ ...MOCK_DATA, annualTaxes: null });
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(dispatch).not.toHaveBeenCalledWith(
-        expect.objectContaining({ field: 'taxes' }),
-      );
-    });
-
-    it('returns to idle after apply()', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.apply(); });
-      expect(result.current.status).toBe('idle');
-    });
-  });
-
-  describe('dismiss()', () => {
-    it('returns to idle from preview state', async () => {
-      mockFetchOk(MOCK_DATA);
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('123 Main St'); });
-      act(() => { result.current.dismiss(); });
-      expect(result.current.status).toBe('idle');
-      expect(result.current.previewData).toBeNull();
-    });
-
-    it('returns to idle from error state', async () => {
-      mockFetchError(404, 'not found');
-      const { result } = renderHook(() => useAutofill({ dispatch, apiKey: 'key', apiUrl: 'http://localhost:3001' }));
-      await act(async () => { await result.current.trigger('x'); });
-      act(() => { result.current.dismiss(); });
-      expect(result.current.status).toBe('idle');
-    });
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]));
+    expect(urls.every((u) => !u.includes('/scrape'))).toBe(true);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@rpe/engine':
         specifier: workspace:*
         version: link:../engine
+      '@rpe/property':
+        specifier: workspace:*
+        version: link:../property
       '@rpe/region-defaults':
         specifier: workspace:*
         version: link:../region-defaults


### PR DESCRIPTION
## Summary
- `useAutofill` rebuilt on the RPE-44 tiered resolver: accepts an address OR a listing URL (parsed with `parseListingUrl`, never fetched client-side) plus optional pasted listing text; chain = RentCast api tier → flagged scrape tier → paste heuristics; merged lookup maps to DealInputs **patches**
- Review/override panel (evolved `AutofillPreviewPopover`): per-field source badge (RentCast / Scraped—unverified / Pasted text), confidence chip, current vs new value, accept checkbox; **low-confidence rows and rows over user-edited values start unchecked** — untouched form defaults are not treated as edits; `apply(selected)` dispatches only accepted targets
- Import bar: paste-text area as the zero-key fallback — works before RentCast is configured; stale-request guard preserved via monotonic request ids
- 10 hook tests (URL→address feed, paste-only zero-network, api→paste fall-through, selective apply, stale-supersede, scrape gating)
- **Verified end-to-end in the browser preview**: paste → review panel (correct default selection) → apply → form shows 2,150 rent / 4,210 taxes, untouched price, no console errors

## Review
Copilot unavailable; strict self-review loop. Round 1 (caught live in preview): untouched form defaults were treated as user edits, leaving every row unchecked on a fresh form — fixed by comparing against `DEFAULT_INPUTS`. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 775 tests passing
- [x] Browser preview walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)