### PR TITLE
RPE-98: ci: fix pnpm action-setup version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # version comes from package.json "packageManager" — pinning here too
+      # makes action-setup fail with "Multiple versions of pnpm specified"
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
develop CI dies in 9s at pnpm/action-setup: the workflow's `version: 10` input conflicts with package.json's `packageManager: pnpm@10.33.0` (hard error in action-setup v4). Drop the input — the field already pins the exact version. Evidence: run 27366986757. Self-review: one-line workflow change, verified against action-setup v4 documented behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)