### PR TITLE
RPE-98: as-built — stage app recreated on the new build system

### DIFF
--- a/.do/app.staging.yaml
+++ b/.do/app.staging.yaml
@@ -1,9 +1,12 @@
 # RPE-98 — DigitalOcean App Platform spec: STAGE.
 #
-# App ID:   a5f7c0d2-161b-407d-a84f-ca1a594271da (pre-existing legacy stage
-#           app, updated in place 2026-06-11 — kept its name, region, and
-#           the already-attached stage.rentalpropertyevaluator.com domain)
-# Update:   doctl apps update a5f7c0d2-161b-407d-a84f-ca1a594271da --spec .do/app.staging.yaml
+# App ID:   7ffc325a-5d08-413c-8d4a-d3ddd615293a — RECREATED 2026-06-12:
+#           the legacy app was pinned to DO's old build system
+#           (digitalocean/node 0.5.0, no corepack/pnpm support); fresh
+#           apps get the new chain (nodejs-appdetect + heroku/nodejs).
+#           Default hostname: rental-property-evaluator-stage-r8oy4.ondigitalocean.app
+#           (the stage. CNAME in Cloudflare must point HERE).
+# Update:   doctl apps update 7ffc325a-5d08-413c-8d4a-d3ddd615293a --spec .do/app.staging.yaml
 #
 # Stage tracks the CURRENT RELEASE BRANCH — it always shows what ships
 # next. RELEASE RITUAL: when a new release branch is cut (e.g. v1.9.0),
@@ -101,13 +104,13 @@ services:
       - key: BETTER_AUTH_SECRET
         scope: RUN_TIME
         type: SECRET
-        value: EV[1:OkYkJG1xwm8p7nq5zri51APoJLRmUODd:BWs0jN/Cvh/p+iiqUrsLfT0e4mnQ5VWI6uf4j+ojGLgYu/S3lB3XuGqMnSvDVqjRmcjL63doW7dzGnLL]
+        value: EV[1:CcPcrY7PuhHIMkQYnBOgqwVgdaOTFicY:rcRZMPCryfooZBVk74abhDWyFgUOG26wak/jejjkVBoWwCFMCC6iSecPTHwi5nJXuO5JypGF5sj9N81K]
       # HUD_TOKEN is currently an encrypted EMPTY string — set the real
       # token in the console, then round-trip the new EV value here.
       - key: HUD_TOKEN
         scope: RUN_TIME
         type: SECRET
-        value: EV[1:n+VyEdv3Ve8IAvgyCcZ1KsJOPnqDhu4Q:Y0a+XkkjhScPJqX6QvLLLw==]
+        value: EV[1:uD2gVQMx3ZiYo6y8AlKL/IV7+P84zQAk:XQ5fF27DM85SLD/dcEsl9w==]
 
 static_sites:
   - name: web

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -23,7 +23,7 @@ Specs (one app per branch tier, mirroring the git strategy):
 | Spec | App | Tracks | Hostname |
 |---|---|---|---|
 | [.do/app.yaml](../.do/app.yaml) | rpe-prod (created at cutover) | `main` (releases) | rentalpropertyevaluator.com + aliases |
-| [.do/app.staging.yaml](../.do/app.staging.yaml) | rental-property-evaluator-stage `a5f7c0d2-…` | current release branch (`v1.8.0` — **bump on each release cut**) | stage.rentalpropertyevaluator.com |
+| [.do/app.staging.yaml](../.do/app.staging.yaml) | rental-property-evaluator-stage `7ffc325a-…` (recreated 2026-06-12 — legacy app was pinned to the old build system) | current release branch (`v1.8.0` — **bump on each release cut**) | stage.rentalpropertyevaluator.com |
 | [.do/app.dev.yaml](../.do/app.dev.yaml) | rental-property-evaluator-dev `4e7dd243-…` | `develop` (every merged task) | dev.rentalpropertyevaluator.com |
 
 All apps live in **sfo** (the legacy apps' region — verified 2026-06-11).
@@ -90,7 +90,7 @@ they kept their names, app IDs, domains, certs, and DNS. To change them:
 
 ```bash
 doctl apps update 4e7dd243-c8f4-4061-9f55-7db4f05b661c --spec .do/app.dev.yaml
-doctl apps update a5f7c0d2-161b-407d-a84f-ca1a594271da --spec .do/app.staging.yaml
+doctl apps update 7ffc325a-5d08-413c-8d4a-d3ddd615293a --spec .do/app.staging.yaml
 ```
 
 `BETTER_AUTH_SECRET` is set (committed as encrypted EV values);
@@ -146,7 +146,7 @@ zones (wherever their DNS is hosted).
 | `rentalpropertyevaluator.com` (apex, CNAME-flattened) | rentalpropertyevaluator.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.lowprop.com` CNAME | lowprop.com | `<rpe-prod>.ondigitalocean.app` |
 | `rpe.goldfinchproperties.com` CNAME | goldfinchproperties.com | `<rpe-prod>.ondigitalocean.app` |
-| `stage.rentalpropertyevaluator.com` CNAME (already in place) | rentalpropertyevaluator.com | `rental-property-evaluator-stage-cg55a.ondigitalocean.app` |
+| `stage.rentalpropertyevaluator.com` CNAME (**update — app recreated 2026-06-12**) | rentalpropertyevaluator.com | `rental-property-evaluator-stage-r8oy4.ondigitalocean.app` |
 | `dev.rentalpropertyevaluator.com` CNAME (already in place) | rentalpropertyevaluator.com | `rental-property-evaluator-dev-uv7fo.ondigitalocean.app` |
 
 Certificate issuance: App Platform issues Let's Encrypt certs per


### PR DESCRIPTION
Legacy stage app was generation-pinned to digitalocean/node 0.5.0 (no corepack → pnpm unfindable); no upgrade path existed and force-rebuild didn't change detection. Recreated from the committed spec → new chain detected → deployed ACTIVE first try; full smoke green on the default hostname (v1 health shape, SPA, /region data, auth 200, rate-limit headers). Spec/runbook updated: new app id, fresh sealed EVs, stage CNAME target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)