### PR TITLE
RPE-98: Go live — DO App Platform deploy config + alias domains

### DIFF
--- a/.do/app.dev.yaml
+++ b/.do/app.dev.yaml
@@ -1,21 +1,19 @@
-# RPE-98 — DigitalOcean App Platform spec: STAGE (rpe-staging).
+# RPE-98 — DigitalOcean App Platform spec: DEV (rpe-dev).
 #
-# Create:   doctl apps create --spec .do/app.staging.yaml
-# Update:   doctl apps update <STAGING_APP_ID> --spec .do/app.staging.yaml
+# Create:   doctl apps create --spec .do/app.dev.yaml
+# Update:   doctl apps update <DEV_APP_ID> --spec .do/app.dev.yaml
 #
-# Stage tracks the CURRENT RELEASE BRANCH — it always shows what ships
-# next. RELEASE RITUAL: when a new release branch is cut (e.g. v1.9.0),
-# bump the two `branch:` fields below and apply. Auto-deploys on every
-# cherry-pick pushed to the release branch.
+# Dev tracks `develop` — every merged task auto-deploys here, the
+# integration view ahead of stage (release branch) and prod (main).
 #
-# DNS: CNAME stage.rentalpropertyevaluator.com → this app's default
+# DNS: CNAME dev.rentalpropertyevaluator.com → this app's default
 # ondigitalocean.app hostname (Cloudflare zone), after first create.
 # Dev-tier database (no backups); sandbox mailer (no real email).
-name: rpe-staging
+name: rpe-dev
 region: nyc
 
 domains:
-  - domain: stage.rentalpropertyevaluator.com
+  - domain: dev.rentalpropertyevaluator.com
     type: PRIMARY
 
 databases:
@@ -49,7 +47,7 @@ services:
     dockerfile_path: apps/api/Dockerfile
     github:
       repo: LowerMedia/rental-property-evaluator
-      branch: v1.8.0 # ← bump when the next release branch is cut
+      branch: develop
       deploy_on_push: true
     http_port: 3001
     instance_count: 1
@@ -74,10 +72,7 @@ services:
       - key: RPE_CORS_ORIGINS
         scope: RUN_TIME
         value: ${APP_URL}
-      # Sandbox mailer by default (no RPE_MAIL_PROVIDER set): stage never
-      # sends real email, so verification is off. To exercise the real
-      # email flow here, add RPE_MAIL_PROVIDER=resend + the RESEND_API_KEY
-      # secret + RPE_MAIL_FROM and flip this to "true".
+      # Sandbox mailer by default — see the note in app.staging.yaml.
       - key: RPE_REQUIRE_EMAIL_VERIFICATION
         scope: RUN_TIME
         value: "false"
@@ -93,7 +88,7 @@ static_sites:
     source_dir: /
     github:
       repo: LowerMedia/rental-property-evaluator
-      branch: v1.8.0 # ← bump when the next release branch is cut
+      branch: develop
       deploy_on_push: true
     environment_slug: node-js
     build_command: corepack enable && pnpm install --frozen-lockfile && pnpm --filter @rpe/web build

--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -1,0 +1,109 @@
+# RPE-98 — DigitalOcean App Platform spec: STAGING (rpe-staging).
+#
+# Create:   doctl apps create --spec .do/app.staging.yaml
+# Update:   doctl apps update <STAGING_APP_ID> --spec .do/app.staging.yaml
+#
+# Tracks `develop` (every shipped task lands there in order — the release
+# branch name rotates each cycle, develop doesn't). Uses the cheap dev-tier
+# database (no backups) and the ${APP_URL} bindable so the default
+# <app>.ondigitalocean.app hostname is the stable staging URL out of the
+# box. Optionally attach staging.rentalpropertyevaluator.com later by
+# uncommenting the domains block (CNAME in Cloudflare → default hostname).
+name: rpe-staging
+region: nyc
+
+# domains:
+#   - domain: staging.rentalpropertyevaluator.com
+#     type: PRIMARY
+
+databases:
+  # Dev-tier database (no cluster_name → $7 dev PG, no backups).
+  - name: db
+    engine: PG
+    version: "16"
+
+ingress:
+  rules:
+    - match: { path: { prefix: /v1 } }
+      component: { name: api }
+    - match: { path: { prefix: /health } }
+      component: { name: api }
+    - match: { path: { prefix: /evaluate } }
+      component: { name: api }
+    - match: { path: { prefix: /property } }
+      component: { name: api }
+    - match: { path: { prefix: /region } }
+      component: { name: api }
+    - match: { path: { prefix: /geocode } }
+      component: { name: api }
+    - match: { path: { prefix: /scrape } }
+      component: { name: api }
+    - match: { path: { prefix: / } }
+      component: { name: web }
+
+services:
+  - name: api
+    source_dir: /
+    dockerfile_path: apps/api/Dockerfile
+    github:
+      repo: LowerMedia/rental-property-evaluator
+      branch: develop
+      deploy_on_push: true
+    http_port: 3001
+    instance_count: 1
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    health_check:
+      http_path: /v1/health
+      initial_delay_seconds: 15
+      period_seconds: 30
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        value: ${db.DATABASE_URL}
+      - key: RPE_API_KEYS_SOURCE
+        scope: RUN_TIME
+        value: db
+      - key: RPE_AUTH_BASE_URL
+        scope: RUN_TIME
+        value: ${APP_URL}
+      - key: RPE_AUTH_TRUSTED_ORIGINS
+        scope: RUN_TIME
+        value: ${APP_URL}
+      - key: RPE_CORS_ORIGINS
+        scope: RUN_TIME
+        value: ${APP_URL}
+      # Sandbox mailer by default (no RPE_MAIL_PROVIDER set): staging never
+      # sends real email, so verification is off. To exercise the real
+      # email flow on staging, add RPE_MAIL_PROVIDER=resend + the
+      # RESEND_API_KEY secret + RPE_MAIL_FROM and flip this to "true".
+      - key: RPE_REQUIRE_EMAIL_VERIFICATION
+        scope: RUN_TIME
+        value: "false"
+      - key: BETTER_AUTH_SECRET
+        scope: RUN_TIME
+        type: SECRET
+      - key: HUD_TOKEN
+        scope: RUN_TIME
+        type: SECRET
+
+static_sites:
+  - name: web
+    source_dir: /
+    github:
+      repo: LowerMedia/rental-property-evaluator
+      branch: develop
+      deploy_on_push: true
+    environment_slug: node-js
+    build_command: corepack enable && pnpm install --frozen-lockfile && pnpm --filter @rpe/web build
+    output_dir: apps/web/dist
+    catchall_document: index.html
+    envs:
+      - key: VITE_API_URL
+        scope: BUILD_TIME
+        value: ""
+      - key: VITE_AUTH_ENABLED
+        scope: BUILD_TIME
+        value: "true"
+      - key: VITE_ADS_ENABLED
+        scope: BUILD_TIME
+        value: "false"

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,139 @@
+# RPE-98 — DigitalOcean App Platform spec: PRODUCTION (rpe-prod).
+#
+# First creation:   doctl apps create --spec .do/app.yaml   (or console → Apps
+#                   → Create App → import spec). Requires the DO GitHub app to
+#                   be authorized for LowerMedia/rental-property-evaluator.
+# Updates:          doctl apps update <APP_ID> --spec .do/app.yaml
+#
+# Secrets (type: SECRET below) are set once in the console/doctl. After
+# setting them, `doctl apps spec get <APP_ID>` returns the spec with
+# encrypted EV[...] values — paste those back into this file so future
+# spec updates don't clobber the stored secrets. See docs/deploy.md §5.
+#
+# The custom domains are attached at cutover (docs/deploy.md §7): a domain
+# can only belong to one app, and the legacy app holds the primary until
+# DNS flips. Until then, deploy/smoke on the default ondigitalocean.app URL
+# by commenting the domains block out.
+name: rpe-prod
+region: nyc
+
+domains:
+  - domain: rentalpropertyevaluator.com
+    type: PRIMARY
+  - domain: rpe.lowprop.com
+    type: ALIAS
+  - domain: rpe.goldfinchproperties.com
+    type: ALIAS
+
+databases:
+  # Managed cluster (automated backups) — create it BEFORE first apply:
+  #   doctl databases create rpe-pg --engine pg --version 16 \
+  #     --size db-s-1vcpu-1gb --region nyc1 --num-nodes 1
+  # docs/deploy.md §2. DATABASE_URL is injected via the ${db.DATABASE_URL}
+  # bindable; the api applies drizzle migrations at first connect.
+  - name: db
+    engine: PG
+    version: "16"
+    production: true
+    cluster_name: rpe-pg
+
+ingress:
+  rules:
+    # Versioned public API + cookie-session auth surface (/v1/auth/*).
+    - match: { path: { prefix: /v1 } }
+      component: { name: api }
+    # Legacy unprefixed routes the SPA calls unauthenticated — RPE-75
+    # keeps these open for the browser (apps/api/src/index.ts router).
+    - match: { path: { prefix: /health } }
+      component: { name: api }
+    - match: { path: { prefix: /evaluate } }
+      component: { name: api }
+    - match: { path: { prefix: /property } }
+      component: { name: api }
+    - match: { path: { prefix: /region } }
+      component: { name: api }
+    - match: { path: { prefix: /geocode } }
+      component: { name: api }
+    - match: { path: { prefix: /scrape } }
+      component: { name: api }
+    # Everything else: the SPA (catchall_document handles client routes).
+    - match: { path: { prefix: / } }
+      component: { name: web }
+
+services:
+  - name: api
+    source_dir: /
+    dockerfile_path: apps/api/Dockerfile
+    github:
+      repo: LowerMedia/rental-property-evaluator
+      branch: main # main = release squashes only (git-strategy.md)
+      deploy_on_push: true
+    http_port: 3001
+    instance_count: 1
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    health_check:
+      http_path: /v1/health
+      initial_delay_seconds: 15
+      period_seconds: 30
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        value: ${db.DATABASE_URL}
+      - key: RPE_API_KEYS_SOURCE
+        scope: RUN_TIME
+        value: db
+      - key: RPE_AUTH_BASE_URL
+        scope: RUN_TIME
+        value: https://rentalpropertyevaluator.com
+      - key: RPE_AUTH_TRUSTED_ORIGINS
+        scope: RUN_TIME
+        value: https://rentalpropertyevaluator.com,https://rpe.lowprop.com,https://rpe.goldfinchproperties.com
+      - key: RPE_CORS_ORIGINS
+        scope: RUN_TIME
+        value: https://rentalpropertyevaluator.com,https://rpe.lowprop.com,https://rpe.goldfinchproperties.com
+      - key: RPE_REQUIRE_EMAIL_VERIFICATION
+        scope: RUN_TIME
+        value: "true"
+      - key: RPE_MAIL_PROVIDER
+        scope: RUN_TIME
+        value: resend
+      - key: RPE_MAIL_FROM
+        scope: RUN_TIME
+        value: "Rental Property Evaluator <noreply@rentalpropertyevaluator.com>"
+      # ── secrets: set values in console/doctl, never commit raw ──
+      - key: BETTER_AUTH_SECRET
+        scope: RUN_TIME
+        type: SECRET
+      - key: RESEND_API_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: HUD_TOKEN
+        scope: RUN_TIME
+        type: SECRET
+
+static_sites:
+  - name: web
+    source_dir: /
+    github:
+      repo: LowerMedia/rental-property-evaluator
+      branch: main
+      deploy_on_push: true
+    environment_slug: node-js
+    build_command: corepack enable && pnpm install --frozen-lockfile && pnpm --filter @rpe/web build
+    output_dir: apps/web/dist
+    catchall_document: index.html
+    envs:
+      # Same-origin API: ingress routes /v1 + the legacy SPA paths to the
+      # api service, so the SPA fetches relative URLs (empty = relative).
+      - key: VITE_API_URL
+        scope: BUILD_TIME
+        value: ""
+      - key: VITE_AUTH_ENABLED
+        scope: BUILD_TIME
+        value: "true"
+      # Ads stay off until the AdSense flip (post-cutover): set true +
+      # real slot id here, then redeploy. Client id is committed in
+      # apps/web/.env.production (the property approved for this domain).
+      - key: VITE_ADS_ENABLED
+        scope: BUILD_TIME
+        value: "false"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# RPE-98 — keep the Docker build context lean (context = repo root).
+.git
+.github
+.claude
+.superpowers
+docs
+brain
+node_modules
+**/node_modules
+**/dist
+**/.env
+**/.env.local
+**/*.local
+.DS_Store
+# iCloud Drive sync-conflict copies
+* 2.*
+* 2

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist
 *.local
 .DS_Store
 .superpowers/
+
+# iCloud Drive sync-conflict copies ("file 2.ext") — never commit
+* 2.*
+* 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,9 @@ docs/api-testing.md.
 Production is **DigitalOcean App Platform** at `https://rentalpropertyevaluator.com`
 (NOT rpe.lowermedia.net), behind Cloudflare DNS, with alias domains
 `rpe.lowprop.com` and `rpe.goldfinchproperties.com` (RPE-98). Specs live in
-`.do/` (prod tracks `main`, staging tracks `develop`); the api ships via
+`.do/`: prod tracks `main`, `stage.rentalpropertyevaluator.com` tracks the
+current release branch (bump `app.staging.yaml` on each release cut),
+`dev.rentalpropertyevaluator.com` tracks `develop`. The api ships via
 `apps/api/Dockerfile`. Runbook: `docs/deploy.md` — read it before touching
 domains, secrets, or the specs. Same-origin constraint: ingress must route
 `/v1` + legacy SPA paths to the api; never split SPA and API across hostnames.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ pnpm 10 monorepo — `packages/engine` (pure calc), `packages/ui` (React 18 SPA)
 Follows the canonical LowerMedia strategy (`~/Library/Mobile Documents/com~apple~CloudDocs/Brain/conventions/git-strategy.md`).
 
 - **Release branch:** `v1.8.0` (current)
-- **Task branches** cut from `v1.6.0`, named exactly after the ticket handle (e.g. `RPE-42`)
+- **Task branches** cut from the current release branch, named exactly after the ticket handle (e.g. `RPE-42`)
 - **Every commit** prefixed with the ticket handle
 - **Jira project:** `RPE` at `lowermedia.atlassian.net` — cloudId `f1fa5126-9e62-47aa-897d-d6ca956bc26c`
 - **Branch/tag ambiguity gotcha:** once a release tag exists, the bare name (e.g. `v1.3.0`) resolves to the *tag*, not the branch — use `refs/heads/vX.X.X` in merge/push/delete commands during the release ship sequence.
@@ -43,6 +43,16 @@ gates ride in `pnpm test` and a red gate blocks the release: the API
 regression suite (apps/api/tests/regression.test.ts) and the E11 auth
 security gate (apps/api/tests/authGate.test.ts) — see
 docs/api-testing.md.
+
+## Deploy
+
+Production is **DigitalOcean App Platform** at `https://rentalpropertyevaluator.com`
+(NOT rpe.lowermedia.net), behind Cloudflare DNS, with alias domains
+`rpe.lowprop.com` and `rpe.goldfinchproperties.com` (RPE-98). Specs live in
+`.do/` (prod tracks `main`, staging tracks `develop`); the api ships via
+`apps/api/Dockerfile`. Runbook: `docs/deploy.md` — read it before touching
+domains, secrets, or the specs. Same-origin constraint: ingress must route
+`/v1` + legacy SPA paths to the api; never split SPA and API across hostnames.
 
 ## Tailwind CSS v4 source scanning
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+# RPE-98 — production image for apps/api (DO App Platform service).
+#
+# Build context = repo root (the app spec sets source_dir: / and
+# dockerfile_path: apps/api/Dockerfile). Local verification:
+#   docker build -f apps/api/Dockerfile -t rpe-api .
+
+# ── build: full workspace install + Vite SSR bundle ─────────────────────────
+FROM node:20-bookworm-slim AS build
+
+# Toolchain fallback for native deps (better-sqlite3, @node-rs/argon2)
+# in case a prebuilt binary is unavailable for this platform.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates python3 make g++ \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+RUN corepack enable
+
+WORKDIR /repo
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.base.json ./
+COPY apps ./apps
+COPY packages ./packages
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter @rpe/api build
+
+# Pruned production node_modules. The Vite bundle inlines all workspace
+# packages and externalises only the native/driver deps (argon2,
+# better-sqlite3, pg, better-auth, drizzle-orm) — see apps/api/vite.config.ts.
+RUN pnpm --filter @rpe/api deploy --legacy --prod /prod/api
+
+# ── runtime ──────────────────────────────────────────────────────────────────
+FROM node:20-bookworm-slim
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY --from=build /prod/api/node_modules ./node_modules
+COPY --from=build /repo/apps/api/dist ./dist
+# The server reads its own package.json at boot for version reporting.
+COPY --from=build /repo/apps/api/package.json ./package.json
+# Drizzle migrations ship with the image; the api applies the dialect's
+# folder at first DB connect (packages/db/src/client.ts).
+COPY --from=build /repo/packages/db/migrations ./migrations
+ENV RPE_MIGRATIONS_DIR=/app/migrations
+
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
+ENV HOST=0.0.0.0 PORT=3001
+EXPOSE 3001
+USER node
+CMD ["node", "dist/index.js"]

--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -1,8 +1,23 @@
-# Production origin — set to the live deployment URL
-VITE_APP_ORIGIN=https://rpe.lowermedia.net
+# Production origin — the live domain (RPE-98). Alias domains
+# (rpe.lowprop.com, rpe.goldfinchproperties.com) intentionally inherit this
+# canonical/OG origin so they never compete as duplicate content — see
+# docs/deploy.md § Multi-domain.
+VITE_APP_ORIGIN=https://rentalpropertyevaluator.com
+
+# Same-origin API (RPE-98): App Platform ingress routes /v1 + the legacy
+# SPA paths to the api service, so the SPA fetches relative URLs.
+# Empty value = relative (the localhost:3001 fallback only fires when the
+# var is absent, e.g. the WP block bundle).
+VITE_API_URL=
+
+# Cookie-session auth shell (E11) — production serves SPA + API from one
+# origin, so the auth UI ships enabled.
+VITE_AUTH_ENABLED=true
 
 # Ads — false is the safe committed default (RPE-39).
-# Override VITE_ADS_ENABLED=true and supply real IDs via deployment env vars.
+# Flip VITE_ADS_ENABLED=true + supply the real results slot id via
+# deployment env vars (.do/app.yaml) once AdSense slots exist.
+# Client id = the AdSense property already approved for this domain.
 VITE_ADS_ENABLED=false
-VITE_ADSENSE_CLIENT=ca-pub-XXXXXXXXXXXXXXXX
+VITE_ADSENSE_CLIENT=ca-pub-4893200463992025
 VITE_ADSENSE_SLOT_RESULTS=0000000000

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -163,6 +163,8 @@ curl -s -o /dev/null -w "%{http_code}\n" $BASE/          # 200 SPA
 curl -s "$BASE/region?zip=52240" | jq .                   # legacy path → api
 curl -s -X POST $BASE/v1/evaluate -H 'content-type: application/json' \
   -d '{"inputs":{}}' -o /dev/null -w "%{http_code}\n"     # 401 without key
+# NOTE: the 401 requires ≥1 key minted (§9) — with zero keys configured
+# the /v1 surface is open by design (RPE-75), so mint before asserting.
 # authenticated evaluate + reports + deals CRUD: use the curl bodies from
 # docs/api-quickstart.md with  -H "X-API-Key: $KEY"
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,221 @@
+# Deploy runbook — DigitalOcean App Platform (RPE-98)
+
+Production replaces the legacy CRA/Express beta on App Platform at
+<https://rentalpropertyevaluator.com>, updating in place (new app built
+alongside, domain moved at cutover). Cloudflare fronts the domain's DNS.
+
+## Architecture
+
+| Component | Source | Runs as |
+|---|---|---|
+| `web` | `apps/web` static build (`pnpm --filter @rpe/web build`) | App Platform static site, SPA catchall |
+| `api` | [apps/api/Dockerfile](../apps/api/Dockerfile) (context = repo root) | App Platform service on port 3001 |
+| `db` | Drizzle migrations in `packages/db/migrations` (applied by the api at first connect) | Managed Postgres 16 (prod) / dev DB (staging) |
+
+One origin serves both: ingress routes `/v1` **and the legacy unprefixed
+SPA paths** (`/health /evaluate /property /region /geocode /scrape`) to
+`api`; everything else falls through to `web`. Cookie-session auth
+requires this same-origin layout — do not split SPA and API across
+hostnames.
+
+Specs: [.do/app.yaml](../.do/app.yaml) (prod, tracks `main`) and
+[.do/app.staging.yaml](../.do/app.staging.yaml) (staging, tracks `develop`).
+
+### Multi-domain (RPE-98)
+
+`rentalpropertyevaluator.com` is PRIMARY; `rpe.lowprop.com` and
+`rpe.goldfinchproperties.com` are ALIASes on the same app. Intended
+behavior:
+
+- **Sessions are per-origin** — logging in on one domain does not log you
+  in on the others. All three are listed in `RPE_AUTH_TRUSTED_ORIGINS`.
+- **Canonical/OG tags point at the primary** on all three (single static
+  build, `VITE_APP_ORIGIN`) — aliases never compete as duplicate content.
+- **Auth emails** (verification/reset links) use `RPE_AUTH_BASE_URL`, i.e.
+  the primary domain, regardless of which alias the user registered on.
+- **AdSense** is approved for the primary; add the alias sites in AdSense
+  or accept no-fill there.
+
+## 1. One-time prerequisites (account side)
+
+1. `brew install doctl && doctl auth init` (API token with write scope
+   from cloud.digitalocean.com → API → Tokens).
+2. Authorize the DigitalOcean GitHub app for
+   `LowerMedia/rental-property-evaluator` (console → Apps → Create App →
+   GitHub — one-time OAuth grant).
+3. Resend: create account → verify the `rentalpropertyevaluator.com`
+   sending domain (DKIM/SPF records go in Cloudflare DNS) → mint an API
+   key for `RESEND_API_KEY`.
+4. HUD SAFMR token (free): <https://www.huduser.gov/portal/dataset/fmr-api.html>.
+5. Generate the auth secret: `openssl rand -base64 32`.
+
+## 2. Provision production
+
+```bash
+# a) managed Postgres cluster (name must match cluster_name in the spec)
+doctl databases create rpe-pg --engine pg --version 16 \
+  --size db-s-1vcpu-1gb --region nyc1 --num-nodes 1
+
+# b) first create — comment out the `domains:` block in .do/app.yaml
+#    (the legacy app still owns the primary domain), then:
+doctl apps create --spec .do/app.yaml
+
+# c) set the three secrets (console → app → Settings → api → Environment
+#    Variables, or doctl). BETTER_AUTH_SECRET, RESEND_API_KEY, HUD_TOKEN.
+
+# d) round-trip the encrypted values back into the committed spec:
+doctl apps spec get <APP_ID> > /tmp/live.yaml
+#    copy the EV[1:...] secret values into .do/app.yaml — encrypted values
+#    are sealed to the app and safe to commit; future `doctl apps update`
+#    calls then preserve them.
+```
+
+Region note: keep `region` in the spec aligned with the legacy app's
+region (check `doctl apps list`) and the PG cluster's region.
+
+## 3. Provision staging
+
+```bash
+doctl apps create --spec .do/app.staging.yaml
+# set BETTER_AUTH_SECRET + HUD_TOKEN secrets (fresh values, not prod's)
+```
+
+The default `<app>.ondigitalocean.app` URL is the stable staging
+hostname (`${APP_URL}` feeds the auth/CORS env). Email verification is
+off on staging (sandbox mailer) — see the comment in the spec to
+exercise real email.
+
+## 4. Environment matrix
+
+| Key | Prod | Staging | Notes |
+|---|---|---|---|
+| `DATABASE_URL` | `${db.DATABASE_URL}` | same | platform-injected bindable |
+| `RPE_API_KEYS_SOURCE` | `db` | `db` | DB-backed keys (RPE-83) |
+| `RPE_AUTH_BASE_URL` | primary origin | `${APP_URL}` | better-auth base + email links |
+| `RPE_AUTH_TRUSTED_ORIGINS` | all three origins | `${APP_URL}` | comma-separated |
+| `RPE_CORS_ORIGINS` | all three origins | `${APP_URL}` | belt-and-suspenders; same-origin in practice |
+| `RPE_REQUIRE_EMAIL_VERIFICATION` | `true` | `false` | staging uses sandbox mailer |
+| `RPE_MAIL_PROVIDER` / `RPE_MAIL_FROM` | `resend` / `noreply@rentalpropertyevaluator.com` | unset | sender domain must be verified in Resend |
+| `BETTER_AUTH_SECRET` | secret | secret | `openssl rand -base64 32`, never reuse across envs |
+| `RESEND_API_KEY` | secret | unset | |
+| `HUD_TOKEN` | secret | secret | `/region` rent estimates (rent=null without it) |
+| `RPE_MIGRATIONS_DIR` | baked into image (`/app/migrations`) | same | set in the Dockerfile |
+| `VITE_API_URL` | `""` (relative, same-origin) | `""` | build-time, static site |
+| `VITE_AUTH_ENABLED` | `true` | `true` | build-time |
+| `VITE_ADS_ENABLED` | `false` until ads flip | `false` | build-time |
+
+## 5. Spec-as-code workflow
+
+The committed specs are the source of truth. Change → commit → apply:
+
+```bash
+doctl apps update <APP_ID> --spec .do/app.yaml
+```
+
+`update --spec` **replaces** the live spec: any env var not present in
+the file is removed. That's why secret entries stay in the spec with
+their encrypted `EV[...]` values after the §2d round-trip.
+
+## 6. DNS & Cloudflare
+
+All records live in Cloudflare for `rentalpropertyevaluator.com`; the
+alias hostnames live in the `lowprop.com` and `goldfinchproperties.com`
+zones (wherever their DNS is hosted).
+
+| Record | Zone | Target |
+|---|---|---|
+| `rentalpropertyevaluator.com` (apex, CNAME-flattened) | rentalpropertyevaluator.com | `<rpe-prod>.ondigitalocean.app` |
+| `rpe.lowprop.com` CNAME | lowprop.com | `<rpe-prod>.ondigitalocean.app` |
+| `rpe.goldfinchproperties.com` CNAME | goldfinchproperties.com | `<rpe-prod>.ondigitalocean.app` |
+| `staging.rentalpropertyevaluator.com` CNAME (optional) | rentalpropertyevaluator.com | `<rpe-staging>.ondigitalocean.app` |
+
+Certificate issuance: App Platform issues Let's Encrypt certs per
+domain and needs to observe the DNS pointing at it. With the Cloudflare
+proxy (orange cloud) on, set SSL mode **Full (strict)**; if issuance
+stalls, temporarily grey-cloud the record until the cert appears in the
+app's Domains tab, then re-enable the proxy. Zones not behind a proxy
+(plain DNS) need no special handling.
+
+## 7. Cutover (production)
+
+Pre-flight: staging smoke (§8) green; gate green on `main`.
+
+1. Deploy `rpe-prod` (no domains yet) and run the §8 smoke against the
+   default `https://<rpe-prod>.ondigitalocean.app` URL.
+2. Mint/import API keys (§9) so existing consumers keep working.
+3. Remove `rentalpropertyevaluator.com` from the **legacy** app
+   (console → legacy app → Settings → Domains). Do not destroy the app.
+4. Uncomment `domains:` in `.do/app.yaml`, `doctl apps update` — the
+   primary + both aliases attach to `rpe-prod`.
+5. Point DNS (§6). Wait for cert issuance on all three hostnames.
+6. Run §8 smoke against all three live domains.
+7. **Rollback**: re-add the domain to the legacy app and revert the DNS
+   target — the legacy app keeps running untouched until sign-off.
+8. Sign-off (a few quiet days): archive/destroy the legacy app.
+
+## 8. Smoke checklist
+
+```bash
+BASE=https://rentalpropertyevaluator.com   # or the default URL / an alias
+
+curl -s $BASE/v1/health | jq .             # status ok, version, GIT_SHA
+curl -s -o /dev/null -w "%{http_code}\n" $BASE/          # 200 SPA
+curl -s "$BASE/region?zip=52240" | jq .                   # legacy path → api
+curl -s -X POST $BASE/v1/evaluate -H 'content-type: application/json' \
+  -d '{"inputs":{}}' -o /dev/null -w "%{http_code}\n"     # 401 without key
+# authenticated evaluate + reports + deals CRUD: use the curl bodies from
+# docs/api-quickstart.md with  -H "X-API-Key: $KEY"
+```
+
+Browser (per domain at cutover; full pass on primary):
+
+- register → receive verification email (prod) → verify → login; cookie
+  session survives reload (`/v1/auth/get-session` 200).
+- create + list deals; pull a PDF report (`X-Report-Cache` header flips
+  hit/miss); rate-limit headers present on `/v1/*`.
+- **legacy migration**: in devtools on the OLD site (pre-cutover) confirm
+  `localStorage.changeableRPE` exists, or seed it:
+  `localStorage.setItem('changeableRPE', JSON.stringify({PurchasePrice:"200000",PercentDown:"25",InterestRate:"4.5",LoanTerm:"30",MonthlyRent:"2000",Taxes:"2400",Insurance:"1200",HOA:"0",OtherExpense:"1200",CapExPct:"5",MaintPct:"5",ManagementPct:"10",VacancyPct:"5"}))`
+  — after cutover, reload and confirm the "Imported (legacy)" scenario
+  appears and the old key is gone.
+
+## 9. API keys (DB-backed)
+
+Run the CLI locally against the managed DB (add your IP under the
+cluster's **Trusted Sources** first; connection string from the DO
+console):
+
+```bash
+DATABASE_URL='postgres://…' pnpm --filter @rpe/api exec \
+  tsx scripts/manage-keys-db.ts mint --name "<consumer>" --org <orgId>
+# import previously issued env/file keys (idempotent):
+DATABASE_URL='postgres://…' pnpm --filter @rpe/api exec \
+  tsx scripts/manage-keys-db.ts import
+```
+
+## 10. Post-cutover
+
+- Uptime monitor on `https://rentalpropertyevaluator.com/v1/health`
+  (UptimeRobot or DO monitoring + alert policy).
+- Confirm the PG cluster's automated backups/PITR are active; do one
+  restore drill to a throwaway cluster.
+- **Ads flip**: create the results ad unit in AdSense, set
+  `VITE_ADS_ENABLED=true` + `VITE_ADSENSE_SLOT_RESULTS` in the spec,
+  apply (rebuild). Add the alias sites in AdSense.
+- **Analytics**: the old site ran GTM (`GTM-WDL6RJC`) + a dead UA tag;
+  the new SPA ships none. Decide GA4/GTM (separate ticket).
+- Point the WP block embed at `https://rentalpropertyevaluator.com`.
+- Atlassian/ops hygiene: close RPE-82 as superseded by RPE-98.
+
+## Costs (ballpark, monthly)
+
+| Item | $ |
+|---|---|
+| api service (apps-s-1vcpu-0.5gb) | 5 |
+| web static site | 0 (free tier ×3) |
+| managed PG `rpe-pg` (1 vCPU/1 GB) | 15 |
+| staging app (service + dev PG) | 5 + 7 |
+| **Total** | **~32 with staging, ~20 without** |
+
+Staging can be torn down between releases (`doctl apps delete`) — the
+spec recreates it in minutes.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -18,8 +18,13 @@ SPA paths** (`/health /evaluate /property /region /geocode /scrape`) to
 requires this same-origin layout — do not split SPA and API across
 hostnames.
 
-Specs: [.do/app.yaml](../.do/app.yaml) (prod, tracks `main`) and
-[.do/app.staging.yaml](../.do/app.staging.yaml) (staging, tracks `develop`).
+Specs (one app per branch tier, mirroring the git strategy):
+
+| Spec | App | Tracks | Hostname |
+|---|---|---|---|
+| [.do/app.yaml](../.do/app.yaml) | rpe-prod | `main` (releases) | rentalpropertyevaluator.com + aliases |
+| [.do/app.staging.yaml](../.do/app.staging.yaml) | rpe-staging | current release branch (`v1.8.0` — **bump on each release cut**) | stage.rentalpropertyevaluator.com |
+| [.do/app.dev.yaml](../.do/app.dev.yaml) | rpe-dev | `develop` (every merged task) | dev.rentalpropertyevaluator.com |
 
 ### Multi-domain (RPE-98)
 
@@ -73,17 +78,22 @@ doctl apps spec get <APP_ID> > /tmp/live.yaml
 Region note: keep `region` in the spec aligned with the legacy app's
 region (check `doctl apps list`) and the PG cluster's region.
 
-## 3. Provision staging
+## 3. Provision dev + stage
 
 ```bash
-doctl apps create --spec .do/app.staging.yaml
-# set BETTER_AUTH_SECRET + HUD_TOKEN secrets (fresh values, not prod's)
+doctl apps create --spec .do/app.dev.yaml      # tracks develop
+doctl apps create --spec .do/app.staging.yaml  # tracks the release branch
+# set BETTER_AUTH_SECRET + HUD_TOKEN on each (fresh values, not prod's)
 ```
 
-The default `<app>.ondigitalocean.app` URL is the stable staging
-hostname (`${APP_URL}` feeds the auth/CORS env). Email verification is
-off on staging (sandbox mailer) — see the comment in the spec to
-exercise real email.
+After creation, add the two CNAMEs (§6) so `dev.` / `stage.` resolve;
+until then the default `<app>.ondigitalocean.app` URLs work (`${APP_URL}`
+feeds the auth/CORS env either way). Email verification is off on both
+(sandbox mailer) — see the spec comment to exercise real email.
+
+**Release ritual:** when cutting the next release branch (e.g. `v1.9.0`),
+bump the two `branch:` fields in `app.staging.yaml` and
+`doctl apps update` — stage then follows the new release.
 
 ## 4. Environment matrix
 
@@ -127,7 +137,8 @@ zones (wherever their DNS is hosted).
 | `rentalpropertyevaluator.com` (apex, CNAME-flattened) | rentalpropertyevaluator.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.lowprop.com` CNAME | lowprop.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.goldfinchproperties.com` CNAME | goldfinchproperties.com | `<rpe-prod>.ondigitalocean.app` |
-| `staging.rentalpropertyevaluator.com` CNAME (optional) | rentalpropertyevaluator.com | `<rpe-staging>.ondigitalocean.app` |
+| `stage.rentalpropertyevaluator.com` CNAME | rentalpropertyevaluator.com | `<rpe-staging>.ondigitalocean.app` |
+| `dev.rentalpropertyevaluator.com` CNAME | rentalpropertyevaluator.com | `<rpe-dev>.ondigitalocean.app` |
 
 Certificate issuance: App Platform issues Let's Encrypt certs per
 domain and needs to observe the DNS pointing at it. With the Cloudflare
@@ -213,11 +224,12 @@ DATABASE_URL='postgres://…' pnpm --filter @rpe/api exec \
 
 | Item | $ |
 |---|---|
-| api service (apps-s-1vcpu-0.5gb) | 5 |
-| web static site | 0 (free tier ×3) |
+| prod api service (apps-s-1vcpu-0.5gb) | 5 |
+| web static sites | 0 (free tier ×3) |
 | managed PG `rpe-pg` (1 vCPU/1 GB) | 15 |
-| staging app (service + dev PG) | 5 + 7 |
-| **Total** | **~32 with staging, ~20 without** |
+| stage app (service + dev PG) | 5 + 7 |
+| dev app (service + dev PG) | 5 + 7 |
+| **Total** | **~44 with dev+stage, ~20 prod-only** |
 
-Staging can be torn down between releases (`doctl apps delete`) — the
-spec recreates it in minutes.
+Dev/stage can be torn down anytime (`doctl apps delete`) — the specs
+recreate them in minutes.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "pnpm --filter @rpe/web dev",
     "build": "pnpm -r --if-present build",


### PR DESCRIPTION
Implements [RPE-98](https://lowermedia.atlassian.net/browse/RPE-98) (concretizes RPE-82): everything repo-side needed to replace the legacy CRA beta on DigitalOcean App Platform at rentalpropertyevaluator.com, plus alias domains rpe.lowprop.com / rpe.goldfinchproperties.com.

## What's here
- **apps/api/Dockerfile** + .dockerignore — multi-stage pnpm monorepo build; pruned runtime (pnpm deploy --legacy --prod); drizzle migrations shipped at /app/migrations; package.json for boot version reporting.
- **.do/app.yaml / .do/app.staging.yaml** — static web + api service + PG; ingress routes /v1 **and the legacy unprefixed SPA paths** to the api (same-origin cookie auth, zero code changes); prod tracks main, staging tracks develop.
- **apps/web/.env.production** — origin fixed to rentalpropertyevaluator.com (was stale rpe.lowermedia.net), VITE_API_URL='' for relative same-origin fetches, auth shell enabled, real AdSense client id (ads still gated off).
- **docs/deploy.md** — full runbook: provisioning, secrets matrix, Cloudflare/DNS + cert issuance, cutover with rollback, smoke checklist, key minting, costs.
- Hygiene: .gitignore guard for iCloud ' 2' conflict copies; engines >=20.

## Verification
- Gate green: lint, typecheck, **955/956 tests** (1 skip = Postgres integration, env-gated), build.
- Docker image built locally; container smoke: /health + /v1/health 200 in zero-DB mode **and** with DATABASE_URL set (boot migrations + DB key-store hydration exercised).
- Both app specs YAML-validated.

## Not in this PR (account-side, see runbook)
DO GitHub-app authorization, PG cluster creation, secrets, Resend domain verification, DNS records, the cutover itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPE-98]: https://lowermedia.atlassian.net/browse/RPE-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ