### PR TITLE
RPE-85: API test harness + per-release regression gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,10 @@ Origin is configured at `github.com:LowerMedia/rental-property-evaluator`. Full 
 pnpm lint && pnpm typecheck && pnpm test && pnpm build
 ```
 
-All four must pass. Tests currently: 799 tests, 43 files.
+All four must pass. Tests currently: 799 tests, 43 files. The API
+regression suite (apps/api/tests/regression.test.ts, see
+docs/api-testing.md) rides in `pnpm test` — a red API suite blocks the
+release.
 
 ## Tailwind CSS v4 source scanning
 

--- a/apps/api/tests/helpers/harness.ts
+++ b/apps/api/tests/helpers/harness.ts
@@ -1,0 +1,101 @@
+/**
+ * E10 — reusable API test harness (RPE-85)
+ *
+ * Boots apps/api in-process and exercises it over real HTTP. Every new
+ * /v1 endpoint adds its cases through this harness (see
+ * docs/api-testing.md) instead of hand-rolling server boots.
+ *
+ * Usage:
+ *   const api = await startTestApi();          // ephemeral key minted
+ *   try {
+ *     const res = await api.post('/v1/evaluate', { inputs });
+ *   } finally {
+ *     await api.stop();
+ *   }
+ */
+
+import type { Server } from 'node:http';
+import { createApp, type AppConfig } from '../../src/index';
+import { mintKey, type ApiKeyRecord } from '../../src/services/apiKeys';
+
+export interface TestApi {
+  base: string;
+  /** Ephemeral key secret minted for this instance. */
+  key: string;
+  keyRecord: ApiKeyRecord;
+  /** Authed GET. */
+  get: (path: string, headers?: Record<string, string>) => Promise<Response>;
+  /** Authed POST with a JSON body. */
+  post: (path: string, body: unknown, headers?: Record<string, string>) => Promise<Response>;
+  /** Unauthenticated request (any method). */
+  raw: (path: string, init?: RequestInit) => Promise<Response>;
+  stop: () => Promise<void>;
+}
+
+export interface TestApiOptions {
+  /** Merged over the harness defaults (high limits, caching off). */
+  config?: AppConfig;
+  /** Skip minting/configuring a key (zero-config surface testing). */
+  withoutAuth?: boolean;
+}
+
+/** Boot the API on an ephemeral port with an ephemeral key. */
+export function startTestApi(options: TestApiOptions = {}): Promise<TestApi> {
+  const minted = mintKey('test-harness');
+  const config: AppConfig = {
+    property: { cacheTtlMs: 0, rpm: 1000, dailyCap: 100000 },
+    v1RateLimit: { rpm: 1000, dailyCap: 100000 },
+    ...(options.withoutAuth === true ? {} : { auth: { keys: [minted.record] } }),
+    ...options.config,
+  };
+
+  return new Promise((resolve, reject) => {
+    const server: Server = createApp(config);
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      const addr = server.address() as { port: number };
+      const base = `http://127.0.0.1:${addr.port}`;
+      const authHeaders = options.withoutAuth === true ? {} : { Authorization: `Bearer ${minted.secret}` };
+
+      resolve({
+        base,
+        key: minted.secret,
+        keyRecord: minted.record,
+        get: (path, headers = {}) => fetch(`${base}${path}`, { headers: { ...authHeaders, ...headers } }),
+        post: (path, body, headers = {}) =>
+          fetch(`${base}${path}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...authHeaders, ...headers },
+            body: JSON.stringify(body),
+          }),
+        raw: (path, init) => fetch(`${base}${path}`, init),
+        stop: () =>
+          new Promise<void>((res, rej) => server.close((err) => (err ? rej(err) : res()))),
+      });
+    });
+  });
+}
+
+// ─── Format assertions ────────────────────────────────────────────────────────
+
+export async function expectCsvAttachment(res: Response): Promise<string> {
+  if (res.status !== 200) throw new Error(`expected 200, got ${res.status}`);
+  const type = res.headers.get('content-type') ?? '';
+  if (!type.includes('text/csv')) throw new Error(`expected text/csv, got ${type}`);
+  const disposition = res.headers.get('content-disposition') ?? '';
+  if (!/^attachment; filename="rpe-\d{4}-\d{2}-\d{2}\.csv"$/.test(disposition)) {
+    throw new Error(`unexpected disposition: ${disposition}`);
+  }
+  return res.text();
+}
+
+export async function expectPdfAttachment(res: Response): Promise<Uint8Array> {
+  if (res.status !== 200) throw new Error(`expected 200, got ${res.status}`);
+  const type = res.headers.get('content-type') ?? '';
+  if (type !== 'application/pdf') throw new Error(`expected application/pdf, got ${type}`);
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  const magic = new TextDecoder().decode(bytes.slice(0, 5));
+  if (magic !== '%PDF-') throw new Error(`not a PDF (magic: ${magic})`);
+  return bytes;
+}

--- a/apps/api/tests/regression.test.ts
+++ b/apps/api/tests/regression.test.ts
@@ -1,0 +1,105 @@
+/**
+ * RPE-85: per-release regression gate — harness-driven baseline + golden
+ * report snapshots. Runs in `pnpm test`, which the release ship sequence
+ * requires green; a red suite blocks the release.
+ *
+ * Golden values use the EXAMPLE deal (hand-verified in RPE-68) so any
+ * engine/report change that shifts public output fails loudly here.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { EXAMPLE_DEAL_INPUTS } from '@rpe/engine';
+import { startTestApi, expectCsvAttachment, expectPdfAttachment, type TestApi } from './helpers/harness';
+
+describe('release regression gate (harness)', () => {
+  let api: TestApi;
+
+  beforeAll(async () => {
+    api = await startTestApi();
+  });
+
+  afterAll(() => api.stop());
+
+  it('baseline: health, auth, validation through the harness client', async () => {
+    expect((await api.get('/v1/health')).status).toBe(200);
+
+    const noKey = await api.raw('/v1/evaluate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ inputs: EXAMPLE_DEAL_INPUTS }),
+    });
+    expect(noKey.status).toBe(401);
+
+    const bad = await api.post('/v1/evaluate', { inputs: {} });
+    expect(bad.status).toBe(400);
+  });
+
+  it('golden: /v1/evaluate reproduces the hand-verified Example numbers', async () => {
+    const res = await api.post('/v1/evaluate', { inputs: EXAMPLE_DEAL_INPUTS });
+    expect(res.status).toBe(200);
+    const { results } = await res.json() as { results: Record<string, number | null> };
+
+    // Locked to EXAMPLE_DEAL_EXPECTED (RPE-68) — the engine lock test
+    // guards the math; this guards the PUBLIC API serialization of it
+    expect(results['noiMonthly']).toBe(1_100);
+    expect(results['capRate']).toBeCloseTo(4.4, 10);
+    expect(results['cashFlowMonthly']).toBeCloseTo(-496.73, 2);
+    expect(results['dscr']).toBeCloseTo(0.6889, 4);
+    expect(results['totalCashInvested']).toBe(66_000);
+  });
+
+  it('golden: JSON report snapshot (stable fields)', async () => {
+    const res = await api.post('/v1/reports', { inputs: EXAMPLE_DEAL_INPUTS });
+    const report = await res.json() as {
+      meta: Record<string, unknown>;
+      score: Record<string, number>;
+      metrics: Array<{ key: string; formatted: string; signal: string }>;
+    };
+
+    expect(report.meta['reportVersion']).toBe(1);
+    expect(report.score['total']).toBe(14);
+    // Snapshot the formatted/signal pairs — the public face of the report
+    const byKey = Object.fromEntries(report.metrics.map((m) => [m.key, `${m.formatted}|${m.signal}`]));
+    expect(byKey['capRate']).toBe('4.40%|fail');
+    expect(byKey['cashFlowMonthly']).toBe('-$496.73|fail');
+    expect(byKey['dscr']).toBe('0.69×|fail');
+    expect(byKey['ltv']).toBe('80.0%|pass');
+    expect(byKey['grossYield']).toBe('8.80%|pass');
+    expect(byKey['loanAmount']).toBe('$240,000|info');
+  });
+
+  it('golden: CSV report snapshot lines', async () => {
+    const csv = await expectCsvAttachment(await api.post('/v1/reports?format=csv', { inputs: EXAMPLE_DEAL_INPUTS }));
+    expect(csv).toContain('Returns,Cap Rate,4.40%');
+    expect(csv).toContain('Loan,Loan Amount,"$240,000"');
+    expect(csv).toContain('Capital,Total Cash Invested,"$66,000"');
+  });
+
+  it('golden: PDF generates within the locked size band', async () => {
+    const bytes = await expectPdfAttachment(
+      await api.post('/v1/reports?format=pdf', { inputs: EXAMPLE_DEAL_INPUTS }),
+    );
+    // Loose band — catches blank/exploding output without pinning bytes
+    // (generatedAt varies per request)
+    expect(bytes.length).toBeGreaterThan(2_000);
+    expect(bytes.length).toBeLessThan(50_000);
+  });
+
+  it('rate limit + revocation through the harness', async () => {
+    const tight = await startTestApi({ config: { v1RateLimit: { rpm: 1, dailyCap: 100 } } });
+    try {
+      expect((await tight.get('/v1/health')).status).toBe(200);
+      const limited = await tight.get('/v1/health');
+      expect(limited.status).toBe(429);
+      expect(limited.headers.get('retry-after')).not.toBeNull();
+    } finally {
+      await tight.stop();
+    }
+
+    // Revocation: flip the record and the next request fails
+    api.keyRecord.revokedAt = new Date().toISOString();
+    const revoked = await api.post('/v1/evaluate', { inputs: EXAMPLE_DEAL_INPUTS });
+    expect(revoked.status).toBe(401);
+    api.keyRecord.revokedAt = null; // restore for any later cases
+  });
+});

--- a/docs/api-testing.md
+++ b/docs/api-testing.md
@@ -1,0 +1,49 @@
+# API testing convention (RPE-85)
+
+The public API is verified at HTTP level on **every release** — the
+regression suite is part of `pnpm test`, which the ship sequence requires
+green before any cherry-pick or squash. A red API suite blocks the release.
+
+## The harness
+
+`apps/api/tests/helpers/harness.ts` boots `apps/api` in-process on an
+ephemeral port with an ephemeral hashed key and returns a small client:
+
+```ts
+import { startTestApi, expectCsvAttachment, expectPdfAttachment } from './helpers/harness';
+
+const api = await startTestApi();             // or { withoutAuth: true } / { config: {...} }
+try {
+  const res = await api.post('/v1/evaluate', { inputs });   // authed JSON POST
+  const csv = await expectCsvAttachment(await api.post('/v1/reports?format=csv', { inputs }));
+} finally {
+  await api.stop();
+}
+```
+
+Helpers: `api.get/post` (authed), `api.raw` (unauthenticated, any method),
+`expectCsvAttachment` / `expectPdfAttachment` (status + content-type +
+disposition + magic-byte checks).
+
+## Definition of done for any new /v1 endpoint or version
+
+1. **Harness cases** in `apps/api/tests/` using `startTestApi` — no
+   hand-rolled server boots. Cover at minimum: happy path, 400 envelope,
+   401 without key, and the endpoint's specific failure modes.
+2. **OpenAPI entry** in `apps/api/src/openapi.ts` — the drift test
+   (`openapi.test.ts`) fails in both directions if spec and routes diverge;
+   update `IMPLEMENTED_V1` there too.
+3. **Golden lock** when the endpoint's output derives from the engine or
+   report model — add stable-field snapshots to `regression.test.ts` so
+   output shifts fail loudly.
+4. **Contract additions** in `contract.test.ts` if the endpoint introduces
+   new header, CORS, or abuse-handling behavior.
+
+## Where things live
+
+| Suite | Locks |
+|---|---|
+| `regression.test.ts` | Release gate: golden Example-deal numbers across `/v1/evaluate` + all report formats, auth/limit/revocation baseline |
+| `contract.test.ts` | CORS policy, security headers, fuzz/abuse battery, 401→200→429 walk |
+| `openapi.test.ts` | Spec ↔ routes drift, both directions |
+| `router.test.ts` / `apiKeys.test.ts` / `v1RateLimit.test.ts` / `reports.test.ts` | Per-story behavior detail |


### PR DESCRIPTION
## Summary
- `startTestApi()` harness (`tests/helpers/harness.ts`): boots `apps/api` in-process on an ephemeral port with an ephemeral hashed key; authed `get`/`post`, unauthenticated `raw`, and `expectCsvAttachment`/`expectPdfAttachment` asserts — the durable home for all `/v1` endpoint tests
- Regression suite golden-locks the **public** surface to the hand-verified Example deal (RPE-68): `/v1/evaluate` numbers, JSON report formatted/signal pairs, CSV lines, PDF size band; plus auth/limit/revocation baseline
- Convention + definition-of-done checklist in `docs/api-testing.md` (harness cases, OpenAPI entry + drift list, golden locks, contract additions); CLAUDE.md gate section notes that a red API suite blocks the release
- 6 new harness-driven tests; suite rides in `pnpm test`, already required by the ship sequence

## Review
Copilot unavailable; strict self-review loop — clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — 878 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)