### PR TITLE
RPE-98: strip URL sslmode so pg honors config-object ssl

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -104,6 +104,19 @@ export function pgSsl(
   return undefined;
 }
 
+/**
+ * node-postgres DISCARDS a config-object `ssl` whenever the connection
+ * string carries an `sslmode`/`ssl` query param (the URL's parsed ssl
+ * wins — verified against pg 8.21). When pgSsl() supplies options, the
+ * params must be stripped so the config object is authoritative.
+ */
+export function stripUrlSslParams(url: string): string {
+  const u = new URL(url);
+  u.searchParams.delete('sslmode');
+  u.searchParams.delete('ssl');
+  return u.toString();
+}
+
 /** Create a client for the given DSN (defaults to env DATABASE_URL). */
 export function createDb(url: string | undefined = process.env['DATABASE_URL']): RpeDb {
   if (url === undefined || url.trim() === '') {
@@ -117,7 +130,10 @@ export function createDb(url: string | undefined = process.env['DATABASE_URL']):
     if (ssl !== undefined && ssl.rejectUnauthorized === false) {
       console.warn('@rpe/db: postgres TLS verification DISABLED (DATABASE_SSL_NO_VERIFY) — dev/stage only');
     }
-    const pool = new pg.Pool({ connectionString: url, ...(ssl === undefined ? {} : { ssl }) });
+    const pool =
+      ssl === undefined
+        ? new pg.Pool({ connectionString: url })
+        : new pg.Pool({ connectionString: stripUrlSslParams(url), ssl });
     const db = drizzlePg(pool, { schema: pgSchema });
     return {
       dialect,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,4 @@
-export { createDb, resolveDialect, pgSsl, type Dialect, type RpeDb } from './client.js';
+export { createDb, resolveDialect, pgSsl, stripUrlSslParams, type Dialect, type RpeDb } from './client.js';
 export { appMeta as appMetaPg, pgSchema } from './schema.pg.js';
 export { appMeta as appMetaSqlite, sqliteSchema } from './schema.sqlite.js';
 export { seedDev } from './seed.js';

--- a/packages/db/tests/db.test.ts
+++ b/packages/db/tests/db.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { getTableColumns, getTableName } from 'drizzle-orm';
-import { createDb, resolveDialect, pgSsl, pgSchema, sqliteSchema, appMetaSqlite } from '../src/index';
+import { createDb, resolveDialect, pgSsl, stripUrlSslParams, pgSchema, sqliteSchema, appMetaSqlite } from '../src/index';
 
 describe('resolveDialect', () => {
   it('recognizes postgres and sqlite DSNs and rejects garbage', () => {
@@ -28,6 +28,12 @@ describe('pgSsl (DATABASE_CA_CERT / DATABASE_SSL_NO_VERIFY plumbing, RPE-98)', (
       ca: '-----BEGIN CERTIFICATE-----\nabc',
       rejectUnauthorized: true,
     });
+  });
+
+  it('strips sslmode/ssl params so config-object ssl stays authoritative (pg discards it otherwise)', () => {
+    expect(stripUrlSslParams('postgres://u:p@h:25060/db?sslmode=require')).toBe('postgres://u:p@h:25060/db');
+    expect(stripUrlSslParams('postgres://u:p@h/db?a=1&sslmode=require&ssl=true')).toBe('postgres://u:p@h/db?a=1');
+    expect(stripUrlSslParams('postgres://u:p@h/db')).toBe('postgres://u:p@h/db');
   });
 
   it('falls back to encrypted-unverified only when explicitly flagged', () => {


### PR DESCRIPTION
Root cause finally pinned by local micro-test: `new ConnectionParameters({connectionString: '...?sslmode=require', ssl: {rejectUnauthorized: false}})` → `ssl = {}` — **pg discards config-object ssl when the URL carries sslmode**. Fix strips sslmode/ssl params iff pgSsl supplies options.

Verified by full local repro (self-signed-TLS postgres:16 + the built image): without flag → DEPTH_ZERO_SELF_SIGNED_CERT (negative control matches DO's failure class); with flag → boot warning, 10 tables migrated over TLS, /v1/health 200. Gate green 958/959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)