### PR TITLE
RPE-98: preserve path prefixes in App Platform ingress

### DIFF
--- a/.do/app.dev.yaml
+++ b/.do/app.dev.yaml
@@ -31,19 +31,19 @@ databases:
 ingress:
   rules:
     - match: { path: { prefix: /v1 } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /health } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /evaluate } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /property } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /region } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /geocode } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /scrape } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: / } }
       component: { name: web }
 

--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -33,19 +33,19 @@ databases:
 ingress:
   rules:
     - match: { path: { prefix: /v1 } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /health } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /evaluate } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /property } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /region } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /geocode } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /scrape } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: / } }
       component: { name: web }
 

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -47,21 +47,21 @@ ingress:
   rules:
     # Versioned public API + cookie-session auth surface (/v1/auth/*).
     - match: { path: { prefix: /v1 } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     # Legacy unprefixed routes the SPA calls unauthenticated — RPE-75
     # keeps these open for the browser (apps/api/src/index.ts router).
     - match: { path: { prefix: /health } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /evaluate } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /property } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /region } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /geocode } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     - match: { path: { prefix: /scrape } }
-      component: { name: api }
+      component: { name: api, preserve_path_prefix: true }
     # Everything else: the SPA (catchall_document handles client routes).
     - match: { path: { prefix: / } }
       component: { name: web }


### PR DESCRIPTION
Live-dev smoke caught it: DO ingress strips the matched prefix by default — `/region` reached the api as `/`, `/v1/health` fell through to legacy `/health` (response shape mismatch), `/v1/auth/*` 404'd. `preserve_path_prefix: true` on all seven api rules in all three specs.

Self-review (Copilot unavailable): web catchall rule intentionally left default; verified against the api's error envelope (Unknown endpoint: /) proving requests routed but path-stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)