### PR TITLE
RPE-98: tiered pg TLS — dev-tier DBs need explicit no-verify

### DIFF
--- a/.do/app.dev.yaml
+++ b/.do/app.dev.yaml
@@ -71,6 +71,12 @@ services:
       - key: DATABASE_CA_CERT
         scope: RUN_TIME
         value: ${db.CA_CERT}
+      # Dev-tier DBs don't deliver a resolvable CA via the bindable —
+      # encrypted-but-unverified TLS (in-VPC). Auto-upgrades to verified
+      # if the CA bindable ever resolves. Never set on prod.
+      - key: DATABASE_SSL_NO_VERIFY
+        scope: RUN_TIME
+        value: "true"
       - key: RPE_API_KEYS_SOURCE
         scope: RUN_TIME
         value: db

--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -73,6 +73,12 @@ services:
       - key: DATABASE_CA_CERT
         scope: RUN_TIME
         value: ${db.CA_CERT}
+      # Dev-tier DBs don't deliver a resolvable CA via the bindable —
+      # encrypted-but-unverified TLS (in-VPC). Auto-upgrades to verified
+      # if the CA bindable ever resolves. Never set on prod.
+      - key: DATABASE_SSL_NO_VERIFY
+        scope: RUN_TIME
+        value: "true"
       - key: RPE_API_KEYS_SOURCE
         scope: RUN_TIME
         value: db

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -107,7 +107,8 @@ bump the two `branch:` fields in `app.staging.yaml` and
 | Key | Prod | Staging | Notes |
 |---|---|---|---|
 | `DATABASE_URL` | `${db.DATABASE_URL}` | same | platform-injected bindable |
-| `DATABASE_CA_CERT` | `${db.CA_CERT}` | same | DO PG CA — verified TLS in @rpe/db (`pgSsl`) |
+| `DATABASE_CA_CERT` | `${db.CA_CERT}` | same | DO PG CA — verified TLS in @rpe/db (`pgSsl`); PEM-sniffed |
+| `DATABASE_SSL_NO_VERIFY` | **unset** | `true` | dev-tier DBs ship no resolvable CA bindable → encrypted-unverified TLS (in-VPC). Never set on prod |
 | `RPE_API_KEYS_SOURCE` | `db` | `db` | DB-backed keys (RPE-83) |
 | `RPE_AUTH_BASE_URL` | primary origin | `${APP_URL}` | better-auth base + email links |
 | `RPE_AUTH_TRUSTED_ORIGINS` | all three origins | `${APP_URL}` | comma-separated |

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -81,16 +81,27 @@ export function resolveDialect(url: string): Dialect {
 /**
  * TLS options for managed Postgres (RPE-98). DigitalOcean databases
  * present a CA that is not in the system trust store — node-postgres
- * then fails with SELF_SIGNED_CERT_IN_CHAIN. Deploys inject the PEM via
- * DATABASE_CA_CERT (App Platform's `${db.CA_CERT}` bindable); when
- * present, the pool verifies against it explicitly. When absent, pg's
- * default URL-driven TLS behavior applies (local/CI).
+ * then fails with SELF_SIGNED_CERT_IN_CHAIN. Tiered config:
+ *
+ *   1. DATABASE_CA_CERT holds a real PEM (App Platform `${db.CA_CERT}`
+ *      bindable on managed clusters) → verified TLS against that CA.
+ *      A PEM sniff guards against unresolved `${…}` literals.
+ *   2. DATABASE_SSL_NO_VERIFY=true (dev-tier App Platform databases,
+ *      which don't expose a resolvable CA bindable) → encrypted but
+ *      unverified TLS. In-VPC dev/stage only — never prod.
+ *   3. Neither → pg's default URL-driven behavior (local/CI).
  */
 export function pgSsl(
   caCert: string | undefined = process.env['DATABASE_CA_CERT'],
-): { ca: string; rejectUnauthorized: true } | undefined {
-  if (caCert === undefined || caCert.trim() === '') return undefined;
-  return { ca: caCert, rejectUnauthorized: true };
+  noVerify: string | undefined = process.env['DATABASE_SSL_NO_VERIFY'],
+): { ca: string; rejectUnauthorized: true } | { rejectUnauthorized: false } | undefined {
+  if (caCert !== undefined && caCert.includes('BEGIN CERTIFICATE')) {
+    return { ca: caCert, rejectUnauthorized: true };
+  }
+  if (noVerify === 'true' || noVerify === '1') {
+    return { rejectUnauthorized: false };
+  }
+  return undefined;
 }
 
 /** Create a client for the given DSN (defaults to env DATABASE_URL). */
@@ -103,6 +114,9 @@ export function createDb(url: string | undefined = process.env['DATABASE_URL']):
 
   if (dialect === 'postgres') {
     const ssl = pgSsl();
+    if (ssl !== undefined && ssl.rejectUnauthorized === false) {
+      console.warn('@rpe/db: postgres TLS verification DISABLED (DATABASE_SSL_NO_VERIFY) — dev/stage only');
+    }
     const pool = new pg.Pool({ connectionString: url, ...(ssl === undefined ? {} : { ssl }) });
     const db = drizzlePg(pool, { schema: pgSchema });
     return {

--- a/packages/db/tests/db.test.ts
+++ b/packages/db/tests/db.test.ts
@@ -19,12 +19,24 @@ describe('resolveDialect', () => {
   });
 });
 
-describe('pgSsl (DATABASE_CA_CERT plumbing, RPE-98)', () => {
-  it('returns verified-TLS options only when a CA cert is provided', () => {
-    expect(pgSsl(undefined)).toBeUndefined();
-    expect(pgSsl('')).toBeUndefined();
-    expect(pgSsl('   ')).toBeUndefined();
-    expect(pgSsl('-----BEGIN CERTIFICATE-----\nabc')).toEqual({
+describe('pgSsl (DATABASE_CA_CERT / DATABASE_SSL_NO_VERIFY plumbing, RPE-98)', () => {
+  it('verifies against a real PEM and ignores non-PEM values', () => {
+    expect(pgSsl(undefined, undefined)).toBeUndefined();
+    expect(pgSsl('', undefined)).toBeUndefined();
+    expect(pgSsl('${db.CA_CERT}', undefined)).toBeUndefined(); // unresolved bindable literal
+    expect(pgSsl('-----BEGIN CERTIFICATE-----\nabc', undefined)).toEqual({
+      ca: '-----BEGIN CERTIFICATE-----\nabc',
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('falls back to encrypted-unverified only when explicitly flagged', () => {
+    expect(pgSsl(undefined, 'true')).toEqual({ rejectUnauthorized: false });
+    expect(pgSsl(undefined, '1')).toEqual({ rejectUnauthorized: false });
+    expect(pgSsl(undefined, 'false')).toBeUndefined();
+    expect(pgSsl('${db.CA_CERT}', 'true')).toEqual({ rejectUnauthorized: false });
+    // a real CA always wins over the no-verify flag
+    expect(pgSsl('-----BEGIN CERTIFICATE-----\nabc', 'true')).toEqual({
       ca: '-----BEGIN CERTIFICATE-----\nabc',
       rejectUnauthorized: true,
     });


### PR DESCRIPTION
Round 2 on SELF_SIGNED_CERT_IN_CHAIN: the ${db.CA_CERT} bindable doesn't resolve to a PEM on dev-tier databases (verified by identical crash with the CA plumbing live in the new build's chunks). pgSsl is now tiered: PEM-sniffed CA → verified; explicit DATABASE_SSL_NO_VERIFY (dev/stage only, boot warning, never prod) → encrypted-unverified; else pg defaults. 7 unit tests cover the matrix; gate green 957/958.

Self-review (Copilot unavailable): the PEM sniff prevents an unresolved bindable literal from being passed as a CA; prod spec intentionally lacks the no-verify flag so a prod misconfig fails loudly rather than silently downgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)