### PR TITLE
RPE-83: persistence — org-scoped deals + DB-backed API keys

### DIFF
--- a/apps/api/scripts/manage-keys-db.ts
+++ b/apps/api/scripts/manage-keys-db.ts
@@ -1,0 +1,66 @@
+/**
+ * RPE-83 — DB-backed API key management (run with: npx tsx scripts/manage-keys-db.ts)
+ *
+ *   mint <orgId> <label>      mint a key for an org (secret printed ONCE)
+ *   list                      list all keys (no hashes)
+ *   revoke <keyId>            revoke a key
+ *   import <orgId> <file>     import RPE-75 env/file JSON records under an org
+ *
+ * Requires DATABASE_URL. The RPE-75 model is unchanged: sha256 at rest,
+ * secret shown exactly once at mint.
+ */
+
+import { readFileSync } from 'node:fs';
+import { createDb, listApiKeys, markKeyRevoked } from '@rpe/db';
+import { parseKeyRecords } from '../src/services/apiKeys.js';
+import { DbApiKeyStore } from '../src/services/dbApiKeys.js';
+
+const [, , command, ...args] = process.argv;
+
+const db = createDb();
+await db.applyMigrations();
+const store = await DbApiKeyStore.load(db);
+
+try {
+  switch (command) {
+    case 'mint': {
+      const [orgId, label] = args;
+      if (orgId === undefined || label === undefined) throw new Error('usage: mint <orgId> <label>');
+      const { record, secret } = await store.mint(orgId, label);
+      console.log(`minted ${record.id} (${label}) for org ${orgId}`);
+      console.log(`SECRET (shown once): ${secret}`);
+      break;
+    }
+    case 'list': {
+      for (const row of await listApiKeys(db)) {
+        console.log(
+          `${row.id}  org=${row.organizationId}  label=${row.label}  created=${row.createdAt.toISOString()}` +
+            `${row.revokedAt !== null ? `  REVOKED ${row.revokedAt.toISOString()}` : ''}` +
+            `${row.lastUsedAt !== null ? `  lastUsed=${row.lastUsedAt.toISOString()}` : ''}`,
+        );
+      }
+      break;
+    }
+    case 'revoke': {
+      const [keyId] = args;
+      if (keyId === undefined) throw new Error('usage: revoke <keyId>');
+      const ok = await markKeyRevoked(db, keyId, new Date());
+      console.log(ok ? `revoked ${keyId}` : `no such key: ${keyId}`);
+      break;
+    }
+    case 'import': {
+      const [orgId, file] = args;
+      if (orgId === undefined || file === undefined) throw new Error('usage: import <orgId> <file>');
+      const records = parseKeyRecords(readFileSync(file, 'utf8'), file);
+      const result = await store.importEnvRecords(orgId, records);
+      console.log(`imported ${result.imported}, skipped ${result.skipped} (already present)`);
+      break;
+    }
+    default:
+      console.log('usage: manage-keys-db.ts <mint|list|revoke|import> …');
+      process.exitCode = 1;
+  }
+} finally {
+  await store.flush();
+  await db.close();
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -413,6 +413,8 @@ export interface AppConfig {
    * RPE_API_KEYS env JSON, or RPE_API_KEYS_FILE. */
   auth?: {
     keys?: ApiKeyRecord[];
+    /** RPE-83: a pre-built store (e.g. DbApiKeyStore) — wins over keys/env. */
+    store?: Pick<ApiKeyStore, 'size' | 'verify' | 'revoke'>;
   };
   /** /v1 public-surface throttle (RPE-76) — keyed by api key id, per-IP
    * for unauthenticated paths. In-memory fixed windows: a shared store
@@ -494,7 +496,7 @@ export function createApp(config: AppConfig = {}) {
   const corsAllowlist =
     config.cors?.origins ?? parseCorsOrigins(process.env['RPE_CORS_ORIGINS']);
 
-  const apiKeys = ApiKeyStore.fromEnv(config.auth?.keys);
+  const apiKeys = config.auth?.store ?? ApiKeyStore.fromEnv(config.auth?.keys);
   const sessionAuthHandler =
     config.session !== undefined ? toNodeHandler(config.session.auth) : null;
 
@@ -692,17 +694,22 @@ export function createApp(config: AppConfig = {}) {
  * Returns undefined (auth surface 404s) when any is missing — the
  * zero-config key-only deployment stays the default.
  */
-async function sessionFromEnv(): Promise<{ auth: RpeAuth } | undefined> {
-  const secret = process.env['BETTER_AUTH_SECRET'] ?? '';
-  const baseURL = process.env['RPE_AUTH_BASE_URL'] ?? '';
-  if (secret === '' || baseURL === '' || (process.env['DATABASE_URL'] ?? '') === '') {
-    return undefined;
-  }
+async function dbFromEnv(): Promise<import('@rpe/db').RpeDb | undefined> {
+  if ((process.env['DATABASE_URL'] ?? '') === '') return undefined;
   const { createDb } = await import('@rpe/db');
-  const { createSessionAuth } = await import('./services/session.js');
-  const { createMailerFromEnv } = await import('./services/mailer.js');
   const db = createDb();
   await db.applyMigrations();
+  return db;
+}
+
+async function sessionFromEnv(db: import('@rpe/db').RpeDb | undefined): Promise<{ auth: RpeAuth } | undefined> {
+  const secret = process.env['BETTER_AUTH_SECRET'] ?? '';
+  const baseURL = process.env['RPE_AUTH_BASE_URL'] ?? '';
+  if (secret === '' || baseURL === '' || db === undefined) {
+    return undefined;
+  }
+  const { createSessionAuth } = await import('./services/session.js');
+  const { createMailerFromEnv } = await import('./services/mailer.js');
   const auth = createSessionAuth({
     db,
     secret,
@@ -720,8 +727,24 @@ async function sessionFromEnv(): Promise<{ auth: RpeAuth } | undefined> {
 if (resolve(process.argv[1] ?? '') === __filename) {
   const port = validatePort(process.env['PORT']);
   const host = process.env['HOST'] ?? '0.0.0.0';
-  const session = await sessionFromEnv();
-  const server = createApp(session !== undefined ? { session } : {});
+  const entryDb = await dbFromEnv();
+  const session = await sessionFromEnv(entryDb);
+  // RPE-83: opt into DB-backed API keys (instant fleet revocation via
+  // periodic refresh); default stays the RPE-75 env/file allowlist
+  let keyStore: Pick<ApiKeyStore, 'size' | 'verify' | 'revoke'> | undefined;
+  if (process.env['RPE_API_KEYS_SOURCE'] === 'db' && entryDb !== undefined) {
+    const { DbApiKeyStore } = await import('./services/dbApiKeys.js');
+    const store = await DbApiKeyStore.load(entryDb);
+    const refreshSec = Number(process.env['RPE_API_KEYS_REFRESH_SEC'] ?? '30');
+    if (Number.isFinite(refreshSec) && refreshSec > 0) {
+      setInterval(() => void store.refresh().catch(() => undefined), refreshSec * 1000).unref();
+    }
+    keyStore = store;
+  }
+  const server = createApp({
+    ...(session !== undefined ? { session } : {}),
+    ...(keyStore !== undefined ? { auth: { store: keyStore } } : {}),
+  });
   server.listen(port, host, () => {
     if (session !== undefined) console.log('  /v1/auth/* (cookie sessions enabled)');
     console.log(`@rpe/api ${VERSION} listening on http://${host}:${port}`);

--- a/apps/api/src/services/dbApiKeys.ts
+++ b/apps/api/src/services/dbApiKeys.ts
@@ -1,0 +1,139 @@
+/**
+ * E10 Phase 2 — DB-backed API key store (RPE-83)
+ *
+ * The DB is the source of truth; verification stays on the RPE-75 sync
+ * hot path via an in-memory mirror hydrated at boot. Writes flow back
+ * asynchronously:
+ *   - verify() marks lastUsedAt in the mirror and queues a persist
+ *   - revoke() is instant in-process and persisted immediately
+ *   - refresh() re-pulls the table (other instances see revocations on
+ *     their next refresh — wire an interval in deploys; single-process
+ *     deployments are instant)
+ *
+ * Drop-in for ApiKeyStore at the dispatcher gate: same verify/revoke/
+ * size surface, same record shape (organizationId added for tenant
+ * scoping in RPE-84).
+ */
+
+import {
+  importApiKeyRecords,
+  insertApiKey,
+  listApiKeys,
+  markKeyRevoked,
+  touchKeyLastUsed,
+  type RpeDb,
+} from '@rpe/db';
+import { ApiKeyStore, hashSecret, KEY_PREFIX, type ApiKeyRecord } from './apiKeys.js';
+import { randomBytes } from 'node:crypto';
+
+export interface DbApiKeyRecord extends ApiKeyRecord {
+  organizationId: string;
+}
+
+export class DbApiKeyStore {
+  private mirror: ApiKeyStore;
+  private orgByKeyId = new Map<string, string>();
+  private pending: Promise<void> = Promise.resolve();
+
+  private constructor(
+    private readonly db: RpeDb,
+    records: ApiKeyRecord[],
+    orgs: Map<string, string>,
+  ) {
+    this.mirror = new ApiKeyStore(records);
+    this.orgByKeyId = orgs;
+  }
+
+  /** Hydrate the sync mirror from the api_key table. */
+  static async load(db: RpeDb): Promise<DbApiKeyStore> {
+    const rows = await listApiKeys(db);
+    const records = rows.map((row) => ({
+      id: row.id,
+      label: row.label,
+      hash: row.hash,
+      createdAt: row.createdAt.toISOString(),
+      revokedAt: row.revokedAt === null ? null : row.revokedAt.toISOString(),
+      lastUsedAt: row.lastUsedAt === null ? null : row.lastUsedAt.toISOString(),
+    }));
+    return new DbApiKeyStore(db, records, new Map(rows.map((r) => [r.id, r.organizationId])));
+  }
+
+  get size(): number {
+    return this.mirror.size;
+  }
+
+  /** Sync verify against the mirror; lastUsedAt persists in the background. */
+  verify(secret: string, now: () => number = Date.now): DbApiKeyRecord | null {
+    const record = this.mirror.verify(secret, now);
+    if (record === null) return null;
+    const when = new Date(now());
+    this.queue(() => touchKeyLastUsed(this.db, record.id, when));
+    return { ...record, organizationId: this.orgByKeyId.get(record.id) ?? '' };
+  }
+
+  /** Instant in-process revocation, persisted to the DB. */
+  revoke(id: string, now: () => number = Date.now): boolean {
+    const revoked = this.mirror.revoke(id, now);
+    if (revoked) {
+      const when = new Date(now());
+      this.queue(() => markKeyRevoked(this.db, id, when).then(() => undefined));
+    }
+    return revoked;
+  }
+
+  /** Mint + persist a key for an org; the secret is returned exactly once. */
+  async mint(organizationId: string, label: string, now: () => number = Date.now): Promise<{
+    record: DbApiKeyRecord;
+    secret: string;
+  }> {
+    const secret = `${KEY_PREFIX}${randomBytes(24).toString('hex')}`;
+    const row = await insertApiKey(this.db, {
+      organizationId,
+      label,
+      hash: hashSecret(secret),
+      createdAt: new Date(now()),
+    });
+    await this.refresh();
+    return {
+      record: {
+        id: row.id,
+        label: row.label,
+        hash: row.hash,
+        createdAt: row.createdAt.toISOString(),
+        revokedAt: null,
+        lastUsedAt: null,
+        organizationId,
+      },
+      secret,
+    };
+  }
+
+  /** Idempotent RPE-75 migration: env/file records → DB rows under an org. */
+  async importEnvRecords(
+    organizationId: string,
+    records: readonly ApiKeyRecord[],
+  ): Promise<{ imported: number; skipped: number }> {
+    const result = await importApiKeyRecords(this.db, organizationId, records);
+    await this.refresh();
+    return result;
+  }
+
+  /** Re-pull the table — picks up revocations/mints from other instances. */
+  async refresh(): Promise<void> {
+    await this.flush();
+    const reloaded = await DbApiKeyStore.load(this.db);
+    this.mirror = reloaded.mirror;
+    this.orgByKeyId = reloaded.orgByKeyId;
+  }
+
+  /** Await queued background writes — tests and graceful shutdown. */
+  async flush(): Promise<void> {
+    await this.pending;
+  }
+
+  private queue(work: () => Promise<void>): void {
+    this.pending = this.pending.then(work).catch((err: unknown) => {
+      console.error('api key store: background write failed —', err instanceof Error ? err.message : String(err));
+    });
+  }
+}

--- a/apps/api/tests/dbApiKeys.test.ts
+++ b/apps/api/tests/dbApiKeys.test.ts
@@ -1,0 +1,114 @@
+/**
+ * RPE-83: DB-backed API keys — mint/verify/revoke against the api_key
+ * table, idempotent RPE-75 env-record import (old secrets keep
+ * working), lastUsedAt persistence, cross-instance refresh, and the
+ * store plugged into the live dispatcher gate.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { mintKey } from '../src/services/apiKeys';
+import { DbApiKeyStore } from '../src/services/dbApiKeys';
+import { createDb, listApiKeys, type RpeDb } from '@rpe/db';
+import { EXAMPLE_DEAL_INPUTS } from '@rpe/engine';
+
+let db: RpeDb;
+
+beforeEach(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+});
+
+afterEach(() => db.close());
+
+describe('DbApiKeyStore (RPE-83)', () => {
+  it('mints into the DB and verifies; the record carries the org id', async () => {
+    const store = await DbApiKeyStore.load(db);
+    expect(store.size).toBe(0);
+
+    const { record, secret } = await store.mint('org-a', 'acme-prod');
+    expect(store.size).toBe(1);
+
+    const verified = store.verify(secret);
+    expect(verified?.id).toBe(record.id);
+    expect(verified?.organizationId).toBe('org-a');
+    expect(store.verify('rpe_live_' + '0'.repeat(48))).toBeNull();
+
+    // lastUsedAt persists after the background write flushes
+    await store.flush();
+    const rows = await listApiKeys(db);
+    expect(rows[0]?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it('imports RPE-75 env records idempotently — previously issued secrets keep working', async () => {
+    const { record, secret } = mintKey('legacy-consumer');
+    const store = await DbApiKeyStore.load(db);
+
+    const first = await store.importEnvRecords('org-legacy', [record]);
+    expect(first).toEqual({ imported: 1, skipped: 0 });
+    const second = await store.importEnvRecords('org-legacy', [record]);
+    expect(second).toEqual({ imported: 0, skipped: 1 });
+
+    const verified = store.verify(secret);
+    expect(verified?.id).toBe(record.id);
+    expect(verified?.organizationId).toBe('org-legacy');
+  });
+
+  it('revocation is instant in-process, persisted, and visible to a fresh instance', async () => {
+    const store = await DbApiKeyStore.load(db);
+    const { record, secret } = await store.mint('org-a', 'to-revoke');
+
+    expect(store.revoke(record.id)).toBe(true);
+    expect(store.verify(secret)).toBeNull();
+
+    await store.flush();
+    const other = await DbApiKeyStore.load(db); // another "instance"
+    expect(other.verify(secret)).toBeNull();
+  });
+
+  it('refresh picks up keys minted by another instance', async () => {
+    const a = await DbApiKeyStore.load(db);
+    const b = await DbApiKeyStore.load(db);
+    const { secret } = await a.mint('org-a', 'minted-elsewhere');
+
+    expect(b.verify(secret)).toBeNull(); // stale mirror
+    await b.refresh();
+    expect(b.verify(secret)?.organizationId).toBe('org-a');
+  });
+
+  it('drives the live dispatcher gate: 401 without, 200 with, 401 after revoke', async () => {
+    const store = await DbApiKeyStore.load(db);
+    const { record, secret } = await store.mint('org-a', 'gate-test');
+
+    const server: Server = createApp({ auth: { store }, v1RateLimit: { rpm: 1000, dailyCap: 10000 } });
+    const port: number = await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve((server.address() as { port: number }).port);
+      });
+    });
+    const base = `http://127.0.0.1:${port}`;
+    const evaluateBody = JSON.stringify({ inputs: EXAMPLE_DEAL_INPUTS });
+    const post = (key?: string) =>
+      fetch(`${base}/v1/evaluate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(key !== undefined ? { Authorization: `Bearer ${key}` } : {}),
+        },
+        body: evaluateBody,
+      });
+
+    try {
+      expect((await post()).status).toBe(401);
+      expect((await post(secret)).status).toBe(200);
+      store.revoke(record.id);
+      expect((await post(secret)).status).toBe(401);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+      await store.flush();
+    }
+  });
+});

--- a/packages/db/migrations/pg/0003_overjoyed_whizzer.sql
+++ b/packages/db/migrations/pg/0003_overjoyed_whizzer.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "api_key" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"label" text NOT NULL,
+	"hash" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"last_used_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "deal" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"inputs" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/migrations/pg/meta/0003_snapshot.json
+++ b/packages/db/migrations/pg/meta/0003_snapshot.json
@@ -1,0 +1,815 @@
+{
+  "id": "1cc37c48-b2ad-45b9-96f6-aa9061606a5b",
+  "prevId": "30cfc361-8421-4540-abde-a5f72672ca3e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_key": {
+      "name": "api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_meta": {
+      "name": "app_meta",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deal": {
+      "name": "deal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/migrations/pg/meta/_journal.json
+++ b/packages/db/migrations/pg/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781111182224,
       "tag": "0002_faithful_rawhide_kid",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781116326599,
+      "tag": "0003_overjoyed_whizzer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/migrations/sqlite/0003_marvelous_beyonder.sql
+++ b/packages/db/migrations/sqlite/0003_marvelous_beyonder.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `api_key` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`label` text NOT NULL,
+	`hash` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`revoked_at` integer,
+	`last_used_at` integer
+);
+--> statement-breakpoint
+CREATE TABLE `deal` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`name` text NOT NULL,
+	`inputs` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL
+);

--- a/packages/db/migrations/sqlite/meta/0003_snapshot.json
+++ b/packages/db/migrations/sqlite/meta/0003_snapshot.json
@@ -1,0 +1,788 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b5c55a56-2473-40d9-8408-64b683178305",
+  "prevId": "0181ebaf-dfbe-46e8-a438-44aa3b201cde",
+  "tables": {
+    "api_key": {
+      "name": "api_key",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_meta": {
+      "name": "app_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "deal": {
+      "name": "deal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/migrations/sqlite/meta/_journal.json
+++ b/packages/db/migrations/sqlite/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781111182409,
       "tag": "0002_tiresome_green_goblin",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1781116326777,
+      "tag": "0003_marvelous_beyonder",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/apiKeys.ts
+++ b/packages/db/src/apiKeys.ts
@@ -1,0 +1,122 @@
+/**
+ * E10 Phase 2 — DB-backed API keys (RPE-83)
+ *
+ * Row CRUD for the api_key table. Keys keep the RPE-75 model — sha256
+ * hash at rest, secret never stored — and gain an organizationId per
+ * the one-identity-layer decision (E11). The apps/api DbApiKeyStore
+ * hydrates from these rows; this module is just the data access.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import type { RpeDb } from './client.js';
+import { pgSchema } from './schema.pg.js';
+import { sqliteSchema } from './schema.sqlite.js';
+
+export interface ApiKeyRow {
+  id: string;
+  organizationId: string;
+  label: string;
+  hash: string;
+  createdAt: Date;
+  revokedAt: Date | null;
+  lastUsedAt: Date | null;
+}
+
+export async function insertApiKey(
+  db: RpeDb,
+  data: { organizationId: string; label: string; hash: string; id?: string; createdAt?: Date },
+): Promise<ApiKeyRow> {
+  const row: ApiKeyRow = {
+    id: data.id ?? `key_${randomUUID().slice(0, 8)}`,
+    organizationId: data.organizationId,
+    label: data.label,
+    hash: data.hash,
+    createdAt: data.createdAt ?? new Date(),
+    revokedAt: null,
+    lastUsedAt: null,
+  };
+  if (db.dialect === 'postgres') {
+    await db.pg.insert(pgSchema.apiKey).values(row);
+  } else {
+    await db.sqlite.insert(sqliteSchema.apiKey).values(row);
+  }
+  return row;
+}
+
+/** All keys, revoked included — the store filters; ops tooling lists. */
+export async function listApiKeys(db: RpeDb): Promise<ApiKeyRow[]> {
+  return db.dialect === 'postgres'
+    ? await db.pg.select().from(pgSchema.apiKey)
+    : await db.sqlite.select().from(sqliteSchema.apiKey);
+}
+
+export async function markKeyRevoked(db: RpeDb, id: string, when: Date): Promise<boolean> {
+  if (db.dialect === 'postgres') {
+    const res = await db.pg
+      .update(pgSchema.apiKey)
+      .set({ revokedAt: when })
+      .where(eq(pgSchema.apiKey.id, id))
+      .returning({ id: pgSchema.apiKey.id });
+    return res.length > 0;
+  }
+  const res = await db.sqlite
+    .update(sqliteSchema.apiKey)
+    .set({ revokedAt: when })
+    .where(eq(sqliteSchema.apiKey.id, id))
+    .returning({ id: sqliteSchema.apiKey.id });
+  return res.length > 0;
+}
+
+export async function touchKeyLastUsed(db: RpeDb, id: string, when: Date): Promise<void> {
+  if (db.dialect === 'postgres') {
+    await db.pg.update(pgSchema.apiKey).set({ lastUsedAt: when }).where(eq(pgSchema.apiKey.id, id));
+    return;
+  }
+  await db.sqlite.update(sqliteSchema.apiKey).set({ lastUsedAt: when }).where(eq(sqliteSchema.apiKey.id, id));
+}
+
+/**
+ * Migration path (RPE-75 → DB): bring existing env/file records into the
+ * DB under an org. The hash IS the credential, so previously issued
+ * secrets keep working. Existing ids are preserved; duplicates (by id)
+ * are skipped so the import is idempotent.
+ */
+export async function importApiKeyRecords(
+  db: RpeDb,
+  organizationId: string,
+  records: ReadonlyArray<{
+    id: string;
+    label: string;
+    hash: string;
+    createdAt: string;
+    revokedAt: string | null;
+    lastUsedAt?: string | null;
+  }>,
+): Promise<{ imported: number; skipped: number }> {
+  const existing = new Set((await listApiKeys(db)).map((k) => k.id));
+  let imported = 0;
+  let skipped = 0;
+  for (const record of records) {
+    if (existing.has(record.id)) {
+      skipped += 1;
+      continue;
+    }
+    const row: ApiKeyRow = {
+      id: record.id,
+      organizationId,
+      label: record.label,
+      hash: record.hash,
+      createdAt: new Date(record.createdAt),
+      revokedAt: record.revokedAt === null ? null : new Date(record.revokedAt),
+      lastUsedAt: record.lastUsedAt == null ? null : new Date(record.lastUsedAt),
+    };
+    if (db.dialect === 'postgres') {
+      await db.pg.insert(pgSchema.apiKey).values(row);
+    } else {
+      await db.sqlite.insert(sqliteSchema.apiKey).values(row);
+    }
+    imported += 1;
+  }
+  return { imported, skipped };
+}

--- a/packages/db/src/deals.ts
+++ b/packages/db/src/deals.ts
@@ -1,0 +1,162 @@
+/**
+ * E10 Phase 2 — org-scoped deal persistence (RPE-83)
+ *
+ * Data-access layer for stored deals. Every function takes the org id
+ * explicitly and filters on it IN THE QUERY — cross-tenant reads/writes
+ * are impossible by construction (the RPE-94 contract), and a miss is
+ * indistinguishable between "doesn't exist" and "not yours".
+ *
+ * `inputs` is the engine's DealInputs as JSON — the engine remains the
+ * single source of shape truth; this layer stores and returns it opaque.
+ *
+ * Dialect note: Drizzle's pg/sqlite builders don't share a callable
+ * type, so each operation branches explicitly (same caveat as orgs.ts).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import type { RpeDb } from './client.js';
+import { pgSchema } from './schema.pg.js';
+import { sqliteSchema } from './schema.sqlite.js';
+
+export interface DealRecord {
+  id: string;
+  organizationId: string;
+  name: string;
+  inputs: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface DealPage {
+  deals: DealRecord[];
+  total: number;
+}
+
+export async function createDeal(
+  db: RpeDb,
+  organizationId: string,
+  data: { name: string; inputs: unknown },
+): Promise<DealRecord> {
+  const now = new Date();
+  const record: DealRecord = {
+    id: randomUUID(),
+    organizationId,
+    name: data.name,
+    inputs: data.inputs,
+    createdAt: now,
+    updatedAt: now,
+  };
+  if (db.dialect === 'postgres') {
+    await db.pg.insert(pgSchema.deal).values(record);
+  } else {
+    await db.sqlite.insert(sqliteSchema.deal).values(record);
+  }
+  return record;
+}
+
+export async function getDeal(
+  db: RpeDb,
+  organizationId: string,
+  dealId: string,
+): Promise<DealRecord | null> {
+  const rows: DealRecord[] =
+    db.dialect === 'postgres'
+      ? await db.pg
+          .select()
+          .from(pgSchema.deal)
+          .where(and(eq(pgSchema.deal.id, dealId), eq(pgSchema.deal.organizationId, organizationId)))
+          .limit(1)
+      : await db.sqlite
+          .select()
+          .from(sqliteSchema.deal)
+          .where(and(eq(sqliteSchema.deal.id, dealId), eq(sqliteSchema.deal.organizationId, organizationId)))
+          .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function listDeals(
+  db: RpeDb,
+  organizationId: string,
+  options: { limit?: number; offset?: number } = {},
+): Promise<DealPage> {
+  const limit = Math.min(Math.max(options.limit ?? 50, 1), 200);
+  const offset = Math.max(options.offset ?? 0, 0);
+
+  const rows: DealRecord[] =
+    db.dialect === 'postgres'
+      ? await db.pg
+          .select()
+          .from(pgSchema.deal)
+          .where(eq(pgSchema.deal.organizationId, organizationId))
+          .orderBy(desc(pgSchema.deal.updatedAt))
+          .limit(limit)
+          .offset(offset)
+      : await db.sqlite
+          .select()
+          .from(sqliteSchema.deal)
+          .where(eq(sqliteSchema.deal.organizationId, organizationId))
+          .orderBy(desc(sqliteSchema.deal.updatedAt))
+          .limit(limit)
+          .offset(offset);
+
+  const counted: Array<{ count: number }> =
+    db.dialect === 'postgres'
+      ? await db.pg
+          .select({ count: sql<number>`count(*)` })
+          .from(pgSchema.deal)
+          .where(eq(pgSchema.deal.organizationId, organizationId))
+      : await db.sqlite
+          .select({ count: sql<number>`count(*)` })
+          .from(sqliteSchema.deal)
+          .where(eq(sqliteSchema.deal.organizationId, organizationId));
+
+  return { deals: rows, total: Number(counted[0]?.count ?? 0) };
+}
+
+export async function updateDeal(
+  db: RpeDb,
+  organizationId: string,
+  dealId: string,
+  patch: { name?: string; inputs?: unknown },
+): Promise<DealRecord | null> {
+  const existing = await getDeal(db, organizationId, dealId);
+  if (existing === null) return null;
+
+  const values = {
+    ...(patch.name !== undefined ? { name: patch.name } : {}),
+    ...(patch.inputs !== undefined ? { inputs: patch.inputs } : {}),
+    updatedAt: new Date(),
+  };
+  if (db.dialect === 'postgres') {
+    await db.pg
+      .update(pgSchema.deal)
+      .set(values)
+      .where(and(eq(pgSchema.deal.id, dealId), eq(pgSchema.deal.organizationId, organizationId)));
+  } else {
+    await db.sqlite
+      .update(sqliteSchema.deal)
+      .set(values)
+      .where(and(eq(sqliteSchema.deal.id, dealId), eq(sqliteSchema.deal.organizationId, organizationId)));
+  }
+  return getDeal(db, organizationId, dealId);
+}
+
+export async function deleteDeal(
+  db: RpeDb,
+  organizationId: string,
+  dealId: string,
+): Promise<boolean> {
+  const existing = await getDeal(db, organizationId, dealId);
+  if (existing === null) return false;
+  if (db.dialect === 'postgres') {
+    await db.pg
+      .delete(pgSchema.deal)
+      .where(and(eq(pgSchema.deal.id, dealId), eq(pgSchema.deal.organizationId, organizationId)));
+  } else {
+    await db.sqlite
+      .delete(sqliteSchema.deal)
+      .where(and(eq(sqliteSchema.deal.id, dealId), eq(sqliteSchema.deal.organizationId, organizationId)));
+  }
+  return true;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,3 +5,5 @@ export { seedDev } from './seed.js';
 export { createAuth, type CreateAuthOptions, type RpeAuth } from './auth.js';
 export { LoginThrottle, type ThrottleDecision, type ThrottlePolicy } from './loginThrottle.js';
 export { findMembership, listMemberships, roleAtLeast, OrgScope, TenantIsolationError, type Membership, type OrgRole } from './orgs.js';
+export { createDeal, getDeal, listDeals, updateDeal, deleteDeal, type DealRecord, type DealPage } from './deals.js';
+export { insertApiKey, listApiKeys, markKeyRevoked, touchKeyLastUsed, importApiKeyRecords, type ApiKeyRow } from './apiKeys.js';

--- a/packages/db/src/schema.pg.ts
+++ b/packages/db/src/schema.pg.ts
@@ -11,7 +11,7 @@
  * stories (RPE-89+, better-auth-generated per ADR 0001).
  */
 
-import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 
 /** Key/value app metadata — the migration smoke table. */
 export const appMeta = pgTable('app_meta', {
@@ -20,6 +20,34 @@ export const appMeta = pgTable('app_meta', {
   updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' })
     .notNull()
     .defaultNow(),
+});
+
+/**
+ * E10 Phase 2 (RPE-83) — org-scoped stored deals. `inputs` is the
+ * engine's DealInputs as JSON; the engine stays the single source of
+ * shape truth, so the DB column is schemaless on purpose.
+ */
+export const deal = pgTable('deal', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull(),
+  name: text('name').notNull(),
+  inputs: jsonb('inputs').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+});
+
+/**
+ * RPE-83 — DB-backed API keys (RPE-75 model: sha256 hash at rest),
+ * attached to an organization per the one-identity-layer decision.
+ */
+export const apiKey = pgTable('api_key', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull(),
+  label: text('label').notNull(),
+  hash: text('hash').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+  revokedAt: timestamp('revoked_at', { withTimezone: true, mode: 'date' }),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true, mode: 'date' }),
 });
 
 import { account as authAccountPg, invitation as authInvitationPg, member as authMemberPg, organization as authOrganizationPg, session as authSessionPg, user as authUserPg, verification as authVerificationPg } from './schema.auth.pg.js';
@@ -33,4 +61,6 @@ export const pgSchema = {
   organization: authOrganizationPg,
   member: authMemberPg,
   invitation: authInvitationPg,
+  deal,
+  apiKey,
 };

--- a/packages/db/src/schema.sqlite.ts
+++ b/packages/db/src/schema.sqlite.ts
@@ -22,6 +22,33 @@ export const appMeta = sqliteTable('app_meta', {
     .default(sql`(unixepoch() * 1000)`),
 });
 
+/** E10 Phase 2 (RPE-83) — org-scoped stored deals (see schema.pg.ts). */
+export const dealLite = sqliteTable('deal', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull(),
+  name: text('name').notNull(),
+  inputs: text('inputs', { mode: 'json' }).notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .default(sql`(unixepoch() * 1000)`),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .default(sql`(unixepoch() * 1000)`),
+});
+
+/** RPE-83 — DB-backed API keys (see schema.pg.ts). */
+export const apiKeyLite = sqliteTable('api_key', {
+  id: text('id').primaryKey(),
+  organizationId: text('organization_id').notNull(),
+  label: text('label').notNull(),
+  hash: text('hash').notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .default(sql`(unixepoch() * 1000)`),
+  revokedAt: integer('revoked_at', { mode: 'timestamp_ms' }),
+  lastUsedAt: integer('last_used_at', { mode: 'timestamp_ms' }),
+});
+
 import { account as authAccountLite, invitation as authInvitationLite, member as authMemberLite, organization as authOrganizationLite, session as authSessionLite, user as authUserLite, verification as authVerificationLite } from './schema.auth.sqlite.js';
 
 export const sqliteSchema = {
@@ -33,4 +60,6 @@ export const sqliteSchema = {
   organization: authOrganizationLite,
   member: authMemberLite,
   invitation: authInvitationLite,
+  deal: dealLite,
+  apiKey: apiKeyLite,
 };

--- a/packages/db/tests/deals.test.ts
+++ b/packages/db/tests/deals.test.ts
@@ -1,0 +1,87 @@
+/**
+ * RPE-83: deal persistence — CRUD round-trips, JSON inputs fidelity,
+ * pagination, and the tenant-scoping contract (org-filtered queries:
+ * cross-org access is a uniform miss, never a leak).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createDb,
+  createDeal,
+  deleteDeal,
+  getDeal,
+  listDeals,
+  updateDeal,
+  type RpeDb,
+} from '../src/index';
+
+let db: RpeDb;
+
+const INPUTS = { purchasePrice: 300000, grossRent: 2200, vacancyPct: 5 };
+
+beforeAll(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+});
+
+afterAll(() => db.close());
+
+describe('deal persistence (RPE-83)', () => {
+  it('creates and round-trips a deal with JSON inputs intact', async () => {
+    const deal = await createDeal(db, 'org-a', { name: 'Maple St duplex', inputs: INPUTS });
+    expect(deal.id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const fetched = await getDeal(db, 'org-a', deal.id);
+    expect(fetched?.name).toBe('Maple St duplex');
+    expect(fetched?.inputs).toEqual(INPUTS);
+    expect(fetched?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('tenant scoping: another org gets a miss for the same id — read, update, and delete', async () => {
+    const deal = await createDeal(db, 'org-a', { name: 'Private', inputs: INPUTS });
+
+    expect(await getDeal(db, 'org-b', deal.id)).toBeNull();
+    expect(await updateDeal(db, 'org-b', deal.id, { name: 'stolen' })).toBeNull();
+    expect(await deleteDeal(db, 'org-b', deal.id)).toBe(false);
+
+    // untouched for the owner
+    const still = await getDeal(db, 'org-a', deal.id);
+    expect(still?.name).toBe('Private');
+  });
+
+  it('updates name/inputs and bumps updatedAt; delete removes the row', async () => {
+    const deal = await createDeal(db, 'org-a', { name: 'v1', inputs: INPUTS });
+    await new Promise((r) => setTimeout(r, 5));
+    const updated = await updateDeal(db, 'org-a', deal.id, {
+      name: 'v2',
+      inputs: { ...INPUTS, grossRent: 2400 },
+    });
+    expect(updated?.name).toBe('v2');
+    expect((updated?.inputs as { grossRent: number }).grossRent).toBe(2400);
+    expect(updated!.updatedAt.getTime()).toBeGreaterThanOrEqual(deal.updatedAt.getTime());
+
+    expect(await deleteDeal(db, 'org-a', deal.id)).toBe(true);
+    expect(await getDeal(db, 'org-a', deal.id)).toBeNull();
+  });
+
+  it('lists only the org\'s deals, newest-updated first, with total + pagination', async () => {
+    const fresh = createDb(':memory:');
+    await fresh.applyMigrations();
+    try {
+      for (let i = 0; i < 5; i++) {
+        await createDeal(fresh, 'org-mine', { name: `deal-${i}`, inputs: INPUTS });
+      }
+      await createDeal(fresh, 'org-other', { name: 'not-mine', inputs: INPUTS });
+
+      const page = await listDeals(fresh, 'org-mine', { limit: 3 });
+      expect(page.total).toBe(5);
+      expect(page.deals).toHaveLength(3);
+      expect(page.deals.every((d) => d.organizationId === 'org-mine')).toBe(true);
+
+      const rest = await listDeals(fresh, 'org-mine', { limit: 3, offset: 3 });
+      expect(rest.deals).toHaveLength(2);
+    } finally {
+      await fresh.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **`deal` table** (0003 migrations, both dialects): org-scoped stored deals; the engine's `DealInputs` ride as opaque JSON (`jsonb` pg / JSON-mode `text` sqlite) so the engine stays the single shape authority. Data-access layer (`createDeal`/`getDeal`/`listDeals`/`updateDeal`/`deleteDeal`) filters `organizationId` **in every where clause** — cross-tenant access impossible by construction, misses never reveal existence (the RPE-94 contract). Paginated list with stable newest-updated ordering
- **`api_key` table + `DbApiKeyStore`:** the DB is the source of truth while verification stays on RPE-75's sync constant-time hot path via a boot-hydrated in-memory mirror; `lastUsedAt` persists through a serialized background queue; `revoke()` is instant in-process + persisted; `refresh()` converges other instances (entry wires a 30 s interval). Keys carry `organizationId` per the one-identity-layer decision
- **Legacy migration path:** `importApiKeyRecords` is idempotent — env/file records move into the DB under an org and previously issued secrets keep working (the hash is the credential). `manage-keys-db.ts` CLI: mint/list/revoke/import (smoke-tested against a file DB)
- **Opt-in:** `RPE_API_KEYS_SOURCE=db` + `DATABASE_URL`; the env/file allowlist stays the zero-config default. `createApp` accepts a pre-built store (`auth.store`)
- 9 new tests (950 total) including the live dispatcher 401→200→revoke→401 walk with a DB-minted key

## Review
Copilot unavailable; strict self-review loop — round 1: union-runner typing didn't compile (rewritten as explicit dialect branches, the documented orgs.ts caveat); round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)