### PR TITLE
RPE-84: /v1/deals CRUD + stored report retrieval (cached)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -57,6 +57,7 @@ import { handleScrape, type ScrapeDeps, type ScrapeSuccessBody } from './routes/
 import { RateLimiter, TtlCache, clientIp } from './services/guardrails.js';
 import { Router, logRequest, normalizePath, resolveRequestId, v1Error } from './router.js';
 import { ApiKeyStore, extractApiKey, type ApiKeyRecord } from './services/apiKeys.js';
+import { handleDeals, type DealsDeps } from './routes/deals.js';
 import { toNodeHandler } from 'better-auth/node';
 import type { RpeAuth } from '@rpe/db';
 
@@ -416,6 +417,12 @@ export interface AppConfig {
     /** RPE-83: a pre-built store (e.g. DbApiKeyStore) — wins over keys/env. */
     store?: Pick<ApiKeyStore, 'size' | 'verify' | 'revoke'>;
   };
+  /** RPE-84: stored-deals surface — requires a DB and org-attached keys.
+   * Env: RPE_REPORT_CACHE_TTL_MS (default 600000) bounds the report cache. */
+  deals?: {
+    db: import('@rpe/db').RpeDb;
+    reportCacheTtlMs?: number;
+  };
   /** /v1 public-surface throttle (RPE-76) — keyed by api key id, per-IP
    * for unauthenticated paths. In-memory fixed windows: a shared store
    * (e.g. Redis) is required before horizontal scaling. Env:
@@ -528,6 +535,11 @@ export function createApp(config: AppConfig = {}) {
     .on('POST', '/scrape', (rq, rs) => handleScrape(rq, rs, jsonWithRequestId, readBody, scrapeDeps));
 
   // /v1-native routes (RPE-79) — never exposed on the legacy unprefixed surface
+  const dealsDb = config.deals?.db ?? null;
+  const reportCache = new TtlCache<{ contentType: string; body: Uint8Array | string; disposition?: string }>(
+    config.deals?.reportCacheTtlMs ?? envInt('RPE_REPORT_CACHE_TTL_MS', 600_000),
+  );
+
   const v1Router = new Router()
     .on('GET', '/openapi.json', (rq, rs) => json(rs, 200, buildOpenApiSpec(VERSION)))
     .on('GET', '/docs', (rq, rs) => sendRaw(rs, 200, 'text/html; charset=utf-8', docsHtml()))
@@ -556,6 +568,7 @@ export function createApp(config: AppConfig = {}) {
     const isV1 = rawPath === '/v1' || rawPath.startsWith('/v1/');
     const path = isV1 ? normalizePath(rawPath.slice(3)) : rawPath;
     let apiKeyId: string | null = null;
+    let apiKeyOrgId: string | null = null;
 
     res.on('finish', () => {
       logRequest({
@@ -597,6 +610,7 @@ export function createApp(config: AppConfig = {}) {
       const record = presented !== null ? apiKeys.verify(presented) : null;
       if (record !== null) {
         apiKeyId = record.id;
+        apiKeyOrgId = (record as { organizationId?: string }).organizationId ?? null;
       } else if (!isV1Open) {
         // health/docs identify but never reject (load balancers and browsers don't auth);
         // everything else on /v1 requires a valid key
@@ -653,6 +667,42 @@ export function createApp(config: AppConfig = {}) {
       req.headers['x-rpe-client-ip'] = clientIp(req);
       sessionAuthHandler(req, res).catch((err: unknown) => {
         console.error('Auth handler error:', err instanceof Error ? err.stack : String(err), 'requestId:', requestId);
+        if (!res.headersSent) {
+          json(res, 500, v1Error('internal', 'Internal server error', requestId));
+        }
+      });
+      return;
+    }
+
+    // Stored deals (RPE-84): org comes from the verified key — requires
+    // the RPE-83 DB-backed store; env-allowlist keys carry no org
+    const isV1Deals = isV1 && (path === '/deals' || path.startsWith('/deals/'));
+    if (isV1Deals) {
+      if (dealsDb === null) {
+        json(res, 404, v1Error('not_found', 'Deal storage is not enabled on this server.', requestId));
+        return;
+      }
+      if (apiKeyOrgId === null || apiKeyOrgId === '') {
+        json(res, 403, v1Error(
+          'forbidden',
+          'Stored deals require an organization-attached API key (DB-backed keys).',
+          requestId,
+        ));
+        return;
+      }
+      const dealsDeps: DealsDeps = {
+        db: dealsDb,
+        organizationId: apiKeyOrgId,
+        json: jsonWithRequestId,
+        readBody,
+        sendRaw,
+        requestId,
+        engineVersion: VERSION,
+        validate: validateEvaluateBody,
+        reportCache,
+      };
+      handleDeals(req, res, path.slice('/deals'.length), dealsDeps).catch((err: unknown) => {
+        console.error('Deals handler error:', err instanceof Error ? err.stack : String(err), 'requestId:', requestId);
         if (!res.headersSent) {
           json(res, 500, v1Error('internal', 'Internal server error', requestId));
         }
@@ -744,6 +794,7 @@ if (resolve(process.argv[1] ?? '') === __filename) {
   const server = createApp({
     ...(session !== undefined ? { session } : {}),
     ...(keyStore !== undefined ? { auth: { store: keyStore } } : {}),
+    ...(entryDb !== undefined ? { deals: { db: entryDb } } : {}),
   });
   server.listen(port, host, () => {
     if (session !== undefined) console.log('  /v1/auth/* (cookie sessions enabled)');

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -151,6 +151,13 @@ function errorResponse(description: string) {
 }
 
 /** Build the spec. Pure — version injected so it tracks the package. */
+const DEAL_ID_PARAM = {
+  name: 'id',
+  in: 'path',
+  required: true,
+  schema: { type: 'string', pattern: '^[\\w-]{1,64}$' },
+} as const;
+
 export function buildOpenApiSpec(version: string): Record<string, unknown> {
   return {
     openapi: '3.1.0',
@@ -174,6 +181,17 @@ export function buildOpenApiSpec(version: string): Record<string, unknown> {
         DealInputs: DEAL_INPUTS,
         EvalOptions: EVAL_OPTS,
         DealReport: DEAL_REPORT,
+        StoredDeal: {
+          type: 'object',
+          required: ['id', 'name', 'inputs', 'createdAt', 'updatedAt'],
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            inputs: { $ref: '#/components/schemas/DealInputs' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
       },
     },
     paths: {
@@ -231,6 +249,152 @@ export function buildOpenApiSpec(version: string): Record<string, unknown> {
             '401': errorResponse('Missing/invalid/revoked API key.'),
             '413': errorResponse('Payload exceeds 64 KB.'),
             '429': errorResponse('Rate limit exceeded — see Retry-After.'),
+          },
+        },
+      },
+      '/deals': {
+        post: {
+          summary: 'Create a stored deal (RPE-84)',
+          description:
+            'Org-scoped persistence: the organization comes from the API key (DB-backed keys only — ' +
+            'env-allowlist keys get 403). Returns the stored deal with its id.',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['name', 'inputs'],
+                  properties: {
+                    name: { type: 'string', maxLength: 200 },
+                    inputs: { $ref: '#/components/schemas/DealInputs' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '201': {
+              description: 'The stored deal.',
+              headers: RATE_LIMIT_HEADERS,
+              content: { 'application/json': { schema: { $ref: '#/components/schemas/StoredDeal' } } },
+            },
+            '400': errorResponse('Invalid name or inputs.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '403': errorResponse('API key is not attached to an organization.'),
+            '429': errorResponse('Rate limit exceeded.'),
+          },
+        },
+        get: {
+          summary: 'List stored deals (org-scoped, newest-updated first)',
+          parameters: [
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer', minimum: 1, maximum: 200, default: 50 } },
+            { name: 'offset', in: 'query', required: false, schema: { type: 'integer', minimum: 0, default: 0 } },
+          ],
+          responses: {
+            '200': {
+              description: 'A page of deals plus the org total.',
+              headers: RATE_LIMIT_HEADERS,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['deals', 'total'],
+                    properties: {
+                      deals: { type: 'array', items: { $ref: '#/components/schemas/StoredDeal' } },
+                      total: { type: 'integer' },
+                    },
+                  },
+                },
+              },
+            },
+            '401': errorResponse('Missing or invalid API key.'),
+            '403': errorResponse('API key is not attached to an organization.'),
+            '429': errorResponse('Rate limit exceeded.'),
+          },
+        },
+      },
+      '/deals/{id}': {
+        get: {
+          summary: 'Fetch a stored deal',
+          parameters: [DEAL_ID_PARAM],
+          responses: {
+            '200': {
+              description: 'The deal.',
+              headers: RATE_LIMIT_HEADERS,
+              content: { 'application/json': { schema: { $ref: '#/components/schemas/StoredDeal' } } },
+            },
+            '404': errorResponse('Deal not found (uniform across tenants — existence never leaks).'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '429': errorResponse('Rate limit exceeded.'),
+          },
+        },
+        patch: {
+          summary: 'Update a stored deal (name and/or inputs)',
+          parameters: [DEAL_ID_PARAM],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string', maxLength: 200 },
+                    inputs: { $ref: '#/components/schemas/DealInputs' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description: 'The updated deal (updatedAt bumped; report cache key rotates).',
+              headers: RATE_LIMIT_HEADERS,
+              content: { 'application/json': { schema: { $ref: '#/components/schemas/StoredDeal' } } },
+            },
+            '400': errorResponse('Invalid name or inputs.'),
+            '404': errorResponse('Deal not found.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '429': errorResponse('Rate limit exceeded.'),
+          },
+        },
+        delete: {
+          summary: 'Delete a stored deal',
+          parameters: [DEAL_ID_PARAM],
+          responses: {
+            '204': { description: 'Deleted.' },
+            '404': errorResponse('Deal not found.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '429': errorResponse('Rate limit exceeded.'),
+          },
+        },
+      },
+      '/deals/{id}/report': {
+        get: {
+          summary: 'Generate a report for a stored deal (cached)',
+          description:
+            'Same format negotiation as /v1/reports (`?format=` > Accept > json). Responses are cached by ' +
+            'deal + format + engine version + updatedAt — updating the deal invalidates structurally. ' +
+            'X-Report-Cache: hit|miss. Generation is synchronous (pdf-lib is fast); no async 202 pattern.',
+          parameters: [
+            DEAL_ID_PARAM,
+            { name: 'format', in: 'query', required: false, schema: { type: 'string', enum: ['json', 'csv', 'pdf'] } },
+          ],
+          responses: {
+            '200': {
+              description: 'The report in the negotiated format.',
+              headers: RATE_LIMIT_HEADERS,
+              content: {
+                'application/json': { schema: { $ref: '#/components/schemas/DealReport' } },
+                'text/csv': { schema: { type: 'string' } },
+                'application/pdf': { schema: { type: 'string', format: 'binary' } },
+              },
+            },
+            '404': errorResponse('Deal not found.'),
+            '406': errorResponse('Unsupported report format.'),
+            '422': errorResponse('Stored inputs no longer validate.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '429': errorResponse('Rate limit exceeded.'),
           },
         },
       },

--- a/apps/api/src/routes/deals.ts
+++ b/apps/api/src/routes/deals.ts
@@ -1,0 +1,286 @@
+/**
+ * /v1/deals — stored deals CRUD + report retrieval (RPE-84)
+ *
+ *   POST   /v1/deals                  create { name, inputs } → 201 { id, … }
+ *   GET    /v1/deals?limit&offset     list (org-scoped, newest first)
+ *   GET    /v1/deals/{id}             fetch one
+ *   PATCH  /v1/deals/{id}             update name/inputs
+ *   DELETE /v1/deals/{id}             delete → 204
+ *   GET    /v1/deals/{id}/report?format=json|csv|pdf
+ *
+ * Tenancy: the org comes from the verified API key (DB-backed keys carry
+ * organizationId — RPE-83); every storage call is org-filtered, so a
+ * foreign id is a uniform 404 (never 403 — existence must not leak).
+ *
+ * Report caching: keyed by deal id + format + engine version + the
+ * deal's updatedAt — an update changes the key, so invalidation is
+ * structural rather than imperative. pdf-lib generation is fast enough
+ * (<100 ms) that the async 202 pattern is deliberately NOT implemented;
+ * revisit if report generation ever grows a slow path.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { DealInputs } from '@rpe/engine';
+import { buildReport, reportToCsv, reportToPdf, type DealReport } from '@rpe/report';
+import {
+  createDeal,
+  deleteDeal,
+  getDeal,
+  listDeals,
+  updateDeal,
+  type DealRecord,
+  type RpeDb,
+} from '@rpe/db';
+import { v1Error } from '../router.js';
+import { resolveFormat, type ValidatedEvalBody } from './reports.js';
+import { TtlCache } from '../services/guardrails.js';
+
+type JsonFn = (res: ServerResponse, status: number, body: unknown) => void;
+type ReadBodyFn = (req: IncomingMessage) => Promise<string>;
+type SendRawFn = (
+  res: ServerResponse,
+  status: number,
+  contentType: string,
+  body: Uint8Array | string,
+  disposition?: string,
+) => void;
+
+export interface DealsDeps {
+  db: RpeDb;
+  organizationId: string;
+  json: JsonFn;
+  readBody: ReadBodyFn;
+  sendRaw: SendRawFn;
+  requestId: string;
+  engineVersion: string;
+  /** Shared with /v1/evaluate — single source of inputs-shape truth. */
+  validate: (parsed: unknown) => ValidatedEvalBody;
+  reportCache: TtlCache<{ contentType: string; body: Uint8Array | string; disposition?: string }>;
+}
+
+const MAX_NAME_LENGTH = 200;
+
+function dealJson(deal: DealRecord) {
+  return {
+    id: deal.id,
+    name: deal.name,
+    inputs: deal.inputs,
+    createdAt: deal.createdAt.toISOString(),
+    updatedAt: deal.updatedAt.toISOString(),
+  };
+}
+
+function validName(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '' && value.length <= MAX_NAME_LENGTH;
+}
+
+/** Validate {name?, inputs?} via the shared evaluate validator. */
+function parseDealBody(
+  deps: DealsDeps,
+  raw: string,
+  options: { requireAll: boolean },
+): { ok: true; name?: string; inputs?: DealInputs } | { ok: false; message: string } {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return { ok: false, message: 'Request body must be valid JSON.' };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, message: 'Request body must be a JSON object.' };
+  }
+
+  const hasName = parsed['name'] !== undefined;
+  const hasInputs = parsed['inputs'] !== undefined;
+  if (options.requireAll && (!hasName || !hasInputs)) {
+    return { ok: false, message: 'Both "name" and "inputs" are required.' };
+  }
+  if (!options.requireAll && !hasName && !hasInputs) {
+    return { ok: false, message: 'Provide "name" and/or "inputs" to update.' };
+  }
+
+  let name: string | undefined;
+  if (hasName) {
+    if (!validName(parsed['name'])) {
+      return { ok: false, message: `"name" must be a non-empty string of at most ${MAX_NAME_LENGTH} characters.` };
+    }
+    name = (parsed['name'] as string).trim();
+  }
+
+  let inputs: DealInputs | undefined;
+  if (hasInputs) {
+    const validated = deps.validate({ inputs: parsed['inputs'] });
+    if (!validated.ok) return { ok: false, message: validated.message };
+    inputs = validated.inputs;
+  }
+
+  return { ok: true, ...(name !== undefined ? { name } : {}), ...(inputs !== undefined ? { inputs } : {}) };
+}
+
+async function handleReport(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: DealsDeps,
+  deal: DealRecord,
+): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://local');
+  const format = resolveFormat(url.searchParams.get('format'), null, req.headers['accept']);
+  if (format === null) {
+    deps.json(res, 406, v1Error(
+      'not_acceptable',
+      'Unsupported report format — use json, csv, or pdf.',
+      deps.requestId,
+    ));
+    return;
+  }
+
+  // updatedAt in the key makes deal edits a structural cache miss
+  const cacheKey = `${deal.id}:${format}:${deps.engineVersion}:${deal.updatedAt.getTime()}`;
+  const cached = deps.reportCache.get(cacheKey);
+  if (cached !== undefined) {
+    res.setHeader('X-Report-Cache', 'hit');
+    deps.sendRaw(res, 200, cached.contentType, cached.body, cached.disposition);
+    return;
+  }
+
+  // Stored inputs re-validate through the shared validator — defense
+  // against rows written by older/looser code paths
+  const validated = deps.validate({ inputs: deal.inputs });
+  if (!validated.ok) {
+    deps.json(res, 422, v1Error(
+      'unprocessable',
+      `Stored inputs no longer validate: ${validated.message}`,
+      deps.requestId,
+    ));
+    return;
+  }
+
+  const report: DealReport = buildReport(validated.inputs, {
+    ...(validated.opts?.mode !== undefined ? { mode: validated.opts.mode } : {}),
+    engineVersion: deps.engineVersion,
+  });
+  const datePart = report.meta.generatedAt.slice(0, 10);
+  let payload: { contentType: string; body: Uint8Array | string; disposition?: string };
+  if (format === 'csv') {
+    payload = {
+      contentType: 'text/csv; charset=utf-8',
+      body: reportToCsv(report),
+      disposition: `attachment; filename="rpe-${datePart}.csv"`,
+    };
+  } else if (format === 'pdf') {
+    payload = {
+      contentType: 'application/pdf',
+      body: await reportToPdf(report),
+      disposition: `attachment; filename="rpe-${datePart}.pdf"`,
+    };
+  } else {
+    payload = { contentType: 'application/json; charset=utf-8', body: JSON.stringify(report) };
+  }
+
+  deps.reportCache.set(cacheKey, payload);
+  res.setHeader('X-Report-Cache', 'miss');
+  deps.sendRaw(res, 200, payload.contentType, payload.body, payload.disposition);
+}
+
+/** Dispatcher entry — subpath is the path AFTER '/deals' ('' | '/{id}' | '/{id}/report'). */
+export async function handleDeals(
+  req: IncomingMessage,
+  res: ServerResponse,
+  subpath: string,
+  deps: DealsDeps,
+): Promise<void> {
+  const segments = subpath.split('/').filter((s) => s !== '');
+
+  // /v1/deals
+  if (segments.length === 0) {
+    if (req.method === 'POST') {
+      const body = parseDealBody(deps, await deps.readBody(req), { requireAll: true });
+      if (!body.ok) {
+        deps.json(res, 400, v1Error('bad_request', body.message, deps.requestId));
+        return;
+      }
+      const deal = await createDeal(deps.db, deps.organizationId, {
+        name: body.name!,
+        inputs: body.inputs!,
+      });
+      deps.json(res, 201, dealJson(deal));
+      return;
+    }
+    if (req.method === 'GET') {
+      const url = new URL(req.url ?? '/', 'http://local');
+      const limit = Number(url.searchParams.get('limit') ?? '50');
+      const offset = Number(url.searchParams.get('offset') ?? '0');
+      if (!Number.isFinite(limit) || !Number.isFinite(offset)) {
+        deps.json(res, 400, v1Error('bad_request', 'limit and offset must be numbers.', deps.requestId));
+        return;
+      }
+      const page = await listDeals(deps.db, deps.organizationId, { limit, offset });
+      deps.json(res, 200, { deals: page.deals.map(dealJson), total: page.total });
+      return;
+    }
+    deps.json(res, 405, v1Error('method_not_allowed', 'Use POST or GET on /v1/deals.', deps.requestId));
+    return;
+  }
+
+  const dealId = segments[0]!;
+  if (!/^[\w-]{1,64}$/.test(dealId)) {
+    deps.json(res, 404, v1Error('not_found', 'Deal not found.', deps.requestId));
+    return;
+  }
+
+  // /v1/deals/{id}/report
+  if (segments.length === 2 && segments[1] === 'report') {
+    if (req.method !== 'GET') {
+      deps.json(res, 405, v1Error('method_not_allowed', 'Use GET on /v1/deals/{id}/report.', deps.requestId));
+      return;
+    }
+    const deal = await getDeal(deps.db, deps.organizationId, dealId);
+    if (deal === null) {
+      deps.json(res, 404, v1Error('not_found', 'Deal not found.', deps.requestId));
+      return;
+    }
+    await handleReport(req, res, deps, deal);
+    return;
+  }
+
+  if (segments.length > 1) {
+    deps.json(res, 404, v1Error('not_found', `Unknown endpoint: /v1/deals/${segments.join('/')}`, deps.requestId));
+    return;
+  }
+
+  // /v1/deals/{id}
+  if (req.method === 'GET') {
+    const deal = await getDeal(deps.db, deps.organizationId, dealId);
+    if (deal === null) {
+      deps.json(res, 404, v1Error('not_found', 'Deal not found.', deps.requestId));
+      return;
+    }
+    deps.json(res, 200, dealJson(deal));
+    return;
+  }
+  if (req.method === 'PATCH') {
+    const body = parseDealBody(deps, await deps.readBody(req), { requireAll: false });
+    if (!body.ok) {
+      deps.json(res, 400, v1Error('bad_request', body.message, deps.requestId));
+      return;
+    }
+    const updated = await updateDeal(deps.db, deps.organizationId, dealId, body);
+    if (updated === null) {
+      deps.json(res, 404, v1Error('not_found', 'Deal not found.', deps.requestId));
+      return;
+    }
+    deps.json(res, 200, dealJson(updated));
+    return;
+  }
+  if (req.method === 'DELETE') {
+    const deleted = await deleteDeal(deps.db, deps.organizationId, dealId);
+    if (!deleted) {
+      deps.json(res, 404, v1Error('not_found', 'Deal not found.', deps.requestId));
+      return;
+    }
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+  deps.json(res, 405, v1Error('method_not_allowed', 'Use GET, PATCH, or DELETE on /v1/deals/{id}.', deps.requestId));
+}

--- a/apps/api/tests/dealsRoutes.test.ts
+++ b/apps/api/tests/dealsRoutes.test.ts
@@ -1,0 +1,160 @@
+/**
+ * RPE-84: /v1/deals over live HTTP — CRUD walk, validation, tenant
+ * isolation (uniform 404 across orgs), report retrieval in all formats
+ * with structural cache invalidation, and the org-less key 403.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { createApp } from '../src/index';
+import { mintKey } from '../src/services/apiKeys';
+import { DbApiKeyStore } from '../src/services/dbApiKeys';
+import { createDb, type RpeDb } from '@rpe/db';
+import { EXAMPLE_DEAL_INPUTS } from '@rpe/engine';
+
+let db: RpeDb;
+let server: Server;
+let base: string;
+let orgAKey: string;
+let orgBKey: string;
+let orglessKey: string;
+
+beforeAll(async () => {
+  db = createDb(':memory:');
+  await db.applyMigrations();
+  const store = await DbApiKeyStore.load(db);
+  orgAKey = (await store.mint('org-a', 'a')).secret;
+  orgBKey = (await store.mint('org-b', 'b')).secret;
+  const legacy = mintKey('legacy-no-org');
+  await store.importEnvRecords('', [legacy.record]); // org-less import
+  orglessKey = legacy.secret;
+
+  server = createApp({
+    auth: { store },
+    deals: { db, reportCacheTtlMs: 60_000 },
+    v1RateLimit: { rpm: 10000, dailyCap: 100000 },
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      base = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+  await db.close();
+});
+
+function call(method: string, path: string, key: string, body?: unknown) {
+  return fetch(`${base}/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${key}`,
+      ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+describe('/v1/deals (RPE-84)', () => {
+  let dealId: string;
+
+  it('full CRUD walk: create → fetch → list → patch → (delete later)', async () => {
+    const created = await call('POST', '/deals', orgAKey, { name: 'Maple St', inputs: EXAMPLE_DEAL_INPUTS });
+    expect(created.status).toBe(201);
+    const deal = await created.json() as { id: string; name: string };
+    expect(deal.name).toBe('Maple St');
+    dealId = deal.id;
+
+    const fetched = await call('GET', `/deals/${dealId}`, orgAKey);
+    expect(fetched.status).toBe(200);
+    expect(((await fetched.json()) as { inputs: unknown }).inputs).toEqual(EXAMPLE_DEAL_INPUTS);
+
+    const list = await call('GET', '/deals?limit=10', orgAKey);
+    const page = await list.json() as { deals: Array<{ id: string }>; total: number };
+    expect(page.total).toBe(1);
+    expect(page.deals[0]?.id).toBe(dealId);
+
+    const patched = await call('PATCH', `/deals/${dealId}`, orgAKey, { name: 'Maple St duplex' });
+    expect(patched.status).toBe(200);
+    expect(((await patched.json()) as { name: string }).name).toBe('Maple St duplex');
+  });
+
+  it('validates: missing fields 400, bad inputs 400 via the shared evaluate validator', async () => {
+    expect((await call('POST', '/deals', orgAKey, { name: 'No inputs' })).status).toBe(400);
+    const badInputs = await call('POST', '/deals', orgAKey, { name: 'Bad', inputs: { purchasePrice: 'lots' } });
+    expect(badInputs.status).toBe(400);
+  });
+
+  it('TENANT ISOLATION: org B gets a uniform 404 for org A\'s deal — read, patch, delete, report', async () => {
+    for (const [method, path, body] of [
+      ['GET', `/deals/${dealId}`, undefined],
+      ['PATCH', `/deals/${dealId}`, { name: 'steal' }],
+      ['DELETE', `/deals/${dealId}`, undefined],
+      ['GET', `/deals/${dealId}/report`, undefined],
+    ] as const) {
+      const res = await call(method, path, orgBKey, body);
+      expect(res.status, `${method} ${path}`).toBe(404);
+    }
+    // ghost id gets the same body shape as a foreign id
+    const foreign = await call('GET', `/deals/${dealId}`, orgBKey);
+    const ghost = await call('GET', '/deals/does-not-exist', orgBKey);
+    const a = await foreign.json() as { error: { code: string; message: string } };
+    const b = await ghost.json() as { error: { code: string; message: string } };
+    expect(a.error.message).toBe(b.error.message);
+  });
+
+  it('org-less keys (env allowlist) are rejected with 403, not silently scoped', async () => {
+    const res = await call('GET', '/deals', orglessKey);
+    expect(res.status).toBe(403);
+    const body = await res.json() as { error: { message: string } };
+    expect(body.error.message).toContain('organization-attached');
+  });
+
+  it('report retrieval: json/csv/pdf with cache miss → hit, and patch rotates the cache key', async () => {
+    const first = await call('GET', `/deals/${dealId}/report?format=json`, orgAKey);
+    expect(first.status).toBe(200);
+    expect(first.headers.get('x-report-cache')).toBe('miss');
+    const report = await first.json() as { meta: { reportVersion: number }; score: unknown };
+    expect(report.meta.reportVersion).toBe(1);
+
+    const second = await call('GET', `/deals/${dealId}/report?format=json`, orgAKey);
+    expect(second.headers.get('x-report-cache')).toBe('hit');
+
+    const csv = await call('GET', `/deals/${dealId}/report?format=csv`, orgAKey);
+    expect(csv.headers.get('content-type')).toContain('text/csv');
+    expect(csv.headers.get('content-disposition')).toContain('.csv');
+
+    const pdf = await call('GET', `/deals/${dealId}/report?format=pdf`, orgAKey);
+    expect(pdf.headers.get('content-type')).toBe('application/pdf');
+    expect((await pdf.arrayBuffer()).byteLength).toBeGreaterThan(500);
+
+    expect((await call('GET', `/deals/${dealId}/report?format=xml`, orgAKey)).status).toBe(406);
+
+    // update → updatedAt changes → structural cache invalidation
+    await call('PATCH', `/deals/${dealId}`, orgAKey, { inputs: { ...EXAMPLE_DEAL_INPUTS, grossRentMonthly: 2500 } });
+    const after = await call('GET', `/deals/${dealId}/report?format=json`, orgAKey);
+    expect(after.headers.get('x-report-cache')).toBe('miss');
+  });
+
+  it('delete → 204, then 404; deals storage 404s cleanly when not configured', async () => {
+    expect((await call('DELETE', `/deals/${dealId}`, orgAKey)).status).toBe(204);
+    expect((await call('GET', `/deals/${dealId}`, orgAKey)).status).toBe(404);
+
+    const bare = createApp({});
+    await new Promise<void>((resolve) => {
+      bare.listen(0, '127.0.0.1', async () => {
+        const port = (bare.address() as { port: number }).port;
+        const res = await fetch(`http://127.0.0.1:${port}/v1/deals`);
+        expect(res.status).toBe(404);
+        bare.close(() => resolve());
+      });
+    });
+  });
+});

--- a/apps/api/tests/openapi.test.ts
+++ b/apps/api/tests/openapi.test.ts
@@ -11,6 +11,7 @@ import type { Server } from 'node:http';
 import { createApp } from '../src/index';
 import { buildOpenApiSpec, docsHtml } from '../src/openapi';
 import { mintKey } from '../src/services/apiKeys';
+import { createDb, type RpeDb } from '@rpe/db';
 
 const acme = mintKey('acme');
 
@@ -24,6 +25,12 @@ const IMPLEMENTED_V1: ReadonlyArray<readonly [string, string]> = [
   ['get', '/region'],
   ['get', '/geocode'],
   ['post', '/scrape'],
+  ['post', '/deals'],
+  ['get', '/deals'],
+  ['get', '/deals/{id}'],
+  ['patch', '/deals/{id}'],
+  ['delete', '/deals/{id}'],
+  ['get', '/deals/{id}/report'],
 ];
 
 /** Doc-surface routes intentionally NOT in the spec (they serve the spec). */
@@ -64,11 +71,15 @@ describe('OpenAPI spec (unit)', () => {
 describe('OpenAPI surface (integration)', () => {
   let server: Server;
   let base: string;
+  let db: RpeDb;
 
-  beforeAll(
-    () =>
-      new Promise<void>((resolve, reject) => {
-        server = createApp({ auth: { keys: [acme.record] }, v1RateLimit: { rpm: 1000, dailyCap: 10000 } });
+  beforeAll(async () => {
+    // deals surface needs a DB; the env key carries no org, so /v1/deals
+    // routes answer 403 (not 404) — exactly the drift contract
+    db = createDb(':memory:');
+    await db.applyMigrations();
+    await new Promise<void>((resolve, reject) => {
+        server = createApp({ auth: { keys: [acme.record] }, deals: { db }, v1RateLimit: { rpm: 1000, dailyCap: 10000 } });
         server.once('error', reject);
         server.listen(0, '127.0.0.1', () => {
           server.off('error', reject);
@@ -76,14 +87,15 @@ describe('OpenAPI surface (integration)', () => {
           base = `http://127.0.0.1:${addr.port}`;
           resolve();
         });
-      }),
-  );
+      });
+  });
 
-  afterAll(
-    () => new Promise<void>((resolve, reject) => {
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
-    }),
-  );
+    });
+    await db.close();
+  });
 
   it('serves the spec at /v1/openapi.json without auth', async () => {
     const res = await fetch(`${base}/v1/openapi.json`);

--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -74,3 +74,27 @@ Errors return the standard envelope with consistent statuses
 
 429 responses include `Retry-After` (seconds). Limits are per key
 (`RPE_V1_RPM`, default 120/min; `RPE_V1_DAILY_CAP`, default 10000/day).
+
+## Stored deals (Phase 2 — RPE-84)
+
+Requires an **organization-attached API key** (DB-backed, `RPE_API_KEYS_SOURCE=db` — mint with `npx tsx apps/api/scripts/manage-keys-db.ts mint <orgId> <label>`). Env-allowlist keys get `403` on this surface.
+
+```bash
+# store a deal (same inputs shape as /v1/evaluate)
+curl -sS -X POST "$BASE/v1/deals" \
+  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
+  -d '{"name":"Maple St duplex","inputs":{...}}'        # → 201 { "id": ... }
+
+# list / fetch / update / delete
+curl -sS "$BASE/v1/deals?limit=20" -H "Authorization: Bearer $KEY"
+curl -sS "$BASE/v1/deals/$DEAL_ID" -H "Authorization: Bearer $KEY"
+curl -sS -X PATCH "$BASE/v1/deals/$DEAL_ID" -H "Authorization: Bearer $KEY" \
+  -H 'Content-Type: application/json' -d '{"name":"Renamed"}'
+curl -sS -X DELETE "$BASE/v1/deals/$DEAL_ID" -H "Authorization: Bearer $KEY"   # → 204
+
+# pull a report for a stored deal (json | csv | pdf; cached — see X-Report-Cache)
+curl -sS "$BASE/v1/deals/$DEAL_ID/report?format=pdf" \
+  -H "Authorization: Bearer $KEY" -o deal-report.pdf
+```
+
+Cross-org ids return a uniform `404` — existence never leaks between tenants.


### PR DESCRIPTION
## Summary
- **Deals CRUD:** `POST/GET /v1/deals`, `GET/PATCH/DELETE /v1/deals/{id}` — org-scoped via the RPE-83 DB-backed key (`organizationId` on the verified record); env-allowlist keys get an explicit 403, never silent scoping; foreign **and** ghost ids return a byte-identical 404 so existence never leaks
- **Stored reports:** `GET /v1/deals/{id}/report?format=json|csv|pdf` with the same negotiation as `/v1/reports`; cached by deal + format + engine version + `updatedAt` — a PATCH rotates the key, so invalidation is structural rather than imperative (`X-Report-Cache: hit|miss`). The async 202 pattern is deliberately omitted (pdf-lib generates in <100 ms) and documented as such
- Inputs validate through the shared evaluate validator on write **and** on read-back (defense against stale rows)
- OpenAPI: six new path+method entries + `StoredDeal` schema; `IMPLEMENTED_V1` updated — the two-direction drift gate covers the new surface
- Quickstart gains the stored-deals curl block; entry point enables the surface whenever `DATABASE_URL` is set
- 6 new tests (956 total)

## Review
Copilot unavailable; strict self-review loop — round 1: passed a JSON string to `validateEvaluateBody` (it takes the parsed object); round 2 clean.

## Test plan
- [x] `pnpm lint && pnpm typecheck && pnpm test && pnpm build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)