### PR TITLE
RPE-75: per-consumer API key auth — hashed store, validation, revocation

### DIFF
--- a/apps/api/scripts/manage-keys.mjs
+++ b/apps/api/scripts/manage-keys.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * E10 — API key issuance CLI (RPE-75)
+ *
+ * Mints/revokes/lists hashed API key records in a JSON file usable as
+ * RPE_API_KEYS_FILE (or paste the array into RPE_API_KEYS). The full
+ * secret is printed exactly once at mint time and is unrecoverable
+ * afterwards — only its sha256 lands in the file.
+ *
+ *   node scripts/manage-keys.mjs mint   --label acme-staging [--file keys.json]
+ *   node scripts/manage-keys.mjs revoke --id key_3f2a1b9c    [--file keys.json]
+ *   node scripts/manage-keys.mjs list                        [--file keys.json]
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function flag(name, fallback) {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 && args[i + 1] !== undefined ? args[i + 1] : fallback;
+}
+
+const file = flag('file', 'keys.json');
+
+function load() {
+  if (!existsSync(file)) return [];
+  const parsed = JSON.parse(readFileSync(file, 'utf8'));
+  if (!Array.isArray(parsed)) throw new Error(`${file} must contain a JSON array`);
+  return parsed;
+}
+
+function save(records) {
+  writeFileSync(file, `${JSON.stringify(records, null, 2)}\n`);
+}
+
+if (command === 'mint') {
+  const label = flag('label');
+  if (!label) {
+    console.error('mint requires --label <consumer>');
+    process.exit(1);
+  }
+  const secret = `rpe_live_${randomBytes(24).toString('hex')}`;
+  const record = {
+    id: `key_${randomBytes(4).toString('hex')}`,
+    label,
+    hash: createHash('sha256').update(secret).digest('hex'),
+    createdAt: new Date().toISOString(),
+    revokedAt: null,
+  };
+  const records = load();
+  records.push(record);
+  save(records);
+  console.log(`Minted ${record.id} (${label}) → ${file}`);
+  console.log('');
+  console.log('  ONE-TIME SECRET (store it now — it cannot be recovered):');
+  console.log(`  ${secret}`);
+} else if (command === 'revoke') {
+  const id = flag('id');
+  if (!id) {
+    console.error('revoke requires --id <key id>');
+    process.exit(1);
+  }
+  const records = load();
+  const record = records.find((r) => r.id === id);
+  if (!record) {
+    console.error(`No key with id ${id} in ${file}`);
+    process.exit(1);
+  }
+  if (record.revokedAt !== null) {
+    console.log(`${id} was already revoked at ${record.revokedAt}`);
+    process.exit(0);
+  }
+  record.revokedAt = new Date().toISOString();
+  save(records);
+  console.log(`Revoked ${id} (${record.label}). Restart the API (env/file stores load at startup).`);
+} else if (command === 'list') {
+  for (const r of load()) {
+    console.log(`${r.id}  ${r.revokedAt === null ? 'active ' : 'REVOKED'}  ${r.label}  created ${r.createdAt}`);
+  }
+} else {
+  console.error('Usage: manage-keys.mjs <mint|revoke|list> [--label X] [--id key_x] [--file keys.json]');
+  process.exit(1);
+}

--- a/apps/api/scripts/manage-keys.mjs
+++ b/apps/api/scripts/manage-keys.mjs
@@ -49,6 +49,7 @@ if (command === 'mint') {
     hash: createHash('sha256').update(secret).digest('hex'),
     createdAt: new Date().toISOString(),
     revokedAt: null,
+    lastUsedAt: null,
   };
   const records = load();
   records.push(record);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -54,6 +54,7 @@ import { handleRegion } from './routes/region.js';
 import { handleScrape, type ScrapeDeps, type ScrapeSuccessBody } from './routes/scrape.js';
 import { RateLimiter, TtlCache } from './services/guardrails.js';
 import { Router, logRequest, normalizePath, resolveRequestId, v1Error } from './router.js';
+import { ApiKeyStore, extractApiKey, type ApiKeyRecord } from './services/apiKeys.js';
 
 // Hoist __filename/__dirname for use in VERSION and the entry-point guard below.
 const __filename = fileURLToPath(import.meta.url);
@@ -359,6 +360,13 @@ export interface AppConfig {
     rpm?: number;
     dailyCap?: number;
   };
+  /** /v1 API key auth (RPE-75). Enforced on the /v1 surface (except
+   * /v1/health) whenever the key store is non-empty; legacy unprefixed
+   * routes stay open for the SPA. Records via config (tests), the
+   * RPE_API_KEYS env JSON, or RPE_API_KEYS_FILE. */
+  auth?: {
+    keys?: ApiKeyRecord[];
+  };
   /** /scrape fallback (RPE-51). OFF unless RPE_SCRAPE_ENABLED=1/true —
    * enabling in production is a product/legal call. Env: RPE_SCRAPE_RPM
    * (default 5), RPE_SCRAPE_DAILY_CAP (default 50). */
@@ -421,6 +429,8 @@ export function createApp(config: AppConfig = {}) {
     ),
   };
 
+  const apiKeys = ApiKeyStore.fromEnv(config.auth?.keys);
+
   // Handler-emitted error bodies carry the request id too (RPE-74) —
   // the dispatcher sets X-Request-Id on the response before dispatch, so
   // the wrapper recovers it without per-request closures
@@ -451,6 +461,7 @@ export function createApp(config: AppConfig = {}) {
     const rawPath = normalizePath(req.url?.split('?')[0] ?? '/');
     const isV1 = rawPath === '/v1' || rawPath.startsWith('/v1/');
     const path = isV1 ? normalizePath(rawPath.slice(3)) : rawPath;
+    let apiKeyId: string | null = null;
 
     res.on('finish', () => {
       logRequest({
@@ -459,6 +470,7 @@ export function createApp(config: AppConfig = {}) {
         status: res.statusCode,
         latencyMs: Date.now() - startedAt,
         requestId,
+        ...(apiKeyId !== null ? { apiKeyId } : {}),
       });
     });
 
@@ -478,6 +490,23 @@ export function createApp(config: AppConfig = {}) {
         gitSha: process.env['GIT_SHA'] ?? null,
       });
       return;
+    }
+
+    // /v1 auth (RPE-75): enforced when keys are configured; /v1/health
+    // stays open for load balancers, legacy unprefixed routes stay open
+    // for the SPA
+    if (isV1 && apiKeys.size > 0) {
+      const presented = extractApiKey(req.headers);
+      const record = presented !== null ? apiKeys.verify(presented) : null;
+      if (record === null) {
+        json(res, 401, v1Error(
+          'unauthorized',
+          'A valid API key is required — send Authorization: Bearer <key> or X-API-Key.',
+          requestId,
+        ));
+        return;
+      }
+      apiKeyId = record.id;
     }
 
     const handler = router.resolve(req.method, path);

--- a/apps/api/src/services/apiKeys.ts
+++ b/apps/api/src/services/apiKeys.ts
@@ -26,6 +26,9 @@ export interface ApiKeyRecord {
   hash: string;
   createdAt: string;
   revokedAt: string | null;
+  /** Updated in-memory on successful verify; env/file stores are not
+   * written back (Phase 2's DB store persists this). */
+  lastUsedAt?: string | null;
 }
 
 export const KEY_PREFIX = 'rpe_live_';
@@ -46,6 +49,7 @@ export function mintKey(label: string, now: () => number = Date.now): {
     hash: hashSecret(secret),
     createdAt: new Date(now()).toISOString(),
     revokedAt: null,
+    lastUsedAt: null,
   };
   return { record, secret };
 }
@@ -118,13 +122,15 @@ export class ApiKeyStore {
    * Verify a presented secret. Constant-time hash comparison; returns
    * the active record or null (missing, malformed, unknown, revoked).
    */
-  verify(secret: string): ApiKeyRecord | null {
+  verify(secret: string, now: () => number = Date.now): ApiKeyRecord | null {
     if (!secret.startsWith(KEY_PREFIX)) return null;
     const presented = Buffer.from(hashSecret(secret), 'hex');
     for (const [hash, record] of this.byHash) {
       const stored = Buffer.from(hash, 'hex');
       if (stored.length === presented.length && timingSafeEqual(stored, presented)) {
-        return record.revokedAt === null ? record : null;
+        if (record.revokedAt !== null) return null;
+        record.lastUsedAt = new Date(now()).toISOString();
+        return record;
       }
     }
     return null;

--- a/apps/api/src/services/apiKeys.ts
+++ b/apps/api/src/services/apiKeys.ts
@@ -1,0 +1,157 @@
+/**
+ * E10 — per-consumer API keys (RPE-75)
+ *
+ * Stateless-phase key store: a hashed allowlist loaded from config, the
+ * RPE_API_KEYS env var (JSON array), or a JSON file (RPE_API_KEYS_FILE).
+ * Secrets are sha256-hashed at issuance and never stored or logged in
+ * plaintext — the full secret is shown exactly once by the mint CLI
+ * (scripts/manage-keys.mjs).
+ *
+ * Format: `rpe_live_<48 hex chars>` — the prefix is identification only,
+ * the entropy lives in the random tail. Verification is constant-time
+ * over the hash. Revocation: revokedAt set in the store source (runtime
+ * revoke() for tests/CLI; deployed env/file stores re-read at restart —
+ * Phase 2's DB store makes revocation instant fleet-wide).
+ */
+
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+export interface ApiKeyRecord {
+  /** Short public identifier — safe for logs ("key_3f2a"). */
+  id: string;
+  /** Human label for the consumer ("acme-staging"). */
+  label: string;
+  /** sha256 hex of the full secret. */
+  hash: string;
+  createdAt: string;
+  revokedAt: string | null;
+}
+
+export const KEY_PREFIX = 'rpe_live_';
+
+export function hashSecret(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex');
+}
+
+/** Mint a new key: returns the record to store and the one-time secret. */
+export function mintKey(label: string, now: () => number = Date.now): {
+  record: ApiKeyRecord;
+  secret: string;
+} {
+  const secret = `${KEY_PREFIX}${randomBytes(24).toString('hex')}`;
+  const record: ApiKeyRecord = {
+    id: `key_${randomBytes(4).toString('hex')}`,
+    label,
+    hash: hashSecret(secret),
+    createdAt: new Date(now()).toISOString(),
+    revokedAt: null,
+  };
+  return { record, secret };
+}
+
+function isApiKeyRecord(value: unknown): value is ApiKeyRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v['id'] === 'string' &&
+    typeof v['label'] === 'string' &&
+    typeof v['hash'] === 'string' &&
+    /^[0-9a-f]{64}$/.test(v['hash'] as string) &&
+    typeof v['createdAt'] === 'string' &&
+    (v['revokedAt'] === null || typeof v['revokedAt'] === 'string')
+  );
+}
+
+/** Parse a JSON array of records, dropping malformed entries loudly. */
+export function parseKeyRecords(json: string, sourceLabel: string): ApiKeyRecord[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    console.error(`API key store ${sourceLabel}: invalid JSON — ignoring`);
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    console.error(`API key store ${sourceLabel}: expected a JSON array — ignoring`);
+    return [];
+  }
+  const records = parsed.filter(isApiKeyRecord);
+  if (records.length !== parsed.length) {
+    console.error(
+      `API key store ${sourceLabel}: dropped ${parsed.length - records.length} malformed record(s)`,
+    );
+  }
+  return records;
+}
+
+export class ApiKeyStore {
+  private readonly byHash = new Map<string, ApiKeyRecord>();
+
+  constructor(records: readonly ApiKeyRecord[] = []) {
+    for (const record of records) this.byHash.set(record.hash, record);
+  }
+
+  /** Load from explicit records → env JSON → file path, first hit wins. */
+  static fromEnv(records?: readonly ApiKeyRecord[]): ApiKeyStore {
+    if (records !== undefined) return new ApiKeyStore(records);
+    const envJson = process.env['RPE_API_KEYS'];
+    if (envJson !== undefined && envJson.trim() !== '') {
+      return new ApiKeyStore(parseKeyRecords(envJson, 'RPE_API_KEYS'));
+    }
+    const file = process.env['RPE_API_KEYS_FILE'];
+    if (file !== undefined && file.trim() !== '') {
+      try {
+        return new ApiKeyStore(parseKeyRecords(readFileSync(file, 'utf8'), file));
+      } catch (err) {
+        console.error(`API key store ${file}: unreadable —`, err instanceof Error ? err.message : String(err));
+      }
+    }
+    return new ApiKeyStore();
+  }
+
+  get size(): number {
+    return this.byHash.size;
+  }
+
+  /**
+   * Verify a presented secret. Constant-time hash comparison; returns
+   * the active record or null (missing, malformed, unknown, revoked).
+   */
+  verify(secret: string): ApiKeyRecord | null {
+    if (!secret.startsWith(KEY_PREFIX)) return null;
+    const presented = Buffer.from(hashSecret(secret), 'hex');
+    for (const [hash, record] of this.byHash) {
+      const stored = Buffer.from(hash, 'hex');
+      if (stored.length === presented.length && timingSafeEqual(stored, presented)) {
+        return record.revokedAt === null ? record : null;
+      }
+    }
+    return null;
+  }
+
+  /** Revoke by key id — effective on the next request. */
+  revoke(id: string, now: () => number = Date.now): boolean {
+    for (const record of this.byHash.values()) {
+      if (record.id === id && record.revokedAt === null) {
+        record.revokedAt = new Date(now()).toISOString();
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+/** Extract the presented key from Authorization: Bearer or X-API-Key. */
+export function extractApiKey(headers: Record<string, string | string[] | undefined>): string | null {
+  const auth = headers['authorization'];
+  const authValue = Array.isArray(auth) ? auth[0] : auth;
+  if (typeof authValue === 'string') {
+    const m = authValue.match(/^Bearer\s+(\S+)$/i);
+    if (m?.[1] !== undefined) return m[1];
+  }
+  const xKey = headers['x-api-key'];
+  const xValue = Array.isArray(xKey) ? xKey[0] : xKey;
+  if (typeof xValue === 'string' && xValue.trim() !== '') return xValue.trim();
+  return null;
+}

--- a/apps/api/tests/apiKeys.test.ts
+++ b/apps/api/tests/apiKeys.test.ts
@@ -1,0 +1,159 @@
+/**
+ * RPE-75: API key auth — store unit tests + /v1 enforcement integration.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import {
+  ApiKeyStore,
+  extractApiKey,
+  hashSecret,
+  mintKey,
+  parseKeyRecords,
+  KEY_PREFIX,
+} from '../src/services/apiKeys';
+
+describe('apiKeys (unit)', () => {
+  it('mints prefixed secrets whose plaintext never lands in the record', () => {
+    const { record, secret } = mintKey('acme');
+    expect(secret.startsWith(KEY_PREFIX)).toBe(true);
+    expect(secret.length).toBeGreaterThan(KEY_PREFIX.length + 40);
+    expect(JSON.stringify(record)).not.toContain(secret);
+    expect(record.hash).toBe(hashSecret(secret));
+    expect(record.revokedAt).toBeNull();
+  });
+
+  it('verifies a minted key and rejects unknown/garbage/unprefixed input', () => {
+    const { record, secret } = mintKey('acme');
+    const store = new ApiKeyStore([record]);
+    expect(store.verify(secret)?.id).toBe(record.id);
+    expect(store.verify(`${KEY_PREFIX}deadbeef`)).toBeNull();
+    expect(store.verify('not-a-key')).toBeNull();
+    expect(store.verify('')).toBeNull();
+  });
+
+  it('revocation takes effect on the next verify', () => {
+    const { record, secret } = mintKey('acme');
+    const store = new ApiKeyStore([record]);
+    expect(store.verify(secret)).not.toBeNull();
+    expect(store.revoke(record.id)).toBe(true);
+    expect(store.verify(secret)).toBeNull();
+    expect(store.revoke(record.id)).toBe(false); // already revoked
+  });
+
+  it('parseKeyRecords drops malformed entries instead of failing', () => {
+    const { record } = mintKey('acme');
+    const json = JSON.stringify([record, { id: 'broken' }, 42]);
+    expect(parseKeyRecords(json, 'test')).toHaveLength(1);
+    expect(parseKeyRecords('not json', 'test')).toEqual([]);
+    expect(parseKeyRecords('{"not":"array"}', 'test')).toEqual([]);
+  });
+
+  it('extractApiKey reads Bearer and X-API-Key', () => {
+    expect(extractApiKey({ authorization: 'Bearer abc' })).toBe('abc');
+    expect(extractApiKey({ authorization: 'bearer abc' })).toBe('abc');
+    expect(extractApiKey({ 'x-api-key': ' xyz ' })).toBe('xyz');
+    expect(extractApiKey({ authorization: 'Basic abc' })).toBeNull();
+    expect(extractApiKey({})).toBeNull();
+  });
+});
+
+describe('/v1 auth enforcement (integration)', () => {
+  const acme = mintKey('acme');
+  const revoked = mintKey('old-consumer');
+  revoked.record.revokedAt = '2026-01-01T00:00:00.000Z';
+
+  let server: Server;
+  let base: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server = createApp({ auth: { keys: [acme.record, revoked.record] } });
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          const addr = server.address() as { port: number };
+          base = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(
+    () => new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  );
+
+  const EVAL_BODY = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      inputs: {
+        purchasePrice: 300000, percentDown: 20, interestRate: 7,
+        loanTermYears: 30, closingCosts: 0, rollClosingCostsIntoLoan: false,
+        grossRent: 2200, vacancyPct: 5,
+        expenses: {
+          taxes: { amount: 3600, period: 'annual' },
+          insurance: { amount: 1200, period: 'annual' },
+        },
+      },
+    }),
+  };
+
+  it('rejects /v1 without a key — standard envelope', async () => {
+    const res = await fetch(`${base}/v1/evaluate`, EVAL_BODY);
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: Record<string, unknown> };
+    expect(body.error['code']).toBe('unauthorized');
+    expect(typeof body.error['requestId']).toBe('string');
+  });
+
+  it('rejects invalid and revoked keys', async () => {
+    const bad = await fetch(`${base}/v1/evaluate`, {
+      ...EVAL_BODY,
+      headers: { ...EVAL_BODY.headers, Authorization: 'Bearer rpe_live_wrong' },
+    });
+    expect(bad.status).toBe(401);
+
+    const rev = await fetch(`${base}/v1/evaluate`, {
+      ...EVAL_BODY,
+      headers: { ...EVAL_BODY.headers, Authorization: `Bearer ${revoked.secret}` },
+    });
+    expect(rev.status).toBe(401);
+  });
+
+  it('accepts a valid key via Bearer and via X-API-Key', async () => {
+    const bearer = await fetch(`${base}/v1/evaluate`, {
+      ...EVAL_BODY,
+      headers: { ...EVAL_BODY.headers, Authorization: `Bearer ${acme.secret}` },
+    });
+    expect(bearer.status).toBe(200);
+
+    const header = await fetch(`${base}/v1/evaluate`, {
+      ...EVAL_BODY,
+      headers: { ...EVAL_BODY.headers, 'X-API-Key': acme.secret },
+    });
+    expect(header.status).toBe(200);
+  });
+
+  it('leaves /v1/health and legacy unprefixed routes open', async () => {
+    expect((await fetch(`${base}/v1/health`)).status).toBe(200);
+    expect((await fetch(`${base}/health`)).status).toBe(200);
+    expect((await fetch(`${base}/evaluate`, EVAL_BODY)).status).toBe(200);
+  });
+
+  it('enforces nothing when no keys are configured (zero-config dev)', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const open = createApp({});
+      open.listen(0, '127.0.0.1', async () => {
+        const addr = open.address() as { port: number };
+        const res = await fetch(`http://127.0.0.1:${addr.port}/v1/evaluate`, EVAL_BODY);
+        expect(res.status).toBe(200);
+        open.close((err) => (err ? reject(err) : resolve()));
+      });
+    });
+  });
+});

--- a/apps/api/tests/apiKeys.test.ts
+++ b/apps/api/tests/apiKeys.test.ts
@@ -42,6 +42,14 @@ describe('apiKeys (unit)', () => {
     expect(store.revoke(record.id)).toBe(false); // already revoked
   });
 
+  it('tracks lastUsedAt in-memory on successful verify', () => {
+    const { record, secret } = mintKey('acme');
+    const store = new ApiKeyStore([record]);
+    expect(record.lastUsedAt).toBeNull();
+    store.verify(secret, () => 1_700_000_000_000);
+    expect(record.lastUsedAt).toBe(new Date(1_700_000_000_000).toISOString());
+  });
+
   it('parseKeyRecords drops malformed entries instead of failing', () => {
     const { record } = mintKey('acme');
     const json = JSON.stringify([record, { id: 'broken' }, 42]);


### PR DESCRIPTION
## Summary
- `rpe_live_`-prefixed opaque secrets, **sha256-hashed at issuance** — plaintext shown exactly once by `scripts/manage-keys.mjs` (mint/revoke/list) and unrecoverable after
- Store loads from `createApp` config (tests) → `RPE_API_KEYS` env JSON → `RPE_API_KEYS_FILE`; malformed records dropped loudly
- Constant-time verification; `Authorization: Bearer` and `X-API-Key` both accepted; missing/invalid/revoked → 401 standard envelope; `lastUsedAt` tracked in-memory per spec metadata (Phase 2 DB persists it)
- Enforcement scoping (design call, documented): `/v1` surface protected **only when keys are configured** — zero-config dev unchanged, `/v1/health` stays open for load balancers, legacy unprefixed SPA routes stay open
- Key **id** (never the secret) joins the structured request log for attribution + future rate limiting
- 11 new tests (store unit + integration: 401 missing/invalid/revoked, 200 Bearer/X-API-Key, open paths, zero-config)

## Review
Copilot unavailable; strict self-review loop. Round 1: `lastUsedAt` spec metadata was missing — added with test. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 823 tests passing
- [x] CLI smoke: mint → list → file contains hash only

🤖 Generated with [Claude Code](https://claude.com/claude-code)