### PR TITLE
RPE-74: API foundation — router, /v1 prefix, request IDs, error envelope

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -53,6 +53,7 @@ import {
 import { handleRegion } from './routes/region.js';
 import { handleScrape, type ScrapeDeps, type ScrapeSuccessBody } from './routes/scrape.js';
 import { RateLimiter, TtlCache } from './services/guardrails.js';
+import { Router, logRequest, normalizePath, resolveRequestId, v1Error } from './router.js';
 
 // Hoist __filename/__dirname for use in VERSION and the entry-point guard below.
 const __filename = fileURLToPath(import.meta.url);
@@ -420,8 +421,46 @@ export function createApp(config: AppConfig = {}) {
     ),
   };
 
+  // Handler-emitted error bodies carry the request id too (RPE-74) —
+  // the dispatcher sets X-Request-Id on the response before dispatch, so
+  // the wrapper recovers it without per-request closures
+  const jsonWithRequestId: typeof json = (rs, status, body) => {
+    const rid = String(rs.getHeader('X-Request-Id') ?? '');
+    if (status >= 400 && body !== null && typeof body === 'object' && !Array.isArray(body) && rid !== '') {
+      json(rs, status, { ...(body as Record<string, unknown>), requestId: rid });
+      return;
+    }
+    json(rs, status, body);
+  };
+
+  // ── Routes (RPE-74) — registered once; /v1 aliases resolve by prefix-strip
+  const router = new Router()
+    .on('GET', '/health', (rq, rs) => handleHealth(rq, rs))
+    .on('POST', '/evaluate', (rq, rs) => handleEvaluate(rq, rs))
+    .on('POST', '/property/context', (rq, rs) => handlePropertyContext(rq, rs, jsonWithRequestId, readBody, propertyContextDeps))
+    .on('POST', '/property', (rq, rs) => handleProperty(rq, rs, jsonWithRequestId, readBody, propertyDeps))
+    .on('GET', '/region', (rq, rs) => handleRegion(rq, rs, jsonWithRequestId))
+    .on('GET', '/geocode', (rq, rs) => handleGeocode(rq, rs, jsonWithRequestId, geocodeDeps))
+    .on('POST', '/scrape', (rq, rs) => handleScrape(rq, rs, jsonWithRequestId, readBody, scrapeDeps));
+
   return createServer((req: IncomingMessage, res: ServerResponse) => {
-    const url = req.url?.split('?')[0] ?? '/';
+    const startedAt = Date.now();
+    const requestId = resolveRequestId(req);
+    res.setHeader('X-Request-Id', requestId);
+
+    const rawPath = normalizePath(req.url?.split('?')[0] ?? '/');
+    const isV1 = rawPath === '/v1' || rawPath.startsWith('/v1/');
+    const path = isV1 ? normalizePath(rawPath.slice(3)) : rawPath;
+
+    res.on('finish', () => {
+      logRequest({
+        method: req.method ?? 'GET',
+        path: rawPath,
+        status: res.statusCode,
+        latencyMs: Date.now() - startedAt,
+        requestId,
+      });
+    });
 
     // Handle CORS preflight globally before routing
     if (req.method === 'OPTIONS') {
@@ -430,35 +469,37 @@ export function createApp(config: AppConfig = {}) {
       return;
     }
 
-    if (url === '/health' || url === '/health/') {
-      handleHealth(req, res);
+    // /v1-native: versioned health with API metadata
+    if (isV1 && path === '/health' && req.method === 'GET') {
+      json(res, 200, {
+        status: 'ok',
+        version: VERSION,
+        apiVersion: 'v1',
+        gitSha: process.env['GIT_SHA'] ?? null,
+      });
       return;
     }
 
-    // Route to async handlers; catch unhandled rejections so every request
-    // gets a response (createServer does not propagate Promise rejections).
-    const asyncHandler =
-      url === '/evaluate' || url === '/evaluate/'
-        ? () => handleEvaluate(req, res)
-        : url === '/property/context' || url === '/property/context/'
-        ? () => handlePropertyContext(req, res, json, readBody, propertyContextDeps)
-        : url === '/property' || url === '/property/'
-        ? () => handleProperty(req, res, json, readBody, propertyDeps)
-        : url === '/region' || url === '/region/'
-        ? () => handleRegion(req, res, json)
-        : url === '/geocode' || url === '/geocode/'
-        ? () => handleGeocode(req, res, json, geocodeDeps)
-        : url === '/scrape' || url === '/scrape/'
-        ? () => handleScrape(req, res, json, readBody, scrapeDeps)
-        : () => {
-            json(res, 404, { error: `Unknown endpoint: ${url}` });
-            return Promise.resolve();
-          };
+    const handler = router.resolve(req.method, path);
+    if (handler === undefined) {
+      // Unknown route: standard envelope on the /v1 surface, legacy flat
+      // shape (now with requestId) for unprefixed callers
+      if (isV1) {
+        json(res, 404, v1Error('not_found', `Unknown endpoint: ${rawPath}`, requestId));
+      } else {
+        json(res, 404, { error: `Unknown endpoint: ${rawPath}`, requestId });
+      }
+      return;
+    }
 
-    asyncHandler().catch((err: unknown) => {
-      console.error('Unhandled request error:', err instanceof Error ? err.stack : String(err));
+    // Catch unhandled rejections so every request gets a response
+    // (createServer does not propagate Promise rejections).
+    Promise.resolve(handler(req, res)).catch((err: unknown) => {
+      console.error('Unhandled request error:', err instanceof Error ? err.stack : String(err), 'requestId:', requestId);
       if (!res.headersSent) {
-        json(res, 500, { error: 'Internal server error' });
+        json(res, 500, isV1
+          ? v1Error('internal', 'Internal server error', requestId)
+          : { error: 'Internal server error', requestId });
       }
     });
   });

--- a/apps/api/src/router.ts
+++ b/apps/api/src/router.ts
@@ -1,0 +1,80 @@
+/**
+ * E10 — minimal public-API router (RPE-74)
+ *
+ * Method + exact-path → handler dispatch over Node's http server — the
+ * deliberate minimalism of apps/api preserved, just no longer ad hoc.
+ *
+ * Conventions established here for the whole /v1 surface:
+ *   - every request gets an X-Request-Id (client value echoed when sane,
+ *     generated otherwise) and a structured completion log line
+ *   - /v1-native errors use the standard envelope
+ *     { error: { code, message, requestId } }
+ *   - legacy unprefixed routes keep their flat shapes (the SPA depends
+ *     on them); the dispatcher aliases them under /v1 unchanged
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+export type RouteHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void> | void;
+
+interface Route {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+}
+
+/** Echoable client request ids: short, printable, header-safe. */
+const REQUEST_ID_PATTERN = /^[\w.-]{1,64}$/;
+
+export function resolveRequestId(req: IncomingMessage): string {
+  const raw = req.headers['x-request-id'];
+  const first = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof first === 'string' && REQUEST_ID_PATTERN.test(first)) return first;
+  return randomUUID();
+}
+
+/** Standard /v1 error envelope. */
+export function v1Error(
+  code: string,
+  message: string,
+  requestId: string,
+): { error: { code: string; message: string; requestId: string } } {
+  return { error: { code, message, requestId } };
+}
+
+export class Router {
+  private readonly routes: Route[] = [];
+
+  /** Register an exact-path route. Trailing slashes are normalized away. */
+  on(method: string, path: string, handler: RouteHandler): this {
+    this.routes.push({ method: method.toUpperCase(), path: normalizePath(path), handler });
+    return this;
+  }
+
+  /** Resolve a handler, or undefined when no route matches. */
+  resolve(method: string | undefined, path: string): RouteHandler | undefined {
+    const m = (method ?? 'GET').toUpperCase();
+    const p = normalizePath(path);
+    return this.routes.find((r) => r.path === p && r.method === m)?.handler
+      // Method-agnostic fallback: handlers own their 405 responses, so a
+      // path that exists under any method still dispatches
+      ?? this.routes.find((r) => r.path === p)?.handler;
+  }
+}
+
+export function normalizePath(path: string): string {
+  const noTrailing = path.replace(/\/+$/, '');
+  return noTrailing === '' ? '/' : noTrailing;
+}
+
+/** One structured line per completed request. */
+export function logRequest(fields: {
+  method: string;
+  path: string;
+  status: number;
+  latencyMs: number;
+  requestId: string;
+}): void {
+  console.log(JSON.stringify({ evt: 'request', ...fields }));
+}

--- a/apps/api/tests/router.test.ts
+++ b/apps/api/tests/router.test.ts
@@ -1,0 +1,166 @@
+/**
+ * RPE-74: API foundation — router unit tests + /v1 surface integration.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import type { IncomingMessage } from 'node:http';
+import { createApp } from '../src/index';
+import { Router, normalizePath, resolveRequestId, v1Error } from '../src/router';
+
+// region/property handlers fetch upstream only when configured — these
+// tests never set tokens/keys, so no network mocking is needed beyond
+// avoiding real lookups.
+
+describe('Router (unit)', () => {
+  it('dispatches on method + normalized path', () => {
+    const router = new Router();
+    const get = vi.fn();
+    const post = vi.fn();
+    router.on('GET', '/thing/', get).on('POST', '/thing', post);
+
+    expect(router.resolve('GET', '/thing')).toBe(get);
+    expect(router.resolve('post', '/thing/')).toBe(post);
+    expect(router.resolve('GET', '/other')).toBeUndefined();
+  });
+
+  it('falls back method-agnostically so handlers own their 405s', () => {
+    const router = new Router();
+    const post = vi.fn();
+    router.on('POST', '/thing', post);
+    expect(router.resolve('GET', '/thing')).toBe(post);
+  });
+
+  it('normalizePath strips trailing slashes but keeps root', () => {
+    expect(normalizePath('/a/b/')).toBe('/a/b');
+    expect(normalizePath('/')).toBe('/');
+    expect(normalizePath('')).toBe('/');
+  });
+
+  it('resolveRequestId echoes sane client ids and regenerates garbage', () => {
+    const reqWith = (v?: string) => ({ headers: { 'x-request-id': v } }) as unknown as IncomingMessage;
+    expect(resolveRequestId(reqWith('abc-123.DEF'))).toBe('abc-123.DEF');
+    expect(resolveRequestId(reqWith('bad id with spaces'))).toMatch(/^[0-9a-f-]{36}$/);
+    expect(resolveRequestId(reqWith('x'.repeat(100)))).toMatch(/^[0-9a-f-]{36}$/);
+    expect(resolveRequestId(reqWith(undefined))).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('v1Error builds the standard envelope', () => {
+    expect(v1Error('not_found', 'nope', 'rid')).toEqual({
+      error: { code: 'not_found', message: 'nope', requestId: 'rid' },
+    });
+  });
+});
+
+describe('/v1 surface (integration)', () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server = createApp({ property: { cacheTtlMs: 0, rpm: 1000, dailyCap: 10000 } });
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          const addr = server.address() as { port: number };
+          base = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(
+    () => new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  );
+
+  it('every response carries X-Request-Id; client ids are echoed', async () => {
+    const fresh = await fetch(`${base}/health`);
+    expect(fresh.headers.get('x-request-id')).toMatch(/^[0-9a-f-]{36}$/);
+
+    const echoed = await fetch(`${base}/health`, { headers: { 'X-Request-Id': 'my-trace-1' } });
+    expect(echoed.headers.get('x-request-id')).toBe('my-trace-1');
+  });
+
+  it('GET /v1/health returns status + version + apiVersion + gitSha', async () => {
+    const res = await fetch(`${base}/v1/health`);
+    const body = await res.json() as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body['status']).toBe('ok');
+    expect(typeof body['version']).toBe('string');
+    expect(body['apiVersion']).toBe('v1');
+    expect('gitSha' in body).toBe(true);
+  });
+
+  it('aliases legacy routes under /v1 with identical behavior', async () => {
+    // /evaluate works identically with and without the prefix
+    const inputs = {
+      purchasePrice: 300000, percentDown: 20, interestRate: 7,
+      loanTermYears: 30, closingCosts: 0, rollClosingCostsIntoLoan: false,
+      grossRent: 2200, vacancyPct: 5,
+      expenses: {
+        taxes: { amount: 3600, period: 'annual' },
+        insurance: { amount: 1200, period: 'annual' },
+      },
+    };
+    const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ inputs }) };
+    const legacy = await (await fetch(`${base}/evaluate`, opts)).json() as { results: Record<string, unknown> };
+    const v1 = await (await fetch(`${base}/v1/evaluate`, opts)).json() as { results: Record<string, unknown> };
+    expect(v1.results).toEqual(legacy.results);
+  });
+
+  it('unknown /v1 routes return the standard nested envelope', async () => {
+    const res = await fetch(`${base}/v1/nope`, { headers: { 'X-Request-Id': 'trace-404' } });
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: Record<string, unknown> };
+    expect(body.error['code']).toBe('not_found');
+    expect(body.error['requestId']).toBe('trace-404');
+    expect(typeof body.error['message']).toBe('string');
+  });
+
+  it('unknown legacy routes keep the flat shape, now with requestId', async () => {
+    const res = await fetch(`${base}/nope`, { headers: { 'X-Request-Id': 'trace-legacy' } });
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body['error']).toBe('string');
+    expect(body['requestId']).toBe('trace-legacy');
+  });
+
+  it('preserves legacy /health untouched semantics', async () => {
+    const res = await fetch(`${base}/health`);
+    const body = await res.json() as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(body['status']).toBe('ok');
+    expect('apiVersion' in body).toBe(false); // legacy shape unchanged
+  });
+
+  it('handler-emitted errors include the requestId (self-review round 1)', async () => {
+    const res = await fetch(`${base}/v1/property`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Request-Id': 'trace-400' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['code']).toBe('bad_request');
+    expect(body['requestId']).toBe('trace-400');
+  });
+
+  it('emits a structured log line per request', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await fetch(`${base}/health`, { headers: { 'X-Request-Id': 'log-check' } });
+    await vi.waitFor(() => {
+      const line = logSpy.mock.calls.map((c) => String(c[0])).find((l) => l.includes('log-check'));
+      expect(line).toBeDefined();
+      const parsed = JSON.parse(line as string) as Record<string, unknown>;
+      expect(parsed['evt']).toBe('request');
+      expect(parsed['method']).toBe('GET');
+      expect(parsed['path']).toBe('/health');
+      expect(parsed['status']).toBe(200);
+      expect(typeof parsed['latencyMs']).toBe('number');
+    });
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Minimal exact-path `Router` (method+path → handler, method-agnostic fallback so handlers own their 405s) replaces the ad-hoc `createServer` dispatch — no framework, per the ticket's deliberate minimalism
- All legacy routes alias under `/v1` unchanged (verified: `/evaluate` and `/v1/evaluate` produce identical results); new `GET /v1/health` adds `apiVersion` + `gitSha`
- `X-Request-Id` on every response — sane client ids echoed (header-injection-safe `[\w.-]{1,64}` pattern), UUID otherwise; structured per-request log lines (`method, path, status, latencyMs, requestId`)
- Error envelope decision (spec tension noted): `/v1`-native errors use the standard `{ error: { code, message, requestId } }`; legacy flat shapes are **preserved** for the SPA per the "existing behavior preserved" criterion, now with `requestId` added (additive). Handler-emitted errors recover the id from the already-set response header — no per-request closures
- 13 new tests (router unit + /v1 surface integration incl. alias parity and log-line shape)

## Review
Copilot unavailable; strict self-review loop. Round 1: handler-emitted error bodies were missing `requestId` (acceptance criterion) — fixed with the header-recovery wrapper + test. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 812 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)