### PR TITLE
RPE-90: registration + email verification — neutral sign-up, policy, default org

### DIFF
--- a/apps/api/tests/registration.test.ts
+++ b/apps/api/tests/registration.test.ts
@@ -1,0 +1,140 @@
+/**
+ * RPE-90: registration + email verification (requireEmailVerification
+ * mode) — neutral no-enumeration sign-up, password policy, verification
+ * token flips emailVerified and gates sign-in, default org + owner
+ * membership provisioned on first registration.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { createSessionAuth } from '../src/services/session';
+import { SandboxMailer } from '../src/services/mailer';
+import { createDb, type RpeDb } from '@rpe/db';
+
+const SECRET = 'rpe-test-secret-0123456789abcdef0123456789abcdef';
+const PASSWORD = 'a-strong-password-123';
+
+let db: RpeDb;
+let sandbox: SandboxMailer;
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+  sandbox = new SandboxMailer();
+
+  const probe = createApp({});
+  const port: number = await new Promise((resolve) => {
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address() as { port: number };
+      probe.close(() => resolve(addr.port));
+    });
+  });
+  base = `http://127.0.0.1:${port}`;
+  const auth = createSessionAuth({
+    db,
+    secret: SECRET,
+    baseURL: base,
+    trustedOrigins: [base],
+    mailer: sandbox,
+    requireEmailVerification: true,
+  });
+  server = createApp({ session: { auth }, v1RateLimit: { rpm: 10000, dailyCap: 100000 } });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  await db.close();
+});
+
+function post(path: string, body: unknown) {
+  return fetch(`${base}/v1/auth${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Origin: base },
+    body: JSON.stringify(body),
+  });
+}
+
+function sqliteRows<T>(sql: string, ...params: unknown[]): T[] {
+  if (db.dialect !== 'sqlite') throw new Error('expected sqlite');
+  return db.sqlite.$client.prepare(sql).all(...params) as T[];
+}
+
+describe('registration (RPE-90)', () => {
+  it('rejects passwords under the policy minimum', async () => {
+    const res = await post('/sign-up/email', { email: 'short@example.com', password: 'tooshort1', name: 'S' });
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sqliteRows('SELECT id FROM user WHERE email = ?', 'short@example.com')).toHaveLength(0);
+  });
+
+  it('fresh sign-up: neutral body, no session cookie, verification email, default org + owner membership', async () => {
+    const res = await post('/sign-up/email', { email: 'new@example.com', password: PASSWORD, name: 'Newbie' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('set-cookie')).toBeNull(); // no session until verified
+    const body = await res.text();
+    expect(JSON.parse(body)).toEqual({ status: true, message: 'Check your email to verify your account.' });
+
+    // verification email captured
+    expect(sandbox.sent).toHaveLength(1);
+    expect(sandbox.sent[0]?.to).toBe('new@example.com');
+    expect(sandbox.sent[0]?.subject).toContain('Verify your email');
+
+    // user exists unverified; default org + owner membership provisioned
+    const users = sqliteRows<{ id: string; email_verified: number }>('SELECT id, email_verified FROM user WHERE email = ?', 'new@example.com');
+    expect(users).toHaveLength(1);
+    expect(users[0]?.email_verified).toBe(0);
+    const orgs = sqliteRows<{ name: string }>(
+      "SELECT o.name FROM organization o JOIN member m ON m.organization_id = o.id WHERE m.user_id = ? AND m.role = 'owner'",
+      users[0]!.id,
+    );
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]?.name).toBe("Newbie's Workspace");
+  });
+
+  it('duplicate sign-up returns a byte-identical neutral 200, creates nothing, sends nothing', async () => {
+    const fresh = await post('/sign-up/email', { email: 'dupe@example.com', password: PASSWORD, name: 'D' });
+    const freshBody = await fresh.text();
+    const sentBefore = sandbox.sent.length;
+
+    const dupe = await post('/sign-up/email', { email: 'dupe@example.com', password: 'different-password-99', name: 'D2' });
+    expect(dupe.status).toBe(200);
+    expect(await dupe.text()).toBe(freshBody); // byte-identical
+
+    expect(sqliteRows('SELECT id FROM user WHERE email = ?', 'dupe@example.com')).toHaveLength(1);
+    expect(sandbox.sent.length).toBe(sentBefore); // no second email
+  });
+
+  it('sign-in is gated until the emailed token verifies the address', async () => {
+    const before = await post('/sign-in/email', { email: 'new@example.com', password: PASSWORD });
+    expect(before.status).toBe(403); // unverified
+
+    // follow the emailed verification link
+    const url = sandbox.sent[0]!.text.match(/https?:\/\/\S+/)![0]!;
+    const verify = await fetch(url, { redirect: 'manual', headers: { Origin: base } });
+    expect([200, 302]).toContain(verify.status);
+
+    const users = sqliteRows<{ email_verified: number }>('SELECT email_verified FROM user WHERE email = ?', 'new@example.com');
+    expect(users[0]?.email_verified).toBe(1); // flipped
+
+    const after = await post('/sign-in/email', { email: 'new@example.com', password: PASSWORD });
+    expect(after.status).toBe(200);
+    expect(after.headers.get('set-cookie')).toContain('better-auth.session_token=');
+  });
+
+  it('argon2id at rest for registered users', async () => {
+    const rows = sqliteRows<{ password: string }>('SELECT password FROM account WHERE password IS NOT NULL');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.password.startsWith('$argon2id$'))).toBe(true);
+  });
+});

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -14,12 +14,15 @@
  * in lockstep with the feature flags here.
  */
 
+import { randomUUID } from 'node:crypto';
 import { Algorithm, hash, verify } from '@node-rs/argon2';
 import { betterAuth } from 'better-auth';
 import { organization } from 'better-auth/plugins/organization';
 import { APIError, createAuthMiddleware } from 'better-auth/api';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import type { RpeDb } from './client.js';
+import { pgSchema } from './schema.pg.js';
+import { sqliteSchema } from './schema.sqlite.js';
 import { LoginThrottle } from './loginThrottle.js';
 
 /** OWASP password-storage cheat-sheet argon2id parameters. */
@@ -52,6 +55,10 @@ export interface CreateAuthOptions {
   /** Reset-request spam throttle (RPE-92) — same mechanism, request-count
    * policy (every request counts; responses are always neutral). */
   resetRequestThrottle?: LoginThrottle;
+  /** RPE-90: block sign-in until the email is verified, return a
+   * neutral no-enumeration sign-up response, and send the verification
+   * email on sign-up. OFF by default (sessions issue immediately). */
+  requireEmailVerification?: boolean;
   /** Org-invite email hook (RPE-93) — bound to the Mailer by apps/api. */
   sendOrgInvite?: (data: { email: string; orgName: string; url: string }) => Promise<void>;
   /** Base URL of the front-end accept page for invite links (RPE-93). */
@@ -79,6 +86,33 @@ function requestIp(headers: Headers | undefined): string {
   return first !== undefined && first !== '' ? first : 'unknown';
 }
 
+/** Byte-identical sign-up response when requireEmailVerification is on. */
+const NEUTRAL_SIGN_UP = {
+  status: true,
+  message: 'Check your email to verify your account.',
+} as const;
+
+/** RPE-90: every new user gets a default org + owner membership. */
+async function createDefaultOrg(db: RpeDb, user: { id: string; name: string; email: string }): Promise<void> {
+  const orgId = randomUUID();
+  const now = new Date();
+  const orgName = `${user.name !== '' ? user.name : user.email.split('@')[0]}'s Workspace`;
+  const member = {
+    id: randomUUID(),
+    organizationId: orgId,
+    userId: user.id,
+    role: 'owner',
+    createdAt: now,
+  };
+  if (db.dialect === 'postgres') {
+    await db.pg.insert(pgSchema.organization).values({ id: orgId, name: orgName, slug: `ws-${user.id.toLowerCase()}`, createdAt: now });
+    await db.pg.insert(pgSchema.member).values(member);
+    return;
+  }
+  await db.sqlite.insert(sqliteSchema.organization).values({ id: orgId, name: orgName, slug: `ws-${user.id.toLowerCase()}`, createdAt: now });
+  await db.sqlite.insert(sqliteSchema.member).values(member);
+}
+
 export function createAuth(options: CreateAuthOptions) {
   const throttle = options.loginThrottle ?? new LoginThrottle();
   const resetThrottle = options.resetRequestThrottle ?? new LoginThrottle(Date.now, RESET_REQUEST_POLICY);
@@ -95,6 +129,8 @@ export function createAuth(options: CreateAuthOptions) {
     database,
     emailAndPassword: {
       enabled: true,
+      minPasswordLength: 10, // RPE-90 password policy
+      requireEmailVerification: options.requireEmailVerification ?? false,
       password: {
         hash: (password) => hash(password, ARGON2ID_PARAMS),
         verify: ({ hash: stored, password }) => verify(stored, password),
@@ -112,13 +148,23 @@ export function createAuth(options: CreateAuthOptions) {
     ...(options.sendVerificationEmail !== undefined
       ? {
           emailVerification: {
-            sendOnSignUp: options.sendVerificationOnSignUp ?? false,
+            sendOnSignUp: (options.sendVerificationOnSignUp ?? false) || (options.requireEmailVerification ?? false),
             sendVerificationEmail: async ({ user, url }) => {
               await options.sendVerificationEmail!({ email: user.email, url });
             },
           },
         }
       : {}),
+    databaseHooks: {
+      user: {
+        create: {
+          // RPE-90: first registration provisions the default org
+          after: async (user) => {
+            await createDefaultOrg(options.db, user);
+          },
+        },
+      },
+    },
     advanced: {
       // better-auth SKIPS the CSRF origin check by default when
       // NODE_ENV=test — pin it on so tests exercise exactly what
@@ -148,6 +194,12 @@ export function createAuth(options: CreateAuthOptions) {
       before: createAuthMiddleware(async (ctx) => {
         const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
         const ip = requestIp(ctx.request?.headers);
+        if (ctx.path === '/sign-up/email' && (options.requireEmailVerification ?? false)) {
+          // No enumeration: duplicates short-circuit to the same neutral
+          // body the after-hook returns for fresh sign-ups
+          const existing = await ctx.context.internalAdapter.findUserByEmail(email);
+          if (existing !== null) return ctx.json(NEUTRAL_SIGN_UP);
+        }
         if (ctx.path === SIGN_IN_PATH) {
           const decision = throttle.check(email, ip);
           if (!decision.allowed) {
@@ -168,6 +220,11 @@ export function createAuth(options: CreateAuthOptions) {
         }
       }),
       after: createAuthMiddleware(async (ctx) => {
+        if (ctx.path === '/sign-up/email' && (options.requireEmailVerification ?? false)) {
+          // Fresh sign-ups get the same neutral body as duplicates
+          if (!(ctx.context.returned instanceof APIError)) return ctx.json(NEUTRAL_SIGN_UP);
+          return;
+        }
         if (ctx.path !== SIGN_IN_PATH) return;
         const email = typeof ctx.body?.email === 'string' ? ctx.body.email : '';
         const ip = requestIp(ctx.request?.headers);


### PR DESCRIPTION
## Summary
- **Password policy:** `minPasswordLength: 10` (argon2id hashing already in from RPE-89, re-proven at rest here)
- **`requireEmailVerification` mode** (opt-in, default off so existing session-on-sign-up flows are unchanged): sign-in 403s until verified; verification email sends on sign-up; sign-up responses are **neutral and byte-identical** for fresh vs duplicate emails — duplicates short-circuit in a before-hook to the exact body the after-hook returns for fresh sign-ups, no session cookie either way, no second email (no-enumeration AC)
- **Default org on first registration:** `databaseHooks.user.create.after` provisions `{name}'s Workspace` + owner membership via direct Drizzle inserts (both dialects) — applies in all modes, ties into RPE-93
- Verification link from the sandbox email flips `email_verified` and unlocks sign-in; tested end to end
- 5 new tests (920 total); full suite re-run confirms the databaseHooks change doesn't disturb the existing sign-up flows

## Review
Copilot unavailable; strict self-review loop — clean on round 1 (the before/after hook short-circuit semantics were verified against better-auth's dispatch source before writing).

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)