### PR TITLE
RPE-98: fix DO web build (node engines/corepack) + as-built spec alignment

### DIFF
--- a/.do/app.dev.yaml
+++ b/.do/app.dev.yaml
@@ -1,16 +1,22 @@
-# RPE-98 — DigitalOcean App Platform spec: DEV (rpe-dev).
+# RPE-98 — DigitalOcean App Platform spec: DEV.
 #
-# Create:   doctl apps create --spec .do/app.dev.yaml
-# Update:   doctl apps update <DEV_APP_ID> --spec .do/app.dev.yaml
+# App ID:   4e7dd243-c8f4-4061-9f55-7db4f05b661c (pre-existing legacy dev
+#           app, updated in place 2026-06-11 — kept its name, region, and
+#           the already-attached dev.rentalpropertyevaluator.com domain)
+# Update:   doctl apps update 4e7dd243-c8f4-4061-9f55-7db4f05b661c --spec .do/app.dev.yaml
 #
 # Dev tracks `develop` — every merged task auto-deploys here, the
 # integration view ahead of stage (release branch) and prod (main).
-#
-# DNS: CNAME dev.rentalpropertyevaluator.com → this app's default
-# ondigitalocean.app hostname (Cloudflare zone), after first create.
 # Dev-tier database (no backups); sandbox mailer (no real email).
-name: rpe-dev
-region: nyc
+# SECRET values are DO-encrypted (EV[...]), sealed to this app — after
+# changing a secret in the console, round-trip `doctl apps spec get`
+# output back here (docs/deploy.md §5).
+name: rental-property-evaluator-dev
+region: sfo
+
+alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
 
 domains:
   - domain: dev.rentalpropertyevaluator.com
@@ -79,9 +85,13 @@ services:
       - key: BETTER_AUTH_SECRET
         scope: RUN_TIME
         type: SECRET
+        value: EV[1:XpVT0JO+RNBfio9Fz6q/TPbX05r9MqtZ:0SQ8eYshVTkeEBGhOcVA/lcuiaonHIzH4/t79wvPDxTqrlPCQ3i/xYFyISmr4iQmmACI5BFU1fPh/to6]
+      # HUD_TOKEN is currently an encrypted EMPTY string — set the real
+      # token in the console, then round-trip the new EV value here.
       - key: HUD_TOKEN
         scope: RUN_TIME
         type: SECRET
+        value: EV[1:hqRa6JU8A7rI4BYv+2Xdhxm3VnjGDi5f:vDFFfrXuHsKxg4IW10XSVg==]
 
 static_sites:
   - name: web
@@ -95,6 +105,11 @@ static_sites:
     output_dir: apps/web/dist
     catchall_document: index.html
     envs:
+      # Buildpack provisions pnpm via corepack (packageManager field) —
+      # needs a corepack-bundled Node (engines <25) and no download prompt.
+      - key: COREPACK_ENABLE_DOWNLOAD_PROMPT
+        scope: BUILD_TIME
+        value: "0"
       - key: VITE_API_URL
         scope: BUILD_TIME
         value: ""

--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -1,18 +1,24 @@
-# RPE-98 — DigitalOcean App Platform spec: STAGE (rpe-staging).
+# RPE-98 — DigitalOcean App Platform spec: STAGE.
 #
-# Create:   doctl apps create --spec .do/app.staging.yaml
-# Update:   doctl apps update <STAGING_APP_ID> --spec .do/app.staging.yaml
+# App ID:   a5f7c0d2-161b-407d-a84f-ca1a594271da (pre-existing legacy stage
+#           app, updated in place 2026-06-11 — kept its name, region, and
+#           the already-attached stage.rentalpropertyevaluator.com domain)
+# Update:   doctl apps update a5f7c0d2-161b-407d-a84f-ca1a594271da --spec .do/app.staging.yaml
 #
 # Stage tracks the CURRENT RELEASE BRANCH — it always shows what ships
 # next. RELEASE RITUAL: when a new release branch is cut (e.g. v1.9.0),
 # bump the two `branch:` fields below and apply. Auto-deploys on every
 # cherry-pick pushed to the release branch.
-#
-# DNS: CNAME stage.rentalpropertyevaluator.com → this app's default
-# ondigitalocean.app hostname (Cloudflare zone), after first create.
 # Dev-tier database (no backups); sandbox mailer (no real email).
-name: rpe-staging
-region: nyc
+# SECRET values are DO-encrypted (EV[...]), sealed to this app — after
+# changing a secret in the console, round-trip `doctl apps spec get`
+# output back here (docs/deploy.md §5).
+name: rental-property-evaluator-stage
+region: sfo
+
+alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
 
 domains:
   - domain: stage.rentalpropertyevaluator.com
@@ -84,9 +90,13 @@ services:
       - key: BETTER_AUTH_SECRET
         scope: RUN_TIME
         type: SECRET
+        value: EV[1:OkYkJG1xwm8p7nq5zri51APoJLRmUODd:BWs0jN/Cvh/p+iiqUrsLfT0e4mnQ5VWI6uf4j+ojGLgYu/S3lB3XuGqMnSvDVqjRmcjL63doW7dzGnLL]
+      # HUD_TOKEN is currently an encrypted EMPTY string — set the real
+      # token in the console, then round-trip the new EV value here.
       - key: HUD_TOKEN
         scope: RUN_TIME
         type: SECRET
+        value: EV[1:n+VyEdv3Ve8IAvgyCcZ1KsJOPnqDhu4Q:Y0a+XkkjhScPJqX6QvLLLw==]
 
 static_sites:
   - name: web
@@ -100,6 +110,11 @@ static_sites:
     output_dir: apps/web/dist
     catchall_document: index.html
     envs:
+      # Buildpack provisions pnpm via corepack (packageManager field) —
+      # needs a corepack-bundled Node (engines <25) and no download prompt.
+      - key: COREPACK_ENABLE_DOWNLOAD_PROMPT
+        scope: BUILD_TIME
+        value: "0"
       - key: VITE_API_URL
         scope: BUILD_TIME
         value: ""

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -14,8 +14,14 @@
 # can only belong to one app, and the legacy app holds the primary until
 # DNS flips. Until then, deploy/smoke on the default ondigitalocean.app URL
 # by commenting the domains block out.
+# Region: sfo — matches the legacy prod app (063f8576-…) and dev/stage
+# (verified 2026-06-11).
 name: rpe-prod
-region: nyc
+region: sfo
+
+alerts:
+  - rule: DEPLOYMENT_FAILED
+  - rule: DOMAIN_FAILED
 
 domains:
   - domain: rentalpropertyevaluator.com
@@ -28,7 +34,7 @@ domains:
 databases:
   # Managed cluster (automated backups) — create it BEFORE first apply:
   #   doctl databases create rpe-pg --engine pg --version 16 \
-  #     --size db-s-1vcpu-1gb --region nyc1 --num-nodes 1
+  #     --size db-s-1vcpu-1gb --region sfo3 --num-nodes 1
   # docs/deploy.md §2. DATABASE_URL is injected via the ${db.DATABASE_URL}
   # bindable; the api applies drizzle migrations at first connect.
   - name: db
@@ -123,6 +129,11 @@ static_sites:
     output_dir: apps/web/dist
     catchall_document: index.html
     envs:
+      # Buildpack provisions pnpm via corepack (packageManager field) —
+      # needs a corepack-bundled Node (engines <25) and no download prompt.
+      - key: COREPACK_ENABLE_DOWNLOAD_PROMPT
+        scope: BUILD_TIME
+        value: "0"
       # Same-origin API: ingress routes /v1 + the legacy SPA paths to the
       # api service, so the SPA fetches relative URLs (empty = relative).
       - key: VITE_API_URL

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -22,9 +22,14 @@ Specs (one app per branch tier, mirroring the git strategy):
 
 | Spec | App | Tracks | Hostname |
 |---|---|---|---|
-| [.do/app.yaml](../.do/app.yaml) | rpe-prod | `main` (releases) | rentalpropertyevaluator.com + aliases |
-| [.do/app.staging.yaml](../.do/app.staging.yaml) | rpe-staging | current release branch (`v1.8.0` — **bump on each release cut**) | stage.rentalpropertyevaluator.com |
-| [.do/app.dev.yaml](../.do/app.dev.yaml) | rpe-dev | `develop` (every merged task) | dev.rentalpropertyevaluator.com |
+| [.do/app.yaml](../.do/app.yaml) | rpe-prod (created at cutover) | `main` (releases) | rentalpropertyevaluator.com + aliases |
+| [.do/app.staging.yaml](../.do/app.staging.yaml) | rental-property-evaluator-stage `a5f7c0d2-…` | current release branch (`v1.8.0` — **bump on each release cut**) | stage.rentalpropertyevaluator.com |
+| [.do/app.dev.yaml](../.do/app.dev.yaml) | rental-property-evaluator-dev `4e7dd243-…` | `develop` (every merged task) | dev.rentalpropertyevaluator.com |
+
+All apps live in **sfo** (the legacy apps' region — verified 2026-06-11).
+Dev + stage were the legacy CRA apps **updated in place** (they kept
+their names, domains, certs, and DNS), so their hostnames were live from
+the first deployment.
 
 ### Multi-domain (RPE-98)
 
@@ -59,7 +64,7 @@ behavior:
 ```bash
 # a) managed Postgres cluster (name must match cluster_name in the spec)
 doctl databases create rpe-pg --engine pg --version 16 \
-  --size db-s-1vcpu-1gb --region nyc1 --num-nodes 1
+  --size db-s-1vcpu-1gb --region sfo3 --num-nodes 1
 
 # b) first create — comment out the `domains:` block in .do/app.yaml
 #    (the legacy app still owns the primary domain), then:
@@ -78,17 +83,19 @@ doctl apps spec get <APP_ID> > /tmp/live.yaml
 Region note: keep `region` in the spec aligned with the legacy app's
 region (check `doctl apps list`) and the PG cluster's region.
 
-## 3. Provision dev + stage
+## 3. Dev + stage (live since 2026-06-11)
+
+Both were legacy CRA apps **updated in place** with the committed specs —
+they kept their names, app IDs, domains, certs, and DNS. To change them:
 
 ```bash
-doctl apps create --spec .do/app.dev.yaml      # tracks develop
-doctl apps create --spec .do/app.staging.yaml  # tracks the release branch
-# set BETTER_AUTH_SECRET + HUD_TOKEN on each (fresh values, not prod's)
+doctl apps update 4e7dd243-c8f4-4061-9f55-7db4f05b661c --spec .do/app.dev.yaml
+doctl apps update a5f7c0d2-161b-407d-a84f-ca1a594271da --spec .do/app.staging.yaml
 ```
 
-After creation, add the two CNAMEs (§6) so `dev.` / `stage.` resolve;
-until then the default `<app>.ondigitalocean.app` URLs work (`${APP_URL}`
-feeds the auth/CORS env either way). Email verification is off on both
+`BETTER_AUTH_SECRET` is set (committed as encrypted EV values);
+`HUD_TOKEN` is an encrypted empty string until the real token is added
+(console → round-trip the EV per §5). Email verification is off on both
 (sandbox mailer) — see the spec comment to exercise real email.
 
 **Release ritual:** when cutting the next release branch (e.g. `v1.9.0`),
@@ -137,8 +144,8 @@ zones (wherever their DNS is hosted).
 | `rentalpropertyevaluator.com` (apex, CNAME-flattened) | rentalpropertyevaluator.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.lowprop.com` CNAME | lowprop.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.goldfinchproperties.com` CNAME | goldfinchproperties.com | `<rpe-prod>.ondigitalocean.app` |
-| `stage.rentalpropertyevaluator.com` CNAME | rentalpropertyevaluator.com | `<rpe-staging>.ondigitalocean.app` |
-| `dev.rentalpropertyevaluator.com` CNAME | rentalpropertyevaluator.com | `<rpe-dev>.ondigitalocean.app` |
+| `stage.rentalpropertyevaluator.com` CNAME (already in place) | rentalpropertyevaluator.com | `rental-property-evaluator-stage-cg55a.ondigitalocean.app` |
+| `dev.rentalpropertyevaluator.com` CNAME (already in place) | rentalpropertyevaluator.com | `rental-property-evaluator-dev-uv7fo.ondigitalocean.app` |
 
 Certificate issuance: App Platform issues Let's Encrypt certs per
 domain and needs to observe the DNS pointing at it. With the Cloudflare

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=20 <25"
   },
   "scripts": {
     "dev": "pnpm --filter @rpe/web dev",


### PR DESCRIPTION
Two commits: (1) cap `engines` to `>=20 <25` — the DO node buildpack resolved Node v26 (no corepack) and its pnpm install died before our build_command ran; both dev/stage first deployments failed on this (dev auto-rolled back, old app kept serving). (2) Align committed specs with the live apps (legacy dev/stage updated in place: real names/ids, sfo, alerts, corepack env, round-tripped EV secrets) + as-built runbook.

Self-review (Copilot unavailable): verified the buildpack failure log (`pnpm: executable file not found`, Node v26 download line), Node 24 = last corepack-bundled line, gate green 955/956 with explicit exit-code checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)