### PR TITLE
RPE-97: auth test harness + security/tenant-isolation release gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,11 @@ Origin is configured at `github.com:LowerMedia/rental-property-evaluator`. Full 
 pnpm lint && pnpm typecheck && pnpm test && pnpm build
 ```
 
-All four must pass. Tests currently: 878 tests, 52 files. The API
-regression suite (apps/api/tests/regression.test.ts, see
-docs/api-testing.md) rides in `pnpm test` — a red API suite blocks the
-release.
+All four must pass. Tests currently: 931 tests, 63 files. Two release
+gates ride in `pnpm test` and a red gate blocks the release: the API
+regression suite (apps/api/tests/regression.test.ts) and the E11 auth
+security gate (apps/api/tests/authGate.test.ts) — see
+docs/api-testing.md.
 
 ## Tailwind CSS v4 source scanning
 

--- a/apps/api/tests/authGate.test.ts
+++ b/apps/api/tests/authGate.test.ts
@@ -1,0 +1,138 @@
+/**
+ * RPE-97: auth security gate — the E11 sibling of regression.test.ts.
+ *
+ * Cross-cutting assertions that must stay green every release. Flow
+ * details live in their story suites (authSession/login/passwordReset/
+ * registration/organizations/orgContext); this gate locks the
+ * security-critical invariants in one place so a regression in any of
+ * them blocks the ship.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { requireOrg } from '../src/services/orgContext';
+import { startAuthApi, TEST_PASSWORD, type AuthTestApi } from './helpers/authHarness';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+let api: AuthTestApi;
+let alice: { cookie: string; userId: string | null };
+let bob: { cookie: string; userId: string | null };
+let aliceOrgId: string;
+
+beforeAll(async () => {
+  api = await startAuthApi();
+  alice = await api.signUp('alice@gate.test');
+  bob = await api.signUp('bob@gate.test');
+  aliceOrgId = await api.createOrg(alice.cookie, 'Alice Holdings', 'alice-holdings');
+});
+
+afterAll(() => api.stop());
+
+describe('auth security gate (RPE-97)', () => {
+  it('session cookies are httpOnly + SameSite and sessions revoke server-side', async () => {
+    const user = await api.signUp('cookiecheck@gate.test');
+    expect(user.cookie).toContain('better-auth.session_token=');
+
+    const fresh = await api.post('/sign-up/email', { email: 'cookieraw@gate.test', password: TEST_PASSWORD, name: 'C' });
+    const setCookie = (fresh.headers.get('set-cookie') ?? '').toLowerCase();
+    expect(setCookie).toContain('httponly');
+    expect(setCookie).toContain('samesite=lax');
+
+    const out = await api.post('/sign-out', {}, user.cookie);
+    expect(out.status).toBe(200);
+    const after = await api.get('/get-session', {}, user.cookie);
+    expect(await after.json()).toBeNull();
+  });
+
+  it('CSRF: cookie-bearing mutations from untrusted origins are rejected', async () => {
+    const res = await api.post('/sign-out', {}, alice.cookie, { Origin: 'https://evil.example' });
+    expect(res.status).toBe(403);
+    // session survives the rejected attempt
+    const still = await api.get('/get-session', {}, alice.cookie);
+    expect(((await still.json()) as { user: { email: string } } | null)?.user.email).toBe('alice@gate.test');
+  });
+
+  it('login failures stay generic and lock out after repeated attempts', async () => {
+    const ghost = await api.post('/sign-in/email', { email: 'ghost@gate.test', password: TEST_PASSWORD });
+    const wrong = await api.post('/sign-in/email', { email: 'alice@gate.test', password: 'wrong-password-00' });
+    expect(ghost.status).toBe(401);
+    expect(wrong.status).toBe(401);
+    expect(((await ghost.json()) as { message?: string }).message).toBe(
+      ((await wrong.json()) as { message?: string }).message,
+    );
+
+    const victim = await api.signUp('lockme@gate.test');
+    expect(victim.cookie).not.toBe('');
+    for (let i = 0; i < 5; i++) {
+      await api.post('/sign-in/email', { email: 'lockme@gate.test', password: 'wrong-password-00' });
+    }
+    const locked = await api.post('/sign-in/email', { email: 'lockme@gate.test', password: TEST_PASSWORD });
+    expect(locked.status).toBe(429);
+  });
+
+  it('passwords are argon2id at rest and never appear in responses', async () => {
+    const res = await api.post('/sign-up/email', { email: 'hashcheck@gate.test', password: TEST_PASSWORD, name: 'H' });
+    expect(JSON.stringify(await res.json())).not.toContain(TEST_PASSWORD);
+
+    if (api.db.dialect !== 'sqlite') throw new Error('expected sqlite');
+    const rows = api.db.sqlite.$client
+      .prepare('SELECT password FROM account WHERE password IS NOT NULL')
+      .all() as Array<{ password: string }>;
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.every((r) => r.password.startsWith('$argon2id$'))).toBe(true);
+  });
+
+  it('TENANT ISOLATION: bob cannot resolve, read, or act on alice\'s org', async () => {
+    // middleware level — identical 403 for real and ghost orgs
+    const capture = () => {
+      const out: { status?: number; body?: unknown } = {};
+      return {
+        out,
+        json: (_r: ServerResponse, status: number, body: unknown) => {
+          out.status = status;
+          out.body = body;
+        },
+        res: {} as ServerResponse,
+      };
+    };
+    const reqWith = (cookie: string, orgId: string) =>
+      ({ headers: { cookie, 'x-org-id': orgId } }) as unknown as IncomingMessage;
+
+    const real = capture();
+    expect(await requireOrg(api.auth, api.db, reqWith(bob.cookie, aliceOrgId), real.res, real.json, 'rid')).toBeNull();
+    const ghost = capture();
+    expect(await requireOrg(api.auth, api.db, reqWith(bob.cookie, 'org-ghost'), ghost.res, ghost.json, 'rid')).toBeNull();
+    expect(real.out.status).toBe(403);
+    expect(JSON.stringify(real.out.body)).toBe(JSON.stringify(ghost.out.body));
+
+    // endpoint level — org data and member actions are walled off
+    const read = await api.get('/organization/get-full-organization', { organizationId: aliceOrgId }, bob.cookie);
+    expect(read.status).toBeGreaterThanOrEqual(400);
+    const act = await api.post(
+      '/organization/invite-member',
+      { organizationId: aliceOrgId, email: 'mole@gate.test', role: 'member' },
+      bob.cookie,
+    );
+    expect(act.status).toBeGreaterThanOrEqual(400);
+
+    // ...while alice herself passes
+    const mine = await api.get('/organization/get-full-organization', { organizationId: aliceOrgId }, alice.cookie);
+    expect(mine.status).toBe(200);
+  });
+
+  it('verification mode: neutral sign-up + sign-in gate (spot check via dedicated instance)', async () => {
+    const gated = await startAuthApi({ requireEmailVerification: true });
+    try {
+      const fresh = await gated.post('/sign-up/email', { email: 'v@gate.test', password: TEST_PASSWORD, name: 'V' });
+      const dupe = await gated.post('/sign-up/email', { email: 'v@gate.test', password: TEST_PASSWORD, name: 'V' });
+      expect(fresh.status).toBe(200);
+      expect(await fresh.text()).toBe(await dupe.text());
+      expect(fresh.headers.get('set-cookie')).toBeNull();
+
+      const blocked = await gated.post('/sign-in/email', { email: 'v@gate.test', password: TEST_PASSWORD });
+      expect(blocked.status).toBe(403);
+      expect(gated.sandbox.sent).toHaveLength(1); // exactly one verification email
+    } finally {
+      await gated.stop();
+    }
+  });
+});

--- a/apps/api/tests/helpers/authHarness.ts
+++ b/apps/api/tests/helpers/authHarness.ts
@@ -1,0 +1,127 @@
+/**
+ * RPE-97: auth test harness — the cookie-session sibling of RPE-85's
+ * startTestApi(). Boots a hermetic SQLite-backed better-auth app
+ * (sandbox mailer, migrations applied, probe-port boot) and exposes the
+ * flow helpers the auth suites repeat: sign-up, sign-in, org creation.
+ *
+ * Convention (docs/api-testing.md): SQLite for speed, sandbox mail
+ * only — a suite using this harness can never touch a network.
+ */
+
+import type { Server } from 'node:http';
+import { createApp } from '../../src/index';
+import { createSessionAuth } from '../../src/services/session';
+import { SandboxMailer } from '../../src/services/mailer';
+import { createDb, type RpeAuth, type RpeDb } from '@rpe/db';
+
+export const TEST_SECRET = 'rpe-test-secret-0123456789abcdef0123456789abcdef';
+export const TEST_PASSWORD = 'a-strong-password-123';
+
+export interface AuthTestApi {
+  base: string;
+  db: RpeDb;
+  auth: RpeAuth;
+  sandbox: SandboxMailer;
+  /** POST /v1/auth{path} with JSON body (+ optional cookie / extra headers). */
+  post: (path: string, body: unknown, cookie?: string, headers?: Record<string, string>) => Promise<Response>;
+  /** GET /v1/auth{path}?query (+ optional cookie). */
+  get: (path: string, query?: Record<string, string>, cookie?: string) => Promise<Response>;
+  /** Sign up a user; returns the session cookie ('' when verification mode withholds it). */
+  signUp: (email: string, name?: string) => Promise<{ cookie: string; userId: string | null }>;
+  /** Sign in with the harness password; returns the session cookie. */
+  signIn: (email: string) => Promise<string>;
+  /** Create an org as the cookie's user; returns the org id. */
+  createOrg: (cookie: string, name: string, slug: string) => Promise<string>;
+  stop: () => Promise<void>;
+}
+
+export async function startAuthApi(
+  options: { requireEmailVerification?: boolean } = {},
+): Promise<AuthTestApi> {
+  const db = createDb(':memory:');
+  await db.applyMigrations();
+  const sandbox = new SandboxMailer();
+
+  const probe = createApp({});
+  const port: number = await new Promise((resolve) => {
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address() as { port: number };
+      probe.close(() => resolve(addr.port));
+    });
+  });
+  const base = `http://127.0.0.1:${port}`;
+
+  const auth = createSessionAuth({
+    db,
+    secret: TEST_SECRET,
+    baseURL: base,
+    trustedOrigins: [base],
+    mailer: sandbox,
+    ...(options.requireEmailVerification !== undefined
+      ? { requireEmailVerification: options.requireEmailVerification }
+      : {}),
+  });
+  const server: Server = createApp({
+    session: { auth },
+    v1RateLimit: { rpm: 10000, dailyCap: 100000 },
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  const post: AuthTestApi['post'] = (path, body, cookie, headers = {}) =>
+    fetch(`${base}/v1/auth${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: base,
+        ...(cookie !== undefined && cookie !== '' ? { Cookie: cookie } : {}),
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    });
+
+  const get: AuthTestApi['get'] = (path, query = {}, cookie) => {
+    const qs = new URLSearchParams(query).toString();
+    return fetch(`${base}/v1/auth${path}${qs === '' ? '' : `?${qs}`}`, {
+      headers: { Origin: base, ...(cookie !== undefined && cookie !== '' ? { Cookie: cookie } : {}) },
+    });
+  };
+
+  return {
+    base,
+    db,
+    auth,
+    sandbox,
+    post,
+    get,
+    signUp: async (email, name = email.split('@')[0]!) => {
+      const res = await post('/sign-up/email', { email, password: TEST_PASSWORD, name });
+      if (res.status !== 200) throw new Error(`signUp(${email}) → ${res.status}`);
+      const cookie = (res.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
+      const body = await res.json() as { user?: { id: string } };
+      return { cookie, userId: body.user?.id ?? null };
+    },
+    signIn: async (email) => {
+      const res = await post('/sign-in/email', { email, password: TEST_PASSWORD });
+      if (res.status !== 200) throw new Error(`signIn(${email}) → ${res.status}`);
+      return (res.headers.get('set-cookie') ?? '').split(';')[0] ?? '';
+    },
+    createOrg: async (cookie, name, slug) => {
+      const res = await post('/organization/create', { name, slug }, cookie);
+      if (res.status !== 200) throw new Error(`createOrg(${name}) → ${res.status}`);
+      const { id } = await res.json() as { id: string };
+      return id;
+    },
+    stop: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+      await db.close();
+    },
+  };
+}

--- a/docs/api-testing.md
+++ b/docs/api-testing.md
@@ -39,11 +39,30 @@ disposition + magic-byte checks).
 4. **Contract additions** in `contract.test.ts` if the endpoint introduces
    new header, CORS, or abuse-handling behavior.
 
+## Auth & multi-tenancy (E11, RPE-97)
+
+Cookie-session suites use `startAuthApi()` from
+`apps/api/tests/helpers/authHarness.ts` — the auth sibling of
+`startTestApi`. It boots a hermetic SQLite-backed better-auth app
+(migrations applied, sandbox mailer — **a suite on this harness can
+never touch a network or send real email**) and exposes `signUp`,
+`signIn`, `createOrg`, `post`/`get` against `/v1/auth`.
+
+Definition of done for an auth/org change:
+
+1. Story-level behavior in its own suite (see table).
+2. If the change touches a security invariant — cookies, CSRF, lockout,
+   hashing, neutrality, tenant isolation — extend **`authGate.test.ts`**:
+   it is the E11 release gate; a red gate blocks the ship exactly like
+   `regression.test.ts`.
+
 ## Where things live
 
 | Suite | Locks |
 |---|---|
 | `regression.test.ts` | Release gate: golden Example-deal numbers across `/v1/evaluate` + all report formats, auth/limit/revocation baseline |
+| `authGate.test.ts` | **Release gate (E11):** httpOnly/SameSite + revocation, CSRF origin rejection, generic-401 + lockout, argon2id at rest, tenant isolation (middleware + endpoint), verification-mode neutrality |
 | `contract.test.ts` | CORS policy, security headers, fuzz/abuse battery, 401→200→429 walk |
 | `openapi.test.ts` | Spec ↔ routes drift, both directions |
 | `router.test.ts` / `apiKeys.test.ts` / `v1RateLimit.test.ts` / `reports.test.ts` | Per-story behavior detail |
+| `authSession.test.ts` / `login.test.ts` / `passwordReset.test.ts` / `registration.test.ts` / `organizations.test.ts` / `orgContext.test.ts` | Per-story auth/org behavior detail (RPE-89–94) |


### PR DESCRIPTION
## Summary
- `startAuthApi()` in `tests/helpers/authHarness.ts` — the cookie-session sibling of RPE-85's `startTestApi`: hermetic SQLite boot with migrations applied, sandbox mailer (suites on this harness can never touch a network), probe-port boot, and `signUp`/`signIn`/`createOrg` + `post`/`get` flow helpers
- **`authGate.test.ts` — the E11 release gate**, red blocks the ship like `regression.test.ts`: httpOnly/SameSite + server-side revocation, CSRF origin rejection with session survival, generic-401 parity + lockout at the threshold, argon2id at rest and never in responses, **tenant isolation at both middleware (existence-blind 403 pair) and endpoint levels**, verification-mode neutrality (byte-identical duplicate, no cookie, exactly one email, gated sign-in)
- `docs/api-testing.md`: auth/multi-tenancy section with the harness convention and a definition-of-done that routes security-invariant changes into the gate; CLAUDE.md lists both release gates (931 tests / 63 files)
- Story-level suites (RPE-89–94) stay as-is — the gate locks invariants, not flow detail
- 6 new tests (931 total)

## Review
Copilot unavailable; strict self-review loop — clean on round 1.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)