### PR TITLE
RPE-95: transactional email — Mailer interface, Resend provider, sandbox

### DIFF
--- a/apps/api/src/services/mailer.ts
+++ b/apps/api/src/services/mailer.ts
@@ -1,0 +1,137 @@
+/**
+ * E11 — transactional email (RPE-95)
+ *
+ * A deliberately small Mailer interface so the provider is swappable and
+ * mockable. Two implementations:
+ *
+ *   - ResendMailer — HTTP API via fetch, zero SDK dependency. Configure
+ *     with RPE_MAIL_PROVIDER=resend, RESEND_API_KEY, RPE_MAIL_FROM
+ *     ("Deals <noreply@yourdomain>" — the domain must be verified in
+ *     Resend for deliverability; see docs note).
+ *   - SandboxMailer — captures sends in memory; the default whenever no
+ *     provider is configured, so CI/local NEVER send real email.
+ *
+ * Templates (verification / password reset / org invite) are plain
+ * text + minimal HTML with explicit link-expiry messaging.
+ */
+
+export interface MailMessage {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export interface Mailer {
+  send(message: MailMessage): Promise<void>;
+}
+
+// ─── Sandbox ──────────────────────────────────────────────────────────────────
+
+/** In-memory capture — the CI/local default and the harness assertion point. */
+export class SandboxMailer implements Mailer {
+  readonly sent: MailMessage[] = [];
+
+  async send(message: MailMessage): Promise<void> {
+    this.sent.push(message);
+  }
+}
+
+// ─── Resend (HTTP, no SDK) ────────────────────────────────────────────────────
+
+const RESEND_TIMEOUT_MS = 10_000;
+
+export class ResendMailer implements Mailer {
+  constructor(
+    private readonly apiKey: string,
+    private readonly from: string,
+  ) {}
+
+  async send(message: MailMessage): Promise<void> {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: this.from,
+        to: [message.to],
+        subject: message.subject,
+        text: message.text,
+        html: message.html,
+      }),
+      signal: AbortSignal.timeout(RESEND_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      // Never log recipient addresses alongside failures beyond what's
+      // needed to debug — status only
+      throw new Error(`Resend send failed: HTTP ${res.status}`);
+    }
+  }
+}
+
+/** Env-driven construction: Resend when configured, sandbox otherwise. */
+export function createMailerFromEnv(): Mailer {
+  const provider = (process.env['RPE_MAIL_PROVIDER'] ?? '').toLowerCase();
+  if (provider === 'resend') {
+    const apiKey = process.env['RESEND_API_KEY'] ?? '';
+    const from = process.env['RPE_MAIL_FROM'] ?? '';
+    if (apiKey === '' || from === '') {
+      throw new Error('RPE_MAIL_PROVIDER=resend requires RESEND_API_KEY and RPE_MAIL_FROM');
+    }
+    return new ResendMailer(apiKey, from);
+  }
+  return new SandboxMailer();
+}
+
+// ─── Templates ────────────────────────────────────────────────────────────────
+
+const APP_NAME = 'Rental Property Evaluator';
+
+function htmlShell(title: string, bodyHtml: string): string {
+  return `<!doctype html><html><body style="font-family:system-ui,sans-serif;max-width:540px;margin:0 auto;padding:24px;color:#111">
+<h2 style="font-weight:600">${title}</h2>
+${bodyHtml}
+<p style="color:#888;font-size:12px;margin-top:32px">${APP_NAME} — if you didn't request this, you can safely ignore this email.</p>
+</body></html>`;
+}
+
+export function verificationEmail(to: string, verifyUrl: string): MailMessage {
+  return {
+    to,
+    subject: `Verify your email — ${APP_NAME}`,
+    text: `Confirm your email address by opening this link (valid for 1 hour):\n\n${verifyUrl}\n\nIf you didn't create an account, ignore this email.`,
+    html: htmlShell(
+      'Verify your email',
+      `<p>Confirm your email address by clicking the link below. The link is valid for <strong>1 hour</strong>.</p>
+<p><a href="${verifyUrl}">Verify email address</a></p>`,
+    ),
+  };
+}
+
+export function passwordResetEmail(to: string, resetUrl: string): MailMessage {
+  return {
+    to,
+    subject: `Reset your password — ${APP_NAME}`,
+    text: `Reset your password by opening this link (valid for 1 hour, single use):\n\n${resetUrl}\n\nIf you didn't request a reset, ignore this email — your password is unchanged.`,
+    html: htmlShell(
+      'Reset your password',
+      `<p>Reset your password by clicking the link below. The link is valid for <strong>1 hour</strong> and can be used once.</p>
+<p><a href="${resetUrl}">Reset password</a></p>`,
+    ),
+  };
+}
+
+export function orgInviteEmail(to: string, orgName: string, acceptUrl: string): MailMessage {
+  return {
+    to,
+    subject: `You're invited to ${orgName} — ${APP_NAME}`,
+    text: `You've been invited to join ${orgName}. Accept the invitation here (valid for 48 hours):\n\n${acceptUrl}`,
+    html: htmlShell(
+      `Join ${orgName}`,
+      `<p>You've been invited to join <strong>${orgName}</strong>. The invitation is valid for <strong>48 hours</strong>.</p>
+<p><a href="${acceptUrl}">Accept invitation</a></p>`,
+    ),
+  };
+}

--- a/apps/api/src/services/session.ts
+++ b/apps/api/src/services/session.ts
@@ -9,8 +9,9 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { fromNodeHeaders } from 'better-auth/node';
-import type { RpeAuth } from '@rpe/db';
+import { createAuth, type CreateAuthOptions, type RpeAuth } from '@rpe/db';
 import { v1Error } from '../router.js';
+import { passwordResetEmail, verificationEmail, type Mailer } from './mailer.js';
 
 type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
 
@@ -54,4 +55,24 @@ export async function requireSession(
     return null;
   }
   return context;
+}
+
+/**
+ * Convenience constructor binding @rpe/db's createAuth to our Mailer
+ * templates (RPE-95) — verification + reset emails flow through the
+ * injected Mailer (sandbox in CI, Resend in production).
+ */
+export function createSessionAuth(
+  options: Omit<CreateAuthOptions, 'sendVerificationEmail' | 'sendResetPassword'> & { mailer: Mailer },
+): RpeAuth {
+  const { mailer, ...rest } = options;
+  return createAuth({
+    ...rest,
+    sendVerificationEmail: async ({ email, url }) => {
+      await mailer.send(verificationEmail(email, url));
+    },
+    sendResetPassword: async ({ email, url }) => {
+      await mailer.send(passwordResetEmail(email, url));
+    },
+  });
 }

--- a/apps/api/tests/mailer.test.ts
+++ b/apps/api/tests/mailer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * RPE-95: Mailer interface — sandbox capture, env construction, Resend
+ * HTTP provider (fetch-mocked), templates, and the better-auth hook
+ * wiring proven end-to-end (sign-up triggers a captured verification
+ * email through the sandbox).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { createSessionAuth } from '../src/services/session';
+import {
+  createMailerFromEnv,
+  orgInviteEmail,
+  passwordResetEmail,
+  ResendMailer,
+  SandboxMailer,
+  verificationEmail,
+} from '../src/services/mailer';
+import { createDb, type RpeDb } from '@rpe/db';
+
+describe('mailer construction (env)', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('defaults to the sandbox — CI/local never send real email', () => {
+    vi.stubEnv('RPE_MAIL_PROVIDER', '');
+    expect(createMailerFromEnv()).toBeInstanceOf(SandboxMailer);
+  });
+
+  it('builds Resend only with complete credentials', () => {
+    vi.stubEnv('RPE_MAIL_PROVIDER', 'resend');
+    vi.stubEnv('RESEND_API_KEY', 're_test');
+    vi.stubEnv('RPE_MAIL_FROM', 'Deals <noreply@example.com>');
+    expect(createMailerFromEnv()).toBeInstanceOf(ResendMailer);
+
+    vi.stubEnv('RESEND_API_KEY', '');
+    expect(() => createMailerFromEnv()).toThrow(/requires RESEND_API_KEY/);
+  });
+});
+
+describe('ResendMailer (HTTP, fetch-mocked)', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('POSTs the message to the Resend API with auth', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      { ok: true, status: 200, json: () => Promise.resolve({}) } as unknown as Response,
+    );
+    const mailer = new ResendMailer('re_key', 'Deals <noreply@example.com>');
+    await mailer.send(verificationEmail('to@example.com', 'https://app/verify?token=t'));
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.resend.com/emails',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer re_key');
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body['to']).toEqual(['to@example.com']);
+    expect(body['from']).toBe('Deals <noreply@example.com>');
+  });
+
+  it('throws with status only on failure (no recipient in the error)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      { ok: false, status: 422 } as unknown as Response,
+    );
+    const mailer = new ResendMailer('re_key', 'noreply@example.com');
+    await expect(
+      mailer.send(verificationEmail('secret-user@example.com', 'https://x')),
+    ).rejects.toSatisfy((err: Error) => {
+      expect(err.message).toContain('422');
+      expect(err.message).not.toContain('secret-user');
+      return true;
+    });
+  });
+});
+
+describe('templates', () => {
+  it('carry the link and explicit expiry messaging in text and html', () => {
+    const v = verificationEmail('a@b.c', 'https://app/verify?token=t1');
+    expect(v.text).toContain('https://app/verify?token=t1');
+    expect(v.html).toContain('https://app/verify?token=t1');
+    expect(v.text).toContain('1 hour');
+
+    const r = passwordResetEmail('a@b.c', 'https://app/reset?token=t2');
+    expect(r.text).toContain('single use');
+    expect(r.html).toContain('1 hour');
+
+    const i = orgInviteEmail('a@b.c', 'Acme Holdings', 'https://app/invite?token=t3');
+    expect(i.subject).toContain('Acme Holdings');
+    expect(i.text).toContain('48 hours');
+  });
+});
+
+describe('better-auth hook wiring (integration)', () => {
+  let db: RpeDb;
+  let server: Server;
+
+  beforeEach(() => vi.restoreAllMocks()); // the Resend suite mocks global fetch
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+    await db.close();
+  });
+
+  it('sign-up triggers a captured verification email through the sandbox', async () => {
+    db = createDb(':memory:');
+    await db.applyMigrations();
+    const sandbox = new SandboxMailer();
+
+    const probe = createApp({});
+    const port: number = await new Promise((resolve) => {
+      probe.listen(0, '127.0.0.1', () => {
+        const addr = probe.address() as { port: number };
+        probe.close(() => resolve(addr.port));
+      });
+    });
+    const base = `http://127.0.0.1:${port}`;
+
+    const auth = createSessionAuth({
+      db,
+      secret: 'rpe-test-secret-0123456789abcdef0123456789abcdef',
+      baseURL: base,
+      trustedOrigins: [base],
+      mailer: sandbox,
+      sendVerificationOnSignUp: true,
+    });
+    server = createApp({ session: { auth }, v1RateLimit: { rpm: 1000, dailyCap: 100000 } });
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, '127.0.0.1', () => {
+        server.off('error', reject);
+        resolve();
+      });
+    });
+
+    const res = await fetch(`${base}/v1/auth/sign-up/email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: base },
+      body: JSON.stringify({ email: 'verifyme@example.com', password: 'a-strong-password-123', name: 'V' }),
+    });
+    expect(res.status).toBe(200);
+
+    expect(sandbox.sent).toHaveLength(1);
+    expect(sandbox.sent[0]?.to).toBe('verifyme@example.com');
+    expect(sandbox.sent[0]?.subject).toContain('Verify your email');
+    expect(sandbox.sent[0]?.text).toMatch(/https?:\/\/[^\s]+/); // a live verification link
+  });
+});

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -27,6 +27,9 @@ const ARGON2ID_PARAMS = {
   parallelism: 1,
 } as const;
 
+/** Mailer-agnostic send hook — apps/api binds these to its Mailer (RPE-95). */
+export type SendEmailHook = (data: { email: string; url: string }) => Promise<void>;
+
 export interface CreateAuthOptions {
   db: RpeDb;
   /** BETTER_AUTH_SECRET — ≥32 chars, env-provided, never committed. */
@@ -35,6 +38,11 @@ export interface CreateAuthOptions {
   baseURL: string;
   /** Browser origins allowed to drive cookie-auth flows (CSRF origin check). */
   trustedOrigins?: string[];
+  /** Email-verification send hook (+ optional send-on-sign-up, RPE-90 flips it). */
+  sendVerificationEmail?: SendEmailHook;
+  sendVerificationOnSignUp?: boolean;
+  /** Password-reset send hook (RPE-92 consumes). */
+  sendResetPassword?: SendEmailHook;
 }
 
 export function createAuth(options: CreateAuthOptions) {
@@ -55,7 +63,24 @@ export function createAuth(options: CreateAuthOptions) {
         hash: (password) => hash(password, ARGON2ID_PARAMS),
         verify: ({ hash: stored, password }) => verify(stored, password),
       },
+      ...(options.sendResetPassword !== undefined
+        ? {
+            sendResetPassword: async ({ user, url }) => {
+              await options.sendResetPassword!({ email: user.email, url });
+            },
+          }
+        : {}),
     },
+    ...(options.sendVerificationEmail !== undefined
+      ? {
+          emailVerification: {
+            sendOnSignUp: options.sendVerificationOnSignUp ?? false,
+            sendVerificationEmail: async ({ user, url }) => {
+              await options.sendVerificationEmail!({ email: user.email, url });
+            },
+          },
+        }
+      : {}),
     advanced: {
       // better-auth SKIPS the CSRF origin check by default when
       // NODE_ENV=test — pin it on so tests exercise exactly what


### PR DESCRIPTION
## Summary
- Swappable `Mailer` interface: `ResendMailer` over the HTTP API via fetch (zero SDK dependencies — `RPE_MAIL_PROVIDER=resend`, `RESEND_API_KEY`, `RPE_MAIL_FROM` with a Resend-verified domain for deliverability) and `SandboxMailer` (in-memory capture, the **default** whenever no provider is configured — CI/local never send real email)
- Templates: email verification, password reset, org invite — text + HTML with explicit link-expiry messaging (1 h / 1 h single-use / 48 h)
- `@rpe/db.createAuth` gains mailer-agnostic `sendVerificationEmail`/`sendResetPassword` hooks (+ `sendVerificationOnSignUp` passthrough for RPE-90); `createSessionAuth()` in apps/api binds the templates in
- Hook wiring proven end to end: sign-up captures a verification email with a live link in the sandbox; Resend failures report status only, never the recipient
- 6 new tests (897 total)

## Review
Copilot unavailable; strict self-review loop — round 1 caught a fetch-mock bleed between suites (the integration test was hitting the Resend mock); round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green, explicit exit codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)