### PR TITLE
RPE-91: login/logout — brute-force lockout via better-auth hooks

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -645,6 +645,10 @@ export function createApp(config: AppConfig = {}) {
         json(res, 404, v1Error('not_found', 'Session auth is not enabled on this server.', requestId));
         return;
       }
+      // Resolve the client IP under the RPE-76 trust boundary (XFF
+      // first hop, socket fallback) so the login throttle never
+      // collapses direct connections into one shared bucket
+      req.headers['x-rpe-client-ip'] = clientIp(req);
       sessionAuthHandler(req, res).catch((err: unknown) => {
         console.error('Auth handler error:', err instanceof Error ? err.stack : String(err), 'requestId:', requestId);
         if (!res.headersSent) {

--- a/apps/api/tests/login.test.ts
+++ b/apps/api/tests/login.test.ts
@@ -1,0 +1,135 @@
+/**
+ * RPE-91: login/logout through /v1/auth — generic 401 (no enumeration),
+ * per-account + per-IP brute-force lockout via the hook-mounted
+ * LoginThrottle, success reset, and logout revocation.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { createDb, createAuth, type RpeAuth, type RpeDb } from '@rpe/db';
+
+const SECRET = 'rpe-test-secret-0123456789abcdef0123456789abcdef';
+const PASSWORD = 'a-strong-password-123';
+
+let db: RpeDb;
+let auth: RpeAuth;
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+
+  const probe = createApp({});
+  const port: number = await new Promise((resolve) => {
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address() as { port: number };
+      probe.close(() => resolve(addr.port));
+    });
+  });
+  base = `http://127.0.0.1:${port}`;
+  auth = createAuth({ db, secret: SECRET, baseURL: base, trustedOrigins: [base] });
+  server = createApp({ session: { auth }, v1RateLimit: { rpm: 10000, dailyCap: 100000 } });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  // Seed accounts
+  for (const email of ['login@example.com', 'locked@example.com', 'bystander@example.com']) {
+    const res = await post('/sign-up/email', { email, password: PASSWORD, name: 'U' }, '198.51.100.250');
+    expect(res.status).toBe(200);
+  }
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  await db.close();
+});
+
+function post(path: string, body: unknown, ip: string, cookie?: string) {
+  return fetch(`${base}/v1/auth${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: base,
+      'X-Forwarded-For': ip,
+      ...(cookie !== undefined ? { Cookie: cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const signIn = (email: string, password: string, ip: string) =>
+  post('/sign-in/email', { email, password }, ip);
+
+describe('login/logout (RPE-91)', () => {
+  it('issues a session on correct credentials; logout revokes it', async () => {
+    const res = await signIn('login@example.com', PASSWORD, '203.0.113.1');
+    expect(res.status).toBe(200);
+    const cookie = (res.headers.get('set-cookie') ?? '').split(';')[0]!;
+    expect(cookie).toContain('better-auth.session_token=');
+
+    const out = await post('/sign-out', {}, '203.0.113.1', cookie);
+    expect(out.status).toBe(200);
+    const after = await fetch(`${base}/v1/auth/get-session`, {
+      headers: { Cookie: cookie, Origin: base },
+    });
+    expect(await after.json()).toBeNull();
+  });
+
+  it('returns an identical generic 401 for unknown user vs wrong password', async () => {
+    const unknown = await signIn('ghost@example.com', PASSWORD, '203.0.113.2');
+    const wrongPw = await signIn('login@example.com', 'wrong-password-000', '203.0.113.3');
+    expect(unknown.status).toBe(401);
+    expect(wrongPw.status).toBe(401);
+
+    const a = await unknown.json() as { message?: string; code?: string };
+    const b = await wrongPw.json() as { message?: string; code?: string };
+    expect(a.message).toBe(b.message); // no enumeration signal in the body
+  });
+
+  it('locks the account after 5 failures — even with the correct password, even from a new IP', async () => {
+    for (let i = 0; i < 5; i++) {
+      const res = await signIn('locked@example.com', 'wrong-password-000', '203.0.113.10');
+      expect(res.status).toBe(401);
+    }
+    // correct password, same IP → throttled
+    const sameIp = await signIn('locked@example.com', PASSWORD, '203.0.113.10');
+    expect(sameIp.status).toBe(429);
+    const body = await sameIp.json() as { message?: string };
+    expect(body.message).toMatch(/Try again in \d+s/);
+
+    // correct password, fresh IP → account key still locked
+    const newIp = await signIn('locked@example.com', PASSWORD, '203.0.113.11');
+    expect(newIp.status).toBe(429);
+
+    // a different account from the attacker's IP is also blocked (per-IP key)
+    const sameIpOtherAcct = await signIn('bystander@example.com', PASSWORD, '203.0.113.10');
+    expect(sameIpOtherAcct.status).toBe(429);
+
+    // unrelated account + unrelated IP → unaffected
+    const unrelated = await signIn('bystander@example.com', PASSWORD, '203.0.113.99');
+    expect(unrelated.status).toBe(200);
+  });
+
+  it('a successful sign-in clears the failure count', async () => {
+    for (let i = 0; i < 3; i++) {
+      await signIn('login@example.com', 'wrong-password-000', '203.0.113.50');
+    }
+    const ok = await signIn('login@example.com', PASSWORD, '203.0.113.50');
+    expect(ok.status).toBe(200);
+    // counter reset — 4 more failures stay under the threshold
+    for (let i = 0; i < 4; i++) {
+      const res = await signIn('login@example.com', 'wrong-password-000', '203.0.113.50');
+      expect(res.status).toBe(401);
+    }
+    expect((await signIn('login@example.com', PASSWORD, '203.0.113.50')).status).toBe(200);
+  });
+});

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -16,8 +16,10 @@
 
 import { Algorithm, hash, verify } from '@node-rs/argon2';
 import { betterAuth } from 'better-auth';
+import { APIError, createAuthMiddleware } from 'better-auth/api';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import type { RpeDb } from './client.js';
+import { LoginThrottle } from './loginThrottle.js';
 
 /** OWASP password-storage cheat-sheet argon2id parameters. */
 const ARGON2ID_PARAMS = {
@@ -43,9 +45,25 @@ export interface CreateAuthOptions {
   sendVerificationOnSignUp?: boolean;
   /** Password-reset send hook (RPE-92 consumes). */
   sendResetPassword?: SendEmailHook;
+  /** Login brute-force throttle (RPE-91). Defaults to a fresh
+   * LoginThrottle; inject for deterministic tests. */
+  loginThrottle?: LoginThrottle;
+}
+
+const SIGN_IN_PATH = '/sign-in/email';
+
+function requestIp(headers: Headers | undefined): string {
+  // Prefer the dispatcher-resolved IP (RPE-76 trust boundary, includes
+  // socket fallback); raw XFF first-hop only as a secondary
+  const resolved = headers?.get('x-rpe-client-ip') ?? '';
+  if (resolved !== '') return resolved;
+  const fwd = headers?.get('x-forwarded-for') ?? '';
+  const first = fwd.split(',')[0]?.trim();
+  return first !== undefined && first !== '' ? first : 'unknown';
 }
 
 export function createAuth(options: CreateAuthOptions) {
+  const throttle = options.loginThrottle ?? new LoginThrottle();
   const database =
     options.db.dialect === 'postgres'
       ? drizzleAdapter(options.db.pg, { provider: 'pg' })
@@ -86,6 +104,29 @@ export function createAuth(options: CreateAuthOptions) {
       // NODE_ENV=test — pin it on so tests exercise exactly what
       // production enforces (caught by the RPE-89 harness)
       disableOriginCheck: false,
+    },
+    hooks: {
+      // Brute-force throttle on the sign-in path (RPE-91): the hook
+      // layer sees the parsed body, so lockout keys on the submitted
+      // email AND the client IP, with progressive backoff
+      before: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== SIGN_IN_PATH) return;
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
+        const decision = throttle.check(email, requestIp(ctx.request?.headers));
+        if (!decision.allowed) {
+          throw new APIError('TOO_MANY_REQUESTS', {
+            message: `Too many sign-in attempts. Try again in ${decision.retryAfterSec ?? 60}s.`,
+          });
+        }
+      }),
+      after: createAuthMiddleware(async (ctx) => {
+        if (ctx.path !== SIGN_IN_PATH) return;
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
+        const ip = requestIp(ctx.request?.headers);
+        const status = ctx.context.returned instanceof APIError ? ctx.context.returned.statusCode : 200;
+        if (status === 200) throttle.onSuccess(email, ip);
+        else if (status === 401) throttle.onFailure(email, ip);
+      }),
     },
   });
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,3 +3,4 @@ export { appMeta as appMetaPg, pgSchema } from './schema.pg.js';
 export { appMeta as appMetaSqlite, sqliteSchema } from './schema.sqlite.js';
 export { seedDev } from './seed.js';
 export { createAuth, type CreateAuthOptions, type RpeAuth } from './auth.js';
+export { LoginThrottle, type ThrottleDecision } from './loginThrottle.js';

--- a/packages/db/src/loginThrottle.ts
+++ b/packages/db/src/loginThrottle.ts
@@ -1,0 +1,93 @@
+/**
+ * E11 — login brute-force throttle (RPE-91)
+ *
+ * Per-account AND per-IP failed-attempt tracking with progressive
+ * lockout, enforced inside better-auth via before/after hooks on the
+ * sign-in path (the hook layer sees the parsed body, so the account key
+ * is the submitted email — no request-stream games in the dispatcher).
+ *
+ * Policy (fixed-window failures → escalating lockout):
+ *   - 5 failures within 15 min → 1 min lockout
+ *   - each further failure doubles the lockout, capped at 1 h
+ *   - any successful sign-in clears both keys
+ *
+ * In-memory, like the RPE-76 limiters — a shared store is required
+ * before horizontal scaling. Maps are hard-capped so spoofed keys can't
+ * exhaust memory (same defense as RateLimiter.prune).
+ */
+
+const WINDOW_MS = 15 * 60 * 1000;
+const THRESHOLD = 5;
+const BASE_LOCKOUT_MS = 60 * 1000;
+const MAX_LOCKOUT_MS = 60 * 60 * 1000;
+const MAX_KEYS = 10_000;
+
+interface FailureState {
+  windowStart: number;
+  failures: number;
+  lockedUntil: number;
+}
+
+export interface ThrottleDecision {
+  allowed: boolean;
+  retryAfterSec?: number;
+}
+
+export class LoginThrottle {
+  private readonly states = new Map<string, FailureState>();
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  /** Check both identity keys — deny if either is locked out. */
+  check(email: string, ip: string): ThrottleDecision {
+    for (const key of this.keys(email, ip)) {
+      const state = this.states.get(key);
+      if (state !== undefined && state.lockedUntil > this.now()) {
+        return {
+          allowed: false,
+          retryAfterSec: Math.ceil((state.lockedUntil - this.now()) / 1000),
+        };
+      }
+    }
+    return { allowed: true };
+  }
+
+  /** Record a failed attempt against both keys; escalate past the threshold. */
+  onFailure(email: string, ip: string): void {
+    const ts = this.now();
+    for (const key of this.keys(email, ip)) {
+      let state = this.states.get(key);
+      if (state === undefined || ts - state.windowStart >= WINDOW_MS) {
+        if (this.states.size >= MAX_KEYS) this.prune(ts);
+        state = { windowStart: ts, failures: 0, lockedUntil: 0 };
+        this.states.set(key, state);
+      }
+      state.failures += 1;
+      if (state.failures >= THRESHOLD) {
+        // Progressive: 1 min at the threshold, doubling per extra failure
+        const escalations = state.failures - THRESHOLD;
+        state.lockedUntil = ts + Math.min(BASE_LOCKOUT_MS * 2 ** escalations, MAX_LOCKOUT_MS);
+      }
+    }
+  }
+
+  /** Successful sign-in clears both keys. */
+  onSuccess(email: string, ip: string): void {
+    for (const key of this.keys(email, ip)) this.states.delete(key);
+  }
+
+  private keys(email: string, ip: string): [string, string] {
+    return [`acct:${email.toLowerCase()}`, `ip:${ip}`];
+  }
+
+  private prune(ts: number): void {
+    for (const [key, state] of this.states) {
+      if (ts - state.windowStart >= WINDOW_MS && state.lockedUntil <= ts) this.states.delete(key);
+    }
+    while (this.states.size >= MAX_KEYS) {
+      const oldest = this.states.keys().next().value;
+      if (oldest === undefined) break;
+      this.states.delete(oldest);
+    }
+  }
+}

--- a/packages/db/tests/loginThrottle.test.ts
+++ b/packages/db/tests/loginThrottle.test.ts
@@ -1,0 +1,73 @@
+/**
+ * RPE-91: LoginThrottle unit tests — threshold, progressive escalation,
+ * window expiry, success reset, dual-key (account + IP) behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LoginThrottle } from '../src/loginThrottle';
+
+const MIN = 60 * 1000;
+
+function throttleAt(start = 0) {
+  let now = start;
+  const t = new LoginThrottle(() => now);
+  return { t, tick: (ms: number) => (now += ms) };
+}
+
+describe('LoginThrottle', () => {
+  it('allows up to 4 failures, locks on the 5th for 1 minute', () => {
+    const { t, tick } = throttleAt();
+    for (let i = 0; i < 4; i++) {
+      t.onFailure('a@x.com', '1.1.1.1');
+      expect(t.check('a@x.com', '1.1.1.1').allowed).toBe(true);
+    }
+    t.onFailure('a@x.com', '1.1.1.1'); // 5th
+    const denied = t.check('a@x.com', '1.1.1.1');
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSec).toBe(60);
+
+    tick(MIN + 1);
+    expect(t.check('a@x.com', '1.1.1.1').allowed).toBe(true);
+  });
+
+  it('escalates: each failure past the threshold doubles the lockout, capped at 1h', () => {
+    const { t, tick } = throttleAt();
+    for (let i = 0; i < 5; i++) t.onFailure('a@x.com', '1.1.1.1');
+    tick(MIN + 1); // first lockout expires
+    t.onFailure('a@x.com', '1.1.1.1'); // 6th in window → 2 min
+    expect(t.check('a@x.com', '1.1.1.1').retryAfterSec).toBe(120);
+
+    // hammer it — lockout caps at one hour
+    for (let i = 0; i < 20; i++) t.onFailure('a@x.com', '1.1.1.1');
+    expect(t.check('a@x.com', '1.1.1.1').retryAfterSec).toBeLessThanOrEqual(3600);
+  });
+
+  it('locks the account from any IP, and the IP for any account', () => {
+    const { t } = throttleAt();
+    for (let i = 0; i < 5; i++) t.onFailure('victim@x.com', '9.9.9.9');
+    // account locked even from a fresh IP
+    expect(t.check('victim@x.com', '2.2.2.2').allowed).toBe(false);
+    // IP locked even for a fresh account
+    expect(t.check('other@x.com', '9.9.9.9').allowed).toBe(false);
+    // unrelated pair unaffected
+    expect(t.check('other@x.com', '2.2.2.2').allowed).toBe(true);
+  });
+
+  it('success clears both keys; the window expires stale counts', () => {
+    const { t, tick } = throttleAt();
+    for (let i = 0; i < 4; i++) t.onFailure('a@x.com', '1.1.1.1');
+    t.onSuccess('a@x.com', '1.1.1.1');
+    for (let i = 0; i < 4; i++) t.onFailure('a@x.com', '1.1.1.1');
+    expect(t.check('a@x.com', '1.1.1.1').allowed).toBe(true); // counter restarted
+
+    tick(15 * MIN + 1); // window expiry
+    t.onFailure('a@x.com', '1.1.1.1');
+    expect(t.check('a@x.com', '1.1.1.1').allowed).toBe(true); // fresh window, count=1
+  });
+
+  it('is case-insensitive on the account key', () => {
+    const { t } = throttleAt();
+    for (let i = 0; i < 5; i++) t.onFailure('User@X.com', '1.1.1.1');
+    expect(t.check('user@x.com', '3.3.3.3').allowed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `LoginThrottle` in `@rpe/db`: 5 failures in 15 min lock **both** the submitted account and the client IP for 1 min, doubling per further failure (1 h cap); any successful sign-in clears both keys. In-memory with hard-capped keys (same scaling caveat + flood defense as the RPE-76 limiters); injectable clock/instance for deterministic tests
- Enforced inside better-auth **before/after hooks** on `/sign-in/email` — the hook layer sees the parsed body, so the account key is the email with no request-stream games in the dispatcher; 429 with retry timing
- Dispatcher stamps `x-rpe-client-ip` via the RPE-76 `clientIp()` trust boundary before delegating, so direct connections never collapse into one shared `'unknown'` bucket (self-review catch — one attacker could otherwise have locked out all proxy-less clients)
- Tests: identical generic 401 for unknown-user vs wrong-password (no enumeration), account locked across IPs, attacker IP locked across accounts, bystanders unaffected, success resets the counter, logout revocation; plus 5 unit tests for escalation/expiry/case-folding
- 9 new tests (906 total)

## Review
Copilot unavailable; strict self-review loop — round 1: the shared-'unknown'-bucket lockout DoS above; round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)