### PR TITLE
RPE-98: fix DO Postgres TLS verification (SELF_SIGNED_CERT_IN_CHAIN)

### DIFF
--- a/.do/app.dev.yaml
+++ b/.do/app.dev.yaml
@@ -66,6 +66,11 @@ services:
       - key: DATABASE_URL
         scope: RUN_TIME
         value: ${db.DATABASE_URL}
+      # DO Postgres presents a CA outside the system trust store —
+      # @rpe/db verifies against this PEM (SELF_SIGNED_CERT_IN_CHAIN fix).
+      - key: DATABASE_CA_CERT
+        scope: RUN_TIME
+        value: ${db.CA_CERT}
       - key: RPE_API_KEYS_SOURCE
         scope: RUN_TIME
         value: db

--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -68,6 +68,11 @@ services:
       - key: DATABASE_URL
         scope: RUN_TIME
         value: ${db.DATABASE_URL}
+      # DO Postgres presents a CA outside the system trust store —
+      # @rpe/db verifies against this PEM (SELF_SIGNED_CERT_IN_CHAIN fix).
+      - key: DATABASE_CA_CERT
+        scope: RUN_TIME
+        value: ${db.CA_CERT}
       - key: RPE_API_KEYS_SOURCE
         scope: RUN_TIME
         value: db

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -85,6 +85,11 @@ services:
       - key: DATABASE_URL
         scope: RUN_TIME
         value: ${db.DATABASE_URL}
+      # DO Postgres presents a CA outside the system trust store —
+      # @rpe/db verifies against this PEM (SELF_SIGNED_CERT_IN_CHAIN fix).
+      - key: DATABASE_CA_CERT
+        scope: RUN_TIME
+        value: ${db.CA_CERT}
       - key: RPE_API_KEYS_SOURCE
         scope: RUN_TIME
         value: db

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -107,6 +107,7 @@ bump the two `branch:` fields in `app.staging.yaml` and
 | Key | Prod | Staging | Notes |
 |---|---|---|---|
 | `DATABASE_URL` | `${db.DATABASE_URL}` | same | platform-injected bindable |
+| `DATABASE_CA_CERT` | `${db.CA_CERT}` | same | DO PG CA — verified TLS in @rpe/db (`pgSsl`) |
 | `RPE_API_KEYS_SOURCE` | `db` | `db` | DB-backed keys (RPE-83) |
 | `RPE_AUTH_BASE_URL` | primary origin | `${APP_URL}` | better-auth base + email links |
 | `RPE_AUTH_TRUSTED_ORIGINS` | all three origins | `${APP_URL}` | comma-separated |

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -78,6 +78,21 @@ export function resolveDialect(url: string): Dialect {
   );
 }
 
+/**
+ * TLS options for managed Postgres (RPE-98). DigitalOcean databases
+ * present a CA that is not in the system trust store — node-postgres
+ * then fails with SELF_SIGNED_CERT_IN_CHAIN. Deploys inject the PEM via
+ * DATABASE_CA_CERT (App Platform's `${db.CA_CERT}` bindable); when
+ * present, the pool verifies against it explicitly. When absent, pg's
+ * default URL-driven TLS behavior applies (local/CI).
+ */
+export function pgSsl(
+  caCert: string | undefined = process.env['DATABASE_CA_CERT'],
+): { ca: string; rejectUnauthorized: true } | undefined {
+  if (caCert === undefined || caCert.trim() === '') return undefined;
+  return { ca: caCert, rejectUnauthorized: true };
+}
+
 /** Create a client for the given DSN (defaults to env DATABASE_URL). */
 export function createDb(url: string | undefined = process.env['DATABASE_URL']): RpeDb {
   if (url === undefined || url.trim() === '') {
@@ -87,7 +102,8 @@ export function createDb(url: string | undefined = process.env['DATABASE_URL']):
   const dialect = resolveDialect(url);
 
   if (dialect === 'postgres') {
-    const pool = new pg.Pool({ connectionString: url });
+    const ssl = pgSsl();
+    const pool = new pg.Pool({ connectionString: url, ...(ssl === undefined ? {} : { ssl }) });
     const db = drizzlePg(pool, { schema: pgSchema });
     return {
       dialect,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-export { createDb, resolveDialect, type Dialect, type RpeDb } from './client.js';
+export { createDb, resolveDialect, pgSsl, type Dialect, type RpeDb } from './client.js';
 export { appMeta as appMetaPg, pgSchema } from './schema.pg.js';
 export { appMeta as appMetaSqlite, sqliteSchema } from './schema.sqlite.js';
 export { seedDev } from './seed.js';

--- a/packages/db/tests/db.test.ts
+++ b/packages/db/tests/db.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { getTableColumns, getTableName } from 'drizzle-orm';
-import { createDb, resolveDialect, pgSchema, sqliteSchema, appMetaSqlite } from '../src/index';
+import { createDb, resolveDialect, pgSsl, pgSchema, sqliteSchema, appMetaSqlite } from '../src/index';
 
 describe('resolveDialect', () => {
   it('recognizes postgres and sqlite DSNs and rejects garbage', () => {
@@ -16,6 +16,18 @@ describe('resolveDialect', () => {
     expect(resolveDialect('./local.sqlite')).toBe('sqlite');
     expect(() => resolveDialect('mysql://nope')).toThrow(/Unrecognized DATABASE_URL/);
     expect(() => createDb('')).toThrow(/DATABASE_URL is required/);
+  });
+});
+
+describe('pgSsl (DATABASE_CA_CERT plumbing, RPE-98)', () => {
+  it('returns verified-TLS options only when a CA cert is provided', () => {
+    expect(pgSsl(undefined)).toBeUndefined();
+    expect(pgSsl('')).toBeUndefined();
+    expect(pgSsl('   ')).toBeUndefined();
+    expect(pgSsl('-----BEGIN CERTIFICATE-----\nabc')).toEqual({
+      ca: '-----BEGIN CERTIFICATE-----\nabc',
+      rejectUnauthorized: true,
+    });
   });
 });
 


### PR DESCRIPTION
api container crashed at boot during drizzle migration: DO PG's CA isn't in the system trust store. Plumb ${db.CA_CERT} → DATABASE_CA_CERT → pg.Pool ssl{ca, rejectUnauthorized:true}. Verified TLS (not no-verify) so the same path is prod-grade. Unit tests for the helper; gate green 956/957.

Self-review (Copilot unavailable): error chain read from deploy logs (dev deployment 7af08e50); fallback behavior (env absent → pg default) preserves local/CI; empty-string bindable resolution degrades to fallback rather than passing a bogus CA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)