### PR TITLE
RPE-70: toggleable score explanation — config-driven 0–14 scale breakdown

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -150,7 +150,16 @@ const SIMPLE_SCORED_KEYS: MetricKey[] = SCORED_KEYS.filter((k) =>
   SIMPLE_RESULT_KEYS.includes(k),
 );
 
+/** Threshold display: "≥ 5%", "≤ 12×", "≥ $0" — driven entirely by config. */
+function fmtThreshold(cfg: (typeof SCREENER_METRIC_CONFIG)[MetricKey]): string {
+  const symbol = cfg.direction === 'higher' ? '≥' : '≤';
+  const t = cfg.threshold ?? 0;
+  const value = cfg.unit === '$' ? `$${t.toLocaleString()}` : `${t}${cfg.unit ?? ''}`;
+  return `${symbol} ${value}`;
+}
+
 function ScoreCard({ result, uiMode = 'complex' }: { result: ScreenerResults; uiMode?: UiMode }) {
+  const [explainOpen, setExplainOpen] = useState(false);
   const scoredKeys = uiMode === 'simple' ? SIMPLE_SCORED_KEYS : SCORED_KEYS;
   const signals = scoredKeys.map((k) => evalSignal(k, result[k]));
   const total = signals.filter((s) => s !== 'null').length;
@@ -178,6 +187,42 @@ function ScoreCard({ result, uiMode = 'complex' }: { result: ScreenerResults; ui
         />
       </div>
       <p className="text-[10px] text-lo mt-1.5">metrics meeting conventional thresholds</p>
+
+      {/* ── Score explanation disclosure (RPE-70) — never printed ───────────── */}
+      <button
+        type="button"
+        onClick={() => setExplainOpen((open) => !open)}
+        aria-expanded={explainOpen}
+        aria-controls="score-explanation"
+        className="no-print mt-2 text-[10px] text-lo hover:text-accent transition-colors"
+      >
+        {explainOpen ? '▾' : '▸'} How is this scored?
+      </button>
+      {explainOpen && (
+        <div id="score-explanation" className="no-print mt-2 space-y-1">
+          {scoredKeys.map((key) => {
+            const cfg = SCREENER_METRIC_CONFIG[key];
+            const signal = evalSignal(key, result[key]);
+            return (
+              <div key={key} className="grid grid-cols-[1fr_auto_auto] gap-2 text-[10px] items-baseline">
+                <span className="text-mid">{cfg.label}</span>
+                <span className="text-lo font-mono">{fmtThreshold(cfg)}</span>
+                <span
+                  className={
+                    signal === 'pass' ? 'text-pass' : signal === 'fail' ? 'text-fail' : 'text-lo'
+                  }
+                >
+                  {signal === 'pass' ? 'pass' : signal === 'fail' ? 'fail' : '—'}
+                </span>
+              </div>
+            );
+          })}
+          <p className="text-[10px] text-lo pt-1 border-t border-border">
+            Score = passing ÷ scored. ≥75% green, ≥50% amber, below red. Informational
+            metrics (no threshold) are not counted.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/tests/scoreExplanation.test.tsx
+++ b/packages/ui/tests/scoreExplanation.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * RPE-70: score explanation disclosure — config-driven, accessible,
+ * pass/fail matches the score numerator.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { evaluate, EXAMPLE_DEAL_INPUTS, SCREENER_METRIC_CONFIG } from '@rpe/engine';
+import type { ScreenerResults } from '@rpe/engine';
+import { Evaluator } from '../src/Evaluator';
+
+const SCORED_COUNT = Object.values(SCREENER_METRIC_CONFIG).filter(
+  (cfg) => cfg.direction !== 'none',
+).length;
+
+describe('ScoreCard explanation disclosure (RPE-70)', () => {
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
+  });
+
+  function openDisclosure() {
+    render(<Evaluator />);
+    const toggle = screen.getAllByRole('button', { name: /How is this scored/ })[0];
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    return toggle;
+  }
+
+  it('is collapsed by default and toggles with aria-expanded', () => {
+    const toggle = openDisclosure();
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('renders every scored metric from config — no hardcoded list', () => {
+    openDisclosure();
+    const panel = document.getElementById('score-explanation')!;
+    const rows = panel.querySelectorAll('.grid');
+    expect(rows.length).toBe(SCORED_COUNT);
+    // Spot-check labels and thresholds come from config
+    for (const cfg of Object.values(SCREENER_METRIC_CONFIG)) {
+      if (cfg.direction === 'none') continue;
+      expect(panel.textContent).toContain(cfg.label);
+    }
+    expect(panel.textContent).toContain('≥');
+    expect(panel.textContent).toContain('≤');
+  });
+
+  it('per-metric pass/fail matches the score numerator', () => {
+    openDisclosure();
+    const panel = document.getElementById('score-explanation')!;
+    const passCount = [...panel.querySelectorAll('.grid')].filter((row) =>
+      row.textContent?.endsWith('pass'),
+    ).length;
+
+    // The default form IS the example deal inputs minus closing costs —
+    // compute the numerator the same way the card does
+    const results = evaluate(EXAMPLE_DEAL_INPUTS) as ScreenerResults;
+    void results; // numerator asserted against the on-screen score instead:
+    const scoreText = document.querySelector('.num.text-lg')?.textContent ?? '';
+    const numerator = Number(scoreText.match(/^(\d+)/)?.[1]);
+    expect(passCount).toBe(numerator);
+  });
+
+  it('explains the color bands and the informational-metric exclusion', () => {
+    openDisclosure();
+    const panel = document.getElementById('score-explanation')!;
+    expect(panel.textContent).toContain('75%');
+    expect(panel.textContent).toContain('50%');
+    expect(panel.textContent).toContain('Informational');
+  });
+
+  it('is excluded from print via no-print', () => {
+    const toggle = openDisclosure();
+    expect(toggle.className).toContain('no-print');
+    expect(document.getElementById('score-explanation')?.className).toContain('no-print');
+  });
+});


### PR DESCRIPTION
## Summary
- "How is this scored?" disclosure on the ScoreCard: every scored metric rendered from `SCREENER_METRIC_CONFIG` (single source of truth — adding/removing a scored metric updates the panel with zero extra changes) with direction symbol, threshold, and live pass/fail for the active scenario
- Color-band mapping note (≥75% green / ≥50% amber / below red) + informational-metric exclusion note
- Collapsed by default; `aria-expanded`/`aria-controls` disclosure semantics; **always excluded from print** via `no-print` (implementer's call per ticket, noted here)
- 5 component tests incl. pass/fail-matches-numerator and config-driven row count

## Review
Copilot unavailable; strict self-review loop — clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 793 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)