### PR TITLE
RPE-79: POST /v1/reports — json/csv/pdf format negotiation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,8 @@
     "@rpe/engine": "workspace:*",
     "@rpe/property": "workspace:*",
     "@rpe/region-defaults": "workspace:*",
-    "@rpe/rentcast": "workspace:*"
+    "@rpe/rentcast": "workspace:*",
+    "@rpe/report": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -51,6 +51,7 @@ import {
   type ContextSuccessBody,
 } from './routes/propertyContext.js';
 import { handleRegion } from './routes/region.js';
+import { handleReports, type ValidatedEvalBody } from './routes/reports.js';
 import { handleScrape, type ScrapeDeps, type ScrapeSuccessBody } from './routes/scrape.js';
 import { RateLimiter, TtlCache, clientIp } from './services/guardrails.js';
 import { Router, logRequest, normalizePath, resolveRequestId, v1Error } from './router.js';
@@ -85,6 +86,24 @@ function json(res: ServerResponse, status: number, body: unknown): void {
   res.writeHead(status, {
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(payload),
+    ...CORS_HEADERS,
+  });
+  res.end(payload);
+}
+
+/** Raw (non-JSON) response writer for downloads — CORS included (RPE-79). */
+function sendRaw(
+  res: ServerResponse,
+  status: number,
+  contentType: string,
+  body: Uint8Array | string,
+  disposition?: string,
+): void {
+  const payload = typeof body === 'string' ? Buffer.from(body, 'utf8') : Buffer.from(body);
+  res.writeHead(status, {
+    'Content-Type': contentType,
+    'Content-Length': payload.byteLength,
+    ...(disposition !== undefined ? { 'Content-Disposition': disposition } : {}),
     ...CORS_HEADERS,
   });
   res.end(payload);
@@ -186,6 +205,114 @@ function handleHealth(req: IncomingMessage, res: ServerResponse): void {
   json(res, 200, { status: 'ok', version: VERSION });
 }
 
+/**
+ * Validate an evaluate/report request body (RPE-79 — shared by
+ * handleEvaluate and POST /v1/reports so the contract can't drift).
+ * Messages preserved verbatim from the original inline validation.
+ */
+export function validateEvaluateBody(parsed: unknown): ValidatedEvalBody {
+  const parsedObj = parsed as Record<string, unknown>;
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    !Object.hasOwn(parsedObj, 'inputs') ||
+    typeof parsedObj['inputs'] !== 'object' ||
+    parsedObj['inputs'] === null
+  ) {
+    return {
+      ok: false,
+      message: 'Request body must be { inputs: DealInputs, opts?: { mode: "screener" | "proforma" } }',
+    };
+  }
+
+  // Guard: opts, if present, must be a plain object — not a string, number, null, or array.
+  // Own-property check prevents prototype-chain values from satisfying the presence guard.
+  const rawOpts = Object.hasOwn(parsedObj, 'opts') ? parsedObj['opts'] : undefined;
+  if (
+    rawOpts !== undefined &&
+    (typeof rawOpts !== 'object' || rawOpts === null || Array.isArray(rawOpts))
+  ) {
+    return { ok: false, message: 'opts must be an object, e.g. { "mode": "screener" }' };
+  }
+
+  const { inputs, opts } = parsed as { inputs: DealInputs; opts?: EvalOptions };
+
+  if (opts?.mode !== undefined && !VALID_MODES.has(opts.mode)) {
+    return { ok: false, message: `opts.mode must be "screener" or "proforma", got "${opts.mode}"` };
+  }
+
+  // Validate required top-level fields — both presence AND type.
+  // Engine normalises absent/null numerics to 0 and non-boolean rollClosingCostsIntoLoan
+  // via Boolean() to false, both producing misleading results without a prior 400.
+  const REQUIRED_NUMERIC = [
+    'purchasePrice', 'percentDown', 'interestRate', 'loanTermYears',
+    'closingCosts', 'grossRent', 'vacancyPct',
+  ] as const;
+  const REQUIRED_BOOLEAN = ['rollClosingCostsIntoLoan'] as const;
+  const rawInputs = inputs as unknown as Record<string, unknown>;
+
+  const invalidFields: string[] = [
+    ...REQUIRED_NUMERIC.filter(
+      (k) =>
+        !Object.hasOwn(rawInputs, k) ||
+        typeof rawInputs[k] !== 'number' ||
+        !Number.isFinite(rawInputs[k] as number),
+    ),
+    ...REQUIRED_BOOLEAN.filter(
+      (k) => !Object.hasOwn(rawInputs, k) || typeof rawInputs[k] !== 'boolean',
+    ),
+  ];
+  if (invalidFields.length > 0) {
+    return { ok: false, message: `Invalid or missing required input fields: ${invalidFields.join(', ')}` };
+  }
+
+  // Guard: expenses must be a plain object — not null, not array.
+  const expField = Object.hasOwn(rawInputs, 'expenses') ? rawInputs['expenses'] : undefined;
+  if (typeof expField !== 'object' || expField === null || Array.isArray(expField)) {
+    return {
+      ok: false,
+      message:
+        'inputs.expenses must be an object including taxes and insurance, each { amount: number, period: "monthly" | "annual" }',
+    };
+  }
+  const expObj = expField as Record<string, unknown>;
+
+  if (!Object.hasOwn(expObj, 'taxes') || !Object.hasOwn(expObj, 'insurance')) {
+    return {
+      ok: false,
+      message:
+        'inputs.expenses must include taxes and insurance, each { amount: number, period: "monthly" | "annual" }',
+    };
+  }
+
+  const EXPENSE_ITEM_KEYS = new Set(['taxes', 'insurance', 'hoa', 'other']);
+  const EXPENSE_PCT_KEYS = new Set(['capExPct', 'maintPct', 'mgmtPct', 'miscPct']);
+
+  const invalidItemKeys = Object.keys(expObj).filter(
+    (k) => EXPENSE_ITEM_KEYS.has(k) && !isValidExpenseItem(expObj[k]),
+  );
+  if (invalidItemKeys.length > 0) {
+    const qualifiedItemKeys = invalidItemKeys.map((k) => `inputs.expenses.${k}`).join(', ');
+    return { ok: false, message: `${qualifiedItemKeys} must each be { amount: number, period: "monthly" | "annual" }` };
+  }
+
+  const invalidPctKeys = Object.keys(expObj).filter(
+    (k) =>
+      EXPENSE_PCT_KEYS.has(k) &&
+      (typeof expObj[k] !== 'number' || !Number.isFinite(expObj[k] as number)),
+  );
+  if (invalidPctKeys.length > 0) {
+    const qualifiedPctKeys = invalidPctKeys.map((k) => `inputs.expenses.${k}`).join(', ');
+    return { ok: false, message: `${qualifiedPctKeys} must each be a finite number` };
+  }
+
+  const format = Object.hasOwn(parsedObj, 'format') && typeof parsedObj['format'] === 'string'
+    ? parsedObj['format']
+    : null;
+
+  return { ok: true, inputs, opts, format };
+}
+
 async function handleEvaluate(req: IncomingMessage, res: ServerResponse): Promise<void> {
   if (req.method !== 'POST') {
     json(res, 405, { error: 'Method not allowed — use POST' });
@@ -210,128 +337,14 @@ async function handleEvaluate(req: IncomingMessage, res: ServerResponse): Promis
     return;
   }
 
-  const parsedObj = parsed as Record<string, unknown>;
-  if (
-    typeof parsed !== 'object' ||
-    parsed === null ||
-    !Object.hasOwn(parsedObj, 'inputs') ||
-    typeof parsedObj['inputs'] !== 'object' ||
-    parsedObj['inputs'] === null
-  ) {
-    json(res, 400, {
-      error:
-        'Request body must be { inputs: DealInputs, opts?: { mode: "screener" | "proforma" } }',
-    });
-    return;
-  }
-
-  // Guard: opts, if present, must be a plain object — not a string, number, null, or array.
-  // Without this check, `opts: "screener"` or `opts: null` would silently pass through
-  // the mode validation and reach evaluate() with the wrong shape.
-  // Own-property check prevents prototype-chain values from satisfying the presence guard.
-  const rawOpts = Object.hasOwn(parsedObj, 'opts') ? parsedObj['opts'] : undefined;
-  if (
-    rawOpts !== undefined &&
-    (typeof rawOpts !== 'object' || rawOpts === null || Array.isArray(rawOpts))
-  ) {
-    json(res, 400, { error: 'opts must be an object, e.g. { "mode": "screener" }' });
-    return;
-  }
-
-  const { inputs, opts } = parsed as { inputs: DealInputs; opts?: EvalOptions };
-
-  if (opts?.mode !== undefined && !VALID_MODES.has(opts.mode)) {
-    json(res, 400, {
-      error: `opts.mode must be "screener" or "proforma", got "${opts.mode}"`,
-    });
-    return;
-  }
-
-  // Validate required top-level fields — both presence AND type.
-  // Engine normalises absent/null numerics to 0 and non-boolean rollClosingCostsIntoLoan
-  // via Boolean() to false, both producing misleading results without a prior 400.
-  // Non-finite numbers (Infinity, NaN) are also rejected — consistent with isValidExpenseItem.
-  const REQUIRED_NUMERIC = [
-    'purchasePrice', 'percentDown', 'interestRate', 'loanTermYears',
-    'closingCosts', 'grossRent', 'vacancyPct',
-  ] as const;
-  const REQUIRED_BOOLEAN = ['rollClosingCostsIntoLoan'] as const;
-  const rawInputs = inputs as unknown as Record<string, unknown>;
-
-  const invalidFields: string[] = [
-    ...REQUIRED_NUMERIC.filter(
-      (k) =>
-        !Object.hasOwn(rawInputs, k) ||
-        typeof rawInputs[k] !== 'number' ||
-        !Number.isFinite(rawInputs[k] as number),
-    ),
-    ...REQUIRED_BOOLEAN.filter(
-      (k) => !Object.hasOwn(rawInputs, k) || typeof rawInputs[k] !== 'boolean',
-    ),
-  ];
-  if (invalidFields.length > 0) {
-    json(res, 400, {
-      error: `Invalid or missing required input fields: ${invalidFields.join(', ')}`,
-    });
-    return;
-  }
-
-  // Guard: expenses must be a plain object — not null, not array.
-  const expField = Object.hasOwn(rawInputs, 'expenses') ? rawInputs['expenses'] : undefined;
-  if (typeof expField !== 'object' || expField === null || Array.isArray(expField)) {
-    json(res, 400, {
-      error:
-        'inputs.expenses must be an object including taxes and insurance, each { amount: number, period: "monthly" | "annual" }',
-    });
-    return;
-  }
-  const expObj = expField as Record<string, unknown>;
-
-  // taxes and insurance are required ExpenseInput fields.
-  if (!Object.hasOwn(expObj, 'taxes') || !Object.hasOwn(expObj, 'insurance')) {
-    json(res, 400, {
-      error:
-        'inputs.expenses must include taxes and insurance, each { amount: number, period: "monthly" | "annual" }',
-    });
-    return;
-  }
-
-  // DealExpenses has two field categories — validate each appropriately:
-  //   ExpenseInput fields (taxes, insurance, hoa, other): { amount: number, period: "monthly"|"annual" }
-  //   Numeric % fields (capExPct, maintPct, mgmtPct, miscPct): finite number
-  // Keys outside these two sets are not validated and are silently ignored by the engine
-  // (normalizeExpenses() only maps known fields).
-  const EXPENSE_ITEM_KEYS = new Set(['taxes', 'insurance', 'hoa', 'other']);
-  const EXPENSE_PCT_KEYS = new Set(['capExPct', 'maintPct', 'mgmtPct', 'miscPct']);
-
-  const invalidItemKeys = Object.keys(expObj).filter(
-    (k) => EXPENSE_ITEM_KEYS.has(k) && !isValidExpenseItem(expObj[k]),
-  );
-  if (invalidItemKeys.length > 0) {
-    // Fully-qualify each key so the message is unambiguous (no "inputs.expenses.taxes, hoa" dotted-path confusion).
-    const qualifiedItemKeys = invalidItemKeys.map((k) => `inputs.expenses.${k}`).join(', ');
-    json(res, 400, {
-      error: `${qualifiedItemKeys} must each be { amount: number, period: "monthly" | "annual" }`,
-    });
-    return;
-  }
-
-  const invalidPctKeys = Object.keys(expObj).filter(
-    (k) =>
-      EXPENSE_PCT_KEYS.has(k) &&
-      (typeof expObj[k] !== 'number' || !Number.isFinite(expObj[k] as number)),
-  );
-  if (invalidPctKeys.length > 0) {
-    // Fully-qualify each key so the message is unambiguous.
-    const qualifiedPctKeys = invalidPctKeys.map((k) => `inputs.expenses.${k}`).join(', ');
-    json(res, 400, {
-      error: `${qualifiedPctKeys} must each be a finite number`,
-    });
+  const validated = validateEvaluateBody(parsed);
+  if (!validated.ok) {
+    json(res, 400, { error: validated.message });
     return;
   }
 
   try {
-    const results = evaluate(inputs, opts);
+    const results = evaluate(validated.inputs, validated.opts);
     json(res, 200, { results });
   } catch (err) {
     // Log full details server-side; return a generic message to clients.
@@ -466,6 +479,15 @@ export function createApp(config: AppConfig = {}) {
     .on('GET', '/geocode', (rq, rs) => handleGeocode(rq, rs, jsonWithRequestId, geocodeDeps))
     .on('POST', '/scrape', (rq, rs) => handleScrape(rq, rs, jsonWithRequestId, readBody, scrapeDeps));
 
+  // /v1-native routes (RPE-79) — never exposed on the legacy unprefixed surface
+  const v1Router = new Router()
+    .on('POST', '/reports', (rq, rs) =>
+      handleReports(rq, rs, jsonWithRequestId, readBody, {
+        validate: validateEvaluateBody,
+        engineVersion: VERSION,
+        sendRaw,
+      }));
+
   return createServer((req: IncomingMessage, res: ServerResponse) => {
     const startedAt = Date.now();
     const requestId = resolveRequestId(req);
@@ -545,7 +567,8 @@ export function createApp(config: AppConfig = {}) {
       return;
     }
 
-    const handler = router.resolve(req.method, path);
+    const handler = (isV1 ? v1Router.resolve(req.method, path) : undefined)
+      ?? router.resolve(req.method, path);
     if (handler === undefined) {
       // Unknown route: standard envelope on the /v1 surface, legacy flat
       // shape (now with requestId) for unprefixed callers
@@ -584,6 +607,7 @@ if (resolve(process.argv[1] ?? '') === __filename) {
     console.log('  POST /property/context');
     console.log('  GET  /region?zip=XXXXX');
     console.log('  GET  /geocode?q=<address>');
+    console.log('  POST /v1/reports (json|csv|pdf)');
   });
   server.on('error', (err) => {
     console.error('Server error:', err);

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,137 @@
+/**
+ * POST /v1/reports — public report endpoint (RPE-79)
+ *
+ * Body: { inputs: DealInputs, opts?: { mode }, format?: 'json'|'csv'|'pdf' }
+ *
+ * Format negotiation, in documented precedence order:
+ *   1. ?format= query parameter
+ *   2. body.format
+ *   3. Accept header (application/json | text/csv | application/pdf)
+ *   4. default: json
+ * Anything else → 406 not_acceptable (standard envelope).
+ *
+ * json → canonical DealReport; csv/pdf → attachment downloads with
+ * rpe-YYYY-MM-DD.{csv,pdf} filenames (date from meta.generatedAt).
+ *
+ * /v1-native only — auth + rate limiting + the standard envelope are
+ * applied by the dispatcher before this handler runs.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { DealInputs, EvalOptions } from '@rpe/engine';
+import { buildReport, reportToCsv, reportToPdf } from '@rpe/report';
+
+type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
+type ReadBodyFn = (req: IncomingMessage) => Promise<string>;
+type SendRawFn = (
+  res: ServerResponse,
+  status: number,
+  contentType: string,
+  body: Uint8Array | string,
+  disposition?: string,
+) => void;
+
+/** Result of validating an evaluate/report request body. */
+export type ValidatedEvalBody =
+  | { ok: true; inputs: DealInputs; opts: EvalOptions | undefined; format: string | null }
+  | { ok: false; message: string };
+
+export interface ReportsDeps {
+  /** Validator shared with handleEvaluate — single source of truth. */
+  validate: (parsed: unknown) => ValidatedEvalBody;
+  engineVersion: string;
+  sendRaw: SendRawFn;
+}
+
+export type ReportFormat = 'json' | 'csv' | 'pdf';
+
+const ACCEPT_TO_FORMAT: ReadonlyArray<readonly [string, ReportFormat]> = [
+  ['application/json', 'json'],
+  ['text/csv', 'csv'],
+  ['application/pdf', 'pdf'],
+];
+
+/** Resolve the requested format. Null = unsupported value was requested. */
+export function resolveFormat(
+  query: string | null,
+  bodyFormat: string | null,
+  acceptHeader: string | undefined,
+): ReportFormat | null {
+  const explicit = query ?? bodyFormat;
+  if (explicit !== null) {
+    return explicit === 'json' || explicit === 'csv' || explicit === 'pdf' ? explicit : null;
+  }
+  if (acceptHeader !== undefined && acceptHeader.trim() !== '' && acceptHeader !== '*/*') {
+    const match = ACCEPT_TO_FORMAT.find(([mime]) => acceptHeader.includes(mime));
+    return match?.[1] ?? null;
+  }
+  return 'json';
+}
+
+export async function handleReports(
+  req: IncomingMessage,
+  res: ServerResponse,
+  json: JsonFn,
+  readBody: ReadBodyFn,
+  deps: ReportsDeps,
+): Promise<void> {
+  if (req.method !== 'POST') {
+    json(res, 405, { error: 'Method not allowed — use POST', code: 'method_not_allowed' });
+    return;
+  }
+
+  let body: string;
+  try {
+    body = await readBody(req);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to read request body';
+    const tooLarge = msg === 'Payload too large';
+    json(res, tooLarge ? 413 : 400, { error: msg, code: tooLarge ? 'payload_too_large' : 'bad_request' });
+    return;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    json(res, 400, { error: 'Invalid JSON', code: 'bad_request' });
+    return;
+  }
+
+  const validated = deps.validate(parsed);
+  if (!validated.ok) {
+    json(res, 400, { error: validated.message, code: 'bad_request' });
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const format = resolveFormat(
+    url.searchParams.get('format'),
+    validated.format,
+    Array.isArray(req.headers.accept) ? req.headers.accept[0] : req.headers.accept,
+  );
+  if (format === null) {
+    json(res, 406, {
+      error: 'Unsupported format — use json, csv, or pdf (?format= takes precedence over Accept).',
+      code: 'not_acceptable',
+    });
+    return;
+  }
+
+  const report = buildReport(validated.inputs, {
+    mode: validated.opts?.mode,
+    engineVersion: deps.engineVersion,
+  });
+  const datestamp = report.meta.generatedAt.slice(0, 10);
+
+  if (format === 'json') {
+    json(res, 200, report);
+    return;
+  }
+  if (format === 'csv') {
+    deps.sendRaw(res, 200, 'text/csv; charset=utf-8', reportToCsv(report), `attachment; filename="rpe-${datestamp}.csv"`);
+    return;
+  }
+  const pdf = await reportToPdf(report);
+  deps.sendRaw(res, 200, 'application/pdf', pdf, `attachment; filename="rpe-${datestamp}.pdf"`);
+}

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -1,0 +1,153 @@
+/**
+ * RPE-79: POST /v1/reports — format negotiation, downloads, validation.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { mintKey } from '../src/services/apiKeys';
+import { resolveFormat } from '../src/routes/reports';
+
+const acme = mintKey('acme');
+
+const INPUTS = {
+  purchasePrice: 300000, percentDown: 20, interestRate: 7,
+  loanTermYears: 30, closingCosts: 6000, rollClosingCostsIntoLoan: false,
+  grossRent: 2200, vacancyPct: 5,
+  expenses: {
+    taxes: { amount: 4800, period: 'annual' },
+    insurance: { amount: 1800, period: 'annual' },
+  },
+};
+
+function post(base: string, path: string, body: unknown, headers: Record<string, string> = {}) {
+  return fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${acme.secret}`,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('resolveFormat precedence (unit)', () => {
+  it('query > body > Accept > json default', () => {
+    expect(resolveFormat('csv', 'pdf', 'application/json')).toBe('csv');
+    expect(resolveFormat(null, 'pdf', 'application/json')).toBe('pdf');
+    expect(resolveFormat(null, null, 'text/csv')).toBe('csv');
+    expect(resolveFormat(null, null, undefined)).toBe('json');
+    expect(resolveFormat(null, null, '*/*')).toBe('json');
+  });
+
+  it('rejects unsupported values instead of defaulting', () => {
+    expect(resolveFormat('xml', null, undefined)).toBeNull();
+    expect(resolveFormat(null, 'docx', undefined)).toBeNull();
+    expect(resolveFormat(null, null, 'application/xml')).toBeNull();
+  });
+});
+
+describe('POST /v1/reports (integration)', () => {
+  let server: Server;
+  let base: string;
+
+  beforeAll(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server = createApp({ auth: { keys: [acme.record] }, v1RateLimit: { rpm: 1000, dailyCap: 10000 } });
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', reject);
+          const addr = server.address() as { port: number };
+          base = `http://127.0.0.1:${addr.port}`;
+          resolve();
+        });
+      }),
+  );
+
+  afterAll(
+    () => new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    }),
+  );
+
+  it('returns the canonical JSON report by default', async () => {
+    const res = await post(base, '/v1/reports', { inputs: INPUTS });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const report = await res.json() as { meta: Record<string, unknown>; score: Record<string, number>; metrics: unknown[] };
+    expect(report.meta['reportVersion']).toBe(1);
+    expect(report.meta['mode']).toBe('screener');
+    expect(typeof report.meta['engineVersion']).toBe('string');
+    expect(report.metrics.length).toBeGreaterThan(20);
+    expect(report.score['total']).toBeGreaterThan(0);
+  });
+
+  it('returns a CSV attachment for ?format=csv', async () => {
+    const res = await post(base, '/v1/reports?format=csv', { inputs: INPUTS });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/csv');
+    expect(res.headers.get('content-disposition')).toMatch(/^attachment; filename="rpe-\d{4}-\d{2}-\d{2}\.csv"$/);
+    const csv = await res.text();
+    expect(csv.startsWith('Group,Metric,Value')).toBe(true);
+    expect(csv).toContain('Returns,Cap Rate');
+  });
+
+  it('returns a PDF attachment via the Accept header', async () => {
+    const res = await post(base, '/v1/reports', { inputs: INPUTS }, { Accept: 'application/pdf' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(res.headers.get('content-disposition')).toMatch(/\.pdf"$/);
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(new TextDecoder().decode(bytes.slice(0, 5))).toBe('%PDF-');
+    expect(bytes.length).toBeGreaterThan(2_000);
+  });
+
+  it('query format beats both body format and Accept', async () => {
+    const res = await post(
+      base,
+      '/v1/reports?format=json',
+      { inputs: INPUTS, format: 'csv' },
+      { Accept: 'application/pdf' },
+    );
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+
+  it('embeds pro-forma in the report when mode is proforma', async () => {
+    const res = await post(base, '/v1/reports', {
+      inputs: { ...INPUTS, holdYears: 5, appreciationPct: 4 },
+      opts: { mode: 'proforma' },
+    });
+    const report = await res.json() as { proForma: { projection: unknown[] } | null };
+    expect(report.proForma?.projection).toHaveLength(5);
+  });
+
+  it('406 with the standard envelope for unsupported formats', async () => {
+    const res = await post(base, '/v1/reports?format=xml', { inputs: INPUTS });
+    expect(res.status).toBe(406);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['code']).toBe('not_acceptable');
+    expect(typeof body['requestId']).toBe('string');
+  });
+
+  it('400 envelope on invalid inputs (shared validator)', async () => {
+    const res = await post(base, '/v1/reports', { inputs: { purchasePrice: 'NaN' } });
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body['code']).toBe('bad_request');
+    expect(String(body['error'])).toContain('Invalid or missing required input fields');
+  });
+
+  it('401 without a key; the legacy surface has no /reports route', async () => {
+    const unauth = await fetch(`${base}/v1/reports`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ inputs: INPUTS }),
+    });
+    expect(unauth.status).toBe(401);
+
+    const legacy = await post(base, '/reports', { inputs: INPUTS });
+    expect(legacy.status).toBe(404);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@rpe/rentcast':
         specifier: workspace:*
         version: link:../../packages/rentcast
+      '@rpe/report':
+        specifier: workspace:*
+        version: link:../../packages/report
     devDependencies:
       '@types/node':
         specifier: ^20.0.0


### PR DESCRIPTION
## Summary
- `POST /v1/reports` (`{ inputs, opts?, format? }`): canonical JSON report, CSV attachment, or PDF attachment — filenames `rpe-YYYY-MM-DD.{csv,pdf}`, correct Content-Type/Content-Disposition per format
- **Format precedence (documented):** `?format=` query > `body.format` > `Accept` header > json default; unsupported values return 406 `not_acceptable` instead of silently defaulting
- Input validation extracted from `handleEvaluate` into `validateEvaluateBody()` — messages preserved verbatim, shared by both endpoints so the contract can't drift; `/v1/evaluate` is thereby the hardened, authed, throttled evaluate per the ticket
- `/v1`-native router: `/reports` is never exposed on the legacy unprefixed surface
- 10 new tests (precedence unit + per-format integration incl. PDF magic bytes, pro-forma embedding, 400/401/404/406)

## Review
Copilot unavailable; strict self-review loop — clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 851 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)