### PR TITLE
RPE-92: password reset — neutral, single-use, revoking, throttled

### DIFF
--- a/apps/api/tests/passwordReset.test.ts
+++ b/apps/api/tests/passwordReset.test.ts
@@ -1,0 +1,140 @@
+/**
+ * RPE-92: password reset through /v1/auth — neutral responses (no
+ * enumeration), emailed single-use token, session revocation on reset,
+ * reset-request throttling.
+ *
+ * Storage note: better-auth stores the reset token plaintext in the
+ * verification table (same threat model as its session tokens) — the
+ * "hashed at rest" AC deviation is documented on the ticket/PR.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { createSessionAuth } from '../src/services/session';
+import { SandboxMailer } from '../src/services/mailer';
+import { createDb, type RpeDb } from '@rpe/db';
+
+const SECRET = 'rpe-test-secret-0123456789abcdef0123456789abcdef';
+const PASSWORD = 'original-password-123';
+const NEW_PASSWORD = 'rotated-password-456';
+
+let db: RpeDb;
+let sandbox: SandboxMailer;
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+  sandbox = new SandboxMailer();
+
+  const probe = createApp({});
+  const port: number = await new Promise((resolve) => {
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address() as { port: number };
+      probe.close(() => resolve(addr.port));
+    });
+  });
+  base = `http://127.0.0.1:${port}`;
+  const auth = createSessionAuth({
+    db,
+    secret: SECRET,
+    baseURL: base,
+    trustedOrigins: [base],
+    mailer: sandbox,
+  });
+  server = createApp({ session: { auth }, v1RateLimit: { rpm: 10000, dailyCap: 100000 } });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const res = await post('/sign-up/email', { email: 'reset@example.com', password: PASSWORD, name: 'R' }, '203.0.113.1');
+  expect(res.status).toBe(200);
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  await db.close();
+});
+
+function post(path: string, body: unknown, ip: string, cookie?: string) {
+  return fetch(`${base}/v1/auth${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: base,
+      'X-Forwarded-For': ip,
+      ...(cookie !== undefined ? { Cookie: cookie } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Pull the token out of the last captured reset email. */
+function lastResetToken(): string {
+  const mail = sandbox.sent.at(-1);
+  expect(mail?.subject).toContain('Reset your password');
+  const match = mail?.text.match(/reset-password\/([\w-]+)\?/);
+  expect(match?.[1]).toBeTruthy();
+  return match![1]!;
+}
+
+describe('password reset (RPE-92)', () => {
+  it('returns the same neutral 200 for existing and unknown emails — email only for the real one', async () => {
+    const known = await post('/request-password-reset', { email: 'reset@example.com', redirectTo: `${base}/reset` }, '203.0.113.2');
+    expect(known.status).toBe(200);
+    const knownBody = await known.json() as { message?: string };
+    expect(sandbox.sent).toHaveLength(1);
+
+    const unknown = await post('/request-password-reset', { email: 'nobody@example.com', redirectTo: `${base}/reset` }, '203.0.113.3');
+    expect(unknown.status).toBe(200);
+    const unknownBody = await unknown.json() as { message?: string };
+    expect(unknownBody.message).toBe(knownBody.message); // byte-identical neutrality
+    expect(sandbox.sent).toHaveLength(1); // no email for the unknown address
+  });
+
+  it('resets with the emailed token: old password dies, sessions are revoked, token is single-use', async () => {
+    // Establish a live session that must not survive the reset
+    const live = await post('/sign-in/email', { email: 'reset@example.com', password: PASSWORD }, '203.0.113.4');
+    expect(live.status).toBe(200);
+    const cookie = (live.headers.get('set-cookie') ?? '').split(';')[0]!;
+
+    const token = lastResetToken();
+    const reset = await post('/reset-password', { newPassword: NEW_PASSWORD, token }, '203.0.113.4');
+    expect(reset.status).toBe(200);
+
+    // session revoked server-side
+    const after = await fetch(`${base}/v1/auth/get-session`, {
+      headers: { Cookie: cookie, Origin: base },
+    });
+    expect(await after.json()).toBeNull();
+
+    // old password rejected, new accepted
+    expect((await post('/sign-in/email', { email: 'reset@example.com', password: PASSWORD }, '203.0.113.5')).status).toBe(401);
+    expect((await post('/sign-in/email', { email: 'reset@example.com', password: NEW_PASSWORD }, '203.0.113.6')).status).toBe(200);
+
+    // token consumed — reuse fails
+    const reuse = await post('/reset-password', { newPassword: 'another-pass-789', token }, '203.0.113.4');
+    expect(reuse.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('throttles repeated reset requests per email/IP', async () => {
+    // 2 more requests exhaust the 3-per-15min budget for this email
+    // (request #1 was the neutral-response test)
+    for (let i = 0; i < 2; i++) {
+      const res = await post('/request-password-reset', { email: 'reset@example.com', redirectTo: `${base}/reset` }, '203.0.113.7');
+      expect(res.status).toBe(200);
+    }
+    const blocked = await post('/request-password-reset', { email: 'reset@example.com', redirectTo: `${base}/reset` }, '203.0.113.7');
+    expect(blocked.status).toBe(429);
+    const body = await blocked.json() as { message?: string };
+    expect(body.message).toMatch(/Try again in \d+s/);
+  });
+});

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -48,9 +48,21 @@ export interface CreateAuthOptions {
   /** Login brute-force throttle (RPE-91). Defaults to a fresh
    * LoginThrottle; inject for deterministic tests. */
   loginThrottle?: LoginThrottle;
+  /** Reset-request spam throttle (RPE-92) — same mechanism, request-count
+   * policy (every request counts; responses are always neutral). */
+  resetRequestThrottle?: LoginThrottle;
 }
 
 const SIGN_IN_PATH = '/sign-in/email';
+const RESET_REQUEST_PATH = '/request-password-reset';
+
+/** RPE-92: 3 reset requests/15 min per email/IP, then 15 min lockout. */
+const RESET_REQUEST_POLICY = {
+  windowMs: 15 * 60 * 1000,
+  threshold: 3,
+  baseLockoutMs: 15 * 60 * 1000,
+  maxLockoutMs: 60 * 60 * 1000,
+};
 
 function requestIp(headers: Headers | undefined): string {
   // Prefer the dispatcher-resolved IP (RPE-76 trust boundary, includes
@@ -64,6 +76,7 @@ function requestIp(headers: Headers | undefined): string {
 
 export function createAuth(options: CreateAuthOptions) {
   const throttle = options.loginThrottle ?? new LoginThrottle();
+  const resetThrottle = options.resetRequestThrottle ?? new LoginThrottle(Date.now, RESET_REQUEST_POLICY);
   const database =
     options.db.dialect === 'postgres'
       ? drizzleAdapter(options.db.pg, { provider: 'pg' })
@@ -88,6 +101,8 @@ export function createAuth(options: CreateAuthOptions) {
             },
           }
         : {}),
+      // RPE-92: a successful reset kills every active session for the user
+      revokeSessionsOnPasswordReset: true,
     },
     ...(options.sendVerificationEmail !== undefined
       ? {
@@ -110,13 +125,25 @@ export function createAuth(options: CreateAuthOptions) {
       // layer sees the parsed body, so lockout keys on the submitted
       // email AND the client IP, with progressive backoff
       before: createAuthMiddleware(async (ctx) => {
-        if (ctx.path !== SIGN_IN_PATH) return;
         const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
-        const decision = throttle.check(email, requestIp(ctx.request?.headers));
-        if (!decision.allowed) {
-          throw new APIError('TOO_MANY_REQUESTS', {
-            message: `Too many sign-in attempts. Try again in ${decision.retryAfterSec ?? 60}s.`,
-          });
+        const ip = requestIp(ctx.request?.headers);
+        if (ctx.path === SIGN_IN_PATH) {
+          const decision = throttle.check(email, ip);
+          if (!decision.allowed) {
+            throw new APIError('TOO_MANY_REQUESTS', {
+              message: `Too many sign-in attempts. Try again in ${decision.retryAfterSec ?? 60}s.`,
+            });
+          }
+        } else if (ctx.path === RESET_REQUEST_PATH) {
+          const decision = resetThrottle.check(email, ip);
+          if (!decision.allowed) {
+            throw new APIError('TOO_MANY_REQUESTS', {
+              message: `Too many reset requests. Try again in ${decision.retryAfterSec ?? 60}s.`,
+            });
+          }
+          // Every request counts — the response is always neutral, so
+          // there is no failure signal to key on
+          resetThrottle.onFailure(email, ip);
         }
       }),
       after: createAuthMiddleware(async (ctx) => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,4 @@ export { appMeta as appMetaPg, pgSchema } from './schema.pg.js';
 export { appMeta as appMetaSqlite, sqliteSchema } from './schema.sqlite.js';
 export { seedDev } from './seed.js';
 export { createAuth, type CreateAuthOptions, type RpeAuth } from './auth.js';
-export { LoginThrottle, type ThrottleDecision } from './loginThrottle.js';
+export { LoginThrottle, type ThrottleDecision, type ThrottlePolicy } from './loginThrottle.js';

--- a/packages/db/src/loginThrottle.ts
+++ b/packages/db/src/loginThrottle.ts
@@ -16,10 +16,21 @@
  * exhaust memory (same defense as RateLimiter.prune).
  */
 
-const WINDOW_MS = 15 * 60 * 1000;
-const THRESHOLD = 5;
-const BASE_LOCKOUT_MS = 60 * 1000;
-const MAX_LOCKOUT_MS = 60 * 60 * 1000;
+export interface ThrottlePolicy {
+  windowMs: number;
+  threshold: number;
+  baseLockoutMs: number;
+  maxLockoutMs: number;
+}
+
+/** RPE-91 sign-in default: 5 failures/15 min → 1 min, doubling to 1 h. */
+const DEFAULT_POLICY: ThrottlePolicy = {
+  windowMs: 15 * 60 * 1000,
+  threshold: 5,
+  baseLockoutMs: 60 * 1000,
+  maxLockoutMs: 60 * 60 * 1000,
+};
+
 const MAX_KEYS = 10_000;
 
 interface FailureState {
@@ -35,8 +46,14 @@ export interface ThrottleDecision {
 
 export class LoginThrottle {
   private readonly states = new Map<string, FailureState>();
+  private readonly policy: ThrottlePolicy;
 
-  constructor(private readonly now: () => number = Date.now) {}
+  constructor(
+    private readonly now: () => number = Date.now,
+    policy: Partial<ThrottlePolicy> = {},
+  ) {
+    this.policy = { ...DEFAULT_POLICY, ...policy };
+  }
 
   /** Check both identity keys — deny if either is locked out. */
   check(email: string, ip: string): ThrottleDecision {
@@ -57,16 +74,17 @@ export class LoginThrottle {
     const ts = this.now();
     for (const key of this.keys(email, ip)) {
       let state = this.states.get(key);
-      if (state === undefined || ts - state.windowStart >= WINDOW_MS) {
+      if (state === undefined || ts - state.windowStart >= this.policy.windowMs) {
         if (this.states.size >= MAX_KEYS) this.prune(ts);
         state = { windowStart: ts, failures: 0, lockedUntil: 0 };
         this.states.set(key, state);
       }
       state.failures += 1;
-      if (state.failures >= THRESHOLD) {
-        // Progressive: 1 min at the threshold, doubling per extra failure
-        const escalations = state.failures - THRESHOLD;
-        state.lockedUntil = ts + Math.min(BASE_LOCKOUT_MS * 2 ** escalations, MAX_LOCKOUT_MS);
+      if (state.failures >= this.policy.threshold) {
+        // Progressive: base lockout at the threshold, doubling per extra failure
+        const escalations = state.failures - this.policy.threshold;
+        state.lockedUntil =
+          ts + Math.min(this.policy.baseLockoutMs * 2 ** escalations, this.policy.maxLockoutMs);
       }
     }
   }
@@ -82,7 +100,7 @@ export class LoginThrottle {
 
   private prune(ts: number): void {
     for (const [key, state] of this.states) {
-      if (ts - state.windowStart >= WINDOW_MS && state.lockedUntil <= ts) this.states.delete(key);
+      if (ts - state.windowStart >= this.policy.windowMs && state.lockedUntil <= ts) this.states.delete(key);
     }
     while (this.states.size >= MAX_KEYS) {
       const oldest = this.states.keys().next().value;


### PR DESCRIPTION
## Summary
- `revokeSessionsOnPasswordReset` enabled — a successful reset kills every active session for the user (better-auth leaves this **off** by default; the AC requires it)
- Reset-request spam throttle: `LoginThrottle` policy is now constructor-injectable; a second instance (3 requests/15 min per email/IP, then 15 min lockout) guards `/request-password-reset` in the same before-hook — every request counts because responses are always neutral
- Flow tests: byte-identical neutral 200 for existing vs unknown emails (email sent only for the real account), emailed token rotates the password (old rejected/new accepted), live sessions revoked server-side, token consumed on use, 4th request inside the window 429s
- **Documented AC deviation:** better-auth stores the reset token plaintext in its verification table — consistent with its session-token threat model; not forked (better-auth's lookup requires the raw identifier). Noted on the ticket
- 3 new tests (909 total)

## Review
Copilot unavailable; strict self-review loop — round 1: stray iCloud duplicate files (`* 2.json`) swept into the commit, stripped and recommitted; round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)