### PR TITLE
RPE-78: headless PDF report pipeline (pdf-lib)

### DIFF
--- a/packages/report/package.json
+++ b/packages/report/package.json
@@ -10,7 +10,8 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@rpe/engine": "workspace:*"
+    "@rpe/engine": "workspace:*",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "typescript": "catalog:"

--- a/packages/report/src/index.ts
+++ b/packages/report/src/index.ts
@@ -23,3 +23,5 @@ export {
   type MetricSignal,
   type ReportMetric,
 } from './report';
+
+export { reportToPdf } from './pdf';

--- a/packages/report/src/pdf.ts
+++ b/packages/report/src/pdf.ts
@@ -1,0 +1,179 @@
+/**
+ * E10 — headless PDF report (RPE-78)
+ *
+ * Approach: PROGRAMMATIC via pdf-lib (vs HTML-to-PDF/Chromium).
+ * Trade-off, recorded per the ticket: pdf-lib is pure JS with zero
+ * native/browser dependencies — millisecond generation and tiny
+ * serverless cold starts — at the cost of hand-built layout instead of
+ * reusing report HTML/CSS. For a tabular metrics report the layout cost
+ * is small and fidelity is deterministic; if a designed brochure-style
+ * report is ever wanted, an HTML pipeline can sit beside this one.
+ *
+ * Rendered from the canonical DealReport (RPE-77) so JSON/CSV/PDF stay
+ * consistent. Deterministic: with a fixed meta.generatedAt the output
+ * bytes are identical run-to-run (creation/mod dates are pinned to it).
+ */
+
+import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from 'pdf-lib';
+import { fmtCurrency, fmtMultiplier, fmtPercent } from './format';
+import type { DealReport } from './report';
+
+const PAGE = { width: 595.28, height: 841.89 } as const; // A4 portrait, points
+const MARGIN = 50;
+const LINE = 16;
+
+const INK = rgb(0.07, 0.07, 0.07);
+const MID = rgb(0.4, 0.4, 0.4);
+const PASS = rgb(0.09, 0.4, 0.2);
+const FAIL = rgb(0.6, 0.11, 0.11);
+
+interface Cursor {
+  doc: PDFDocument;
+  page: PDFPage;
+  y: number;
+  font: PDFFont;
+  bold: PDFFont;
+}
+
+function newPage(c: Cursor): void {
+  c.page = c.doc.addPage([PAGE.width, PAGE.height]);
+  c.y = PAGE.height - MARGIN;
+}
+
+function ensureRoom(c: Cursor, lines: number): void {
+  if (c.y - lines * LINE < MARGIN) newPage(c);
+}
+
+function text(c: Cursor, value: string, opts: { x?: number; size?: number; bold?: boolean; color?: ReturnType<typeof rgb> } = {}): void {
+  c.page.drawText(value, {
+    x: opts.x ?? MARGIN,
+    y: c.y,
+    size: opts.size ?? 10,
+    font: opts.bold === true ? c.bold : c.font,
+    color: opts.color ?? INK,
+  });
+}
+
+function line(c: Cursor): void {
+  c.y -= LINE;
+}
+
+/** Render the canonical report as a PDF. Resolves to the document bytes. */
+export async function reportToPdf(report: DealReport): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+
+  // Deterministic output for a fixed generatedAt
+  const generated = new Date(report.meta.generatedAt);
+  doc.setCreationDate(generated);
+  doc.setModificationDate(generated);
+  doc.setTitle('Rental Property Evaluation Report');
+  doc.setProducer('@rpe/report');
+
+  const c: Cursor = { doc, page: doc.addPage([PAGE.width, PAGE.height]), y: 0, font, bold };
+  c.y = PAGE.height - MARGIN;
+
+  // ── Header ───────────────────────────────────────────────────────────
+  text(c, 'Rental Property Evaluation Report', { size: 18, bold: true });
+  c.y -= 22;
+  text(c, `Generated ${report.meta.generatedAt} · engine ${report.meta.engineVersion} · mode ${report.meta.mode}`, {
+    size: 8,
+    color: MID,
+  });
+  c.y -= 24;
+
+  // ── Deal summary ─────────────────────────────────────────────────────
+  text(c, 'Deal Summary', { size: 12, bold: true });
+  line(c);
+  const i = report.inputs;
+  const summary = [
+    `Purchase price ${fmtCurrency(i.purchasePrice)} · ${fmtPercent(i.percentDown, 0)} down · ` +
+      `${fmtPercent(i.interestRate)} / ${i.loanTermYears} yr`,
+    `Gross rent ${fmtCurrency(i.grossRent)}/mo · vacancy ${fmtPercent(i.vacancyPct, 0)} · ` +
+      `taxes ${fmtCurrency(i.expenses.taxes.amount)}/${i.expenses.taxes.period} · ` +
+      `insurance ${fmtCurrency(i.expenses.insurance.amount)}/${i.expenses.insurance.period}`,
+  ];
+  for (const s of summary) {
+    text(c, s, { size: 9 });
+    line(c);
+  }
+  c.y -= 8;
+
+  // ── Score ────────────────────────────────────────────────────────────
+  text(c, `Score: ${report.score.passing} / ${report.score.total} metrics passing (${report.score.pct.toFixed(0)}%)`, {
+    size: 12,
+    bold: true,
+    color: report.score.pct >= 75 ? PASS : report.score.pct >= 50 ? MID : FAIL,
+  });
+  c.y -= 24;
+
+  // ── Metrics table ────────────────────────────────────────────────────
+  text(c, 'Metrics', { size: 12, bold: true });
+  line(c);
+  let currentGroup = '';
+  for (const metric of report.metrics) {
+    ensureRoom(c, 2);
+    if (metric.group !== currentGroup) {
+      currentGroup = metric.group;
+      c.y -= 4;
+      text(c, currentGroup, { size: 9, bold: true, color: MID });
+      line(c);
+    }
+    text(c, metric.label, { x: MARGIN + 12, size: 9 });
+    text(c, metric.formatted, { x: 300, size: 9 });
+    if (metric.signal === 'pass' || metric.signal === 'fail') {
+      text(c, metric.signal.toUpperCase(), {
+        x: 420,
+        size: 8,
+        bold: true,
+        color: metric.signal === 'pass' ? PASS : FAIL,
+      });
+    }
+    line(c);
+  }
+
+  // ── Pro-forma ────────────────────────────────────────────────────────
+  if (report.proForma !== null && report.proForma.projection.length > 0) {
+    c.y -= 12;
+    ensureRoom(c, report.proForma.projection.length + 10);
+    text(c, 'Pro-Forma Projection', { size: 12, bold: true });
+    line(c);
+    const cols = [MARGIN + 12, 110, 200, 290, 380, 470];
+    const headers = ['Year', 'Cash Flow', 'NOI', 'Value', 'Loan', 'Equity'];
+    headers.forEach((h, idx) => text(c, h, { x: cols[idx], size: 8, bold: true, color: MID }));
+    line(c);
+    for (const year of report.proForma.projection) {
+      ensureRoom(c, 1);
+      const cells = [
+        String(year.year),
+        fmtCurrency(year.cashFlowAnnual),
+        fmtCurrency(year.noiAnnual),
+        fmtCurrency(year.propertyValue),
+        fmtCurrency(year.loanBalance),
+        fmtCurrency(year.equity),
+      ];
+      cells.forEach((v, idx) => text(c, v, { x: cols[idx], size: 8 }));
+      line(c);
+    }
+    c.y -= 8;
+    ensureRoom(c, 5);
+    text(c, 'Hold Summary', { size: 10, bold: true });
+    line(c);
+    const hold = report.proForma;
+    for (const [label, value] of [
+      ['IRR', fmtPercent(hold.irr)],
+      ['NPV', fmtCurrency(hold.npv, true)],
+      ['Equity Multiple', fmtMultiplier(hold.equityMultiple)],
+      ['Net Sale Proceeds', fmtCurrency(hold.netSaleProceeds, true)],
+      ['Total Profit', fmtCurrency(hold.totalProfit, true)],
+    ] as const) {
+      ensureRoom(c, 1);
+      text(c, label, { x: MARGIN + 12, size: 9 });
+      text(c, value, { x: 300, size: 9 });
+      line(c);
+    }
+  }
+
+  return doc.save();
+}

--- a/packages/report/tests/pdf.test.ts
+++ b/packages/report/tests/pdf.test.ts
@@ -1,0 +1,54 @@
+/**
+ * RPE-78: PDF pipeline — valid output, documented sections, determinism.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PDFDocument } from 'pdf-lib';
+import { EXAMPLE_DEAL_INPUTS } from '@rpe/engine';
+import { buildReport, reportToPdf } from '../src/index';
+
+const GENERATED_AT = '2026-06-09T00:00:00.000Z';
+
+const screenerReport = () =>
+  buildReport(EXAMPLE_DEAL_INPUTS, { generatedAt: GENERATED_AT, engineVersion: '1.5.0' });
+
+const proFormaReport = () =>
+  buildReport(
+    { ...EXAMPLE_DEAL_INPUTS, holdYears: 12, rentGrowthPct: 3, expenseGrowthPct: 2, appreciationPct: 4, sellingCostsPct: 6 },
+    { mode: 'proforma', generatedAt: GENERATED_AT, engineVersion: '1.5.0' },
+  );
+
+describe('reportToPdf', () => {
+  it('produces a valid, loadable PDF for a screener report', async () => {
+    const bytes = await reportToPdf(screenerReport());
+    expect(bytes.length).toBeGreaterThan(2_000);
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe('%PDF-');
+
+    const reloaded = await PDFDocument.load(bytes);
+    expect(reloaded.getPageCount()).toBeGreaterThanOrEqual(1);
+    expect(reloaded.getTitle()).toBe('Rental Property Evaluation Report');
+  });
+
+  it('renders pro-forma sections and paginates long projections', async () => {
+    const bytes = await reportToPdf(proFormaReport());
+    const reloaded = await PDFDocument.load(bytes);
+    // 26 metric rows + 12 projection years + summaries spill past one A4 page
+    expect(reloaded.getPageCount()).toBeGreaterThanOrEqual(2);
+  });
+
+  it('is byte-deterministic for a fixed generatedAt', async () => {
+    const a = await reportToPdf(screenerReport());
+    const b = await reportToPdf(screenerReport());
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+
+  it('pins document dates to meta.generatedAt', async () => {
+    // load() defaults to updateMetadata:true, which stamps ModificationDate
+    // on the LOADED doc — disable it so we read what's actually in the bytes
+    const reloaded = await PDFDocument.load(await reportToPdf(screenerReport()), {
+      updateMetadata: false,
+    });
+    expect(reloaded.getCreationDate()?.toISOString()).toBe(GENERATED_AT);
+    expect(reloaded.getModificationDate()?.toISOString()).toBe(GENERATED_AT);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@rpe/engine':
         specifier: workspace:*
         version: link:../engine
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -638,6 +641,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+
+  '@pdf-lib/upng@1.0.1':
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1958,6 +1967,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1986,6 +1998,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2258,6 +2273,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2794,6 +2812,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pdf-lib/standard-fonts@1.0.0':
+    dependencies:
+      pako: 1.0.11
+
+  '@pdf-lib/upng@1.0.1':
+    dependencies:
+      pako: 1.0.11
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4236,6 +4262,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4258,6 +4286,13 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdf-lib@1.17.1:
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
 
   picocolors@1.1.1: {}
 
@@ -4591,6 +4626,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@1.14.1: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## Summary
- `reportToPdf()` in `@rpe/report` rendering the canonical `DealReport` (RPE-77) so JSON/CSV/PDF stay consistent: header + generation metadata, deal summary, score (color-banded), grouped metrics with PASS/FAIL, pro-forma projection table + hold summary, A4 pagination
- **Approach + trade-off (per ticket):** programmatic **pdf-lib** over HTML-to-PDF/Chromium — pure JS, zero native/browser dependencies, millisecond generation, tiny serverless cold starts; cost is hand-built layout, which is small for a tabular metrics report. An HTML pipeline can sit beside this one if a designed brochure report is ever wanted
- Byte-deterministic for a fixed `meta.generatedAt` (creation/modification dates pinned) — suitable for snapshot/size assertions
- 4 tests: valid loadable PDF, multi-page pro-forma, byte determinism, date pinning

## Review
Copilot unavailable; strict self-review loop. Round 1 chased an apparent date-pinning failure to its real cause — pdf-lib's `load()` default (`updateMetadata: true`) stamps the **loaded** doc, not the bytes; fixed in the test with a comment. Round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 841 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)