### PR TITLE
RPE-99: SVG favicon for the SPA

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+    <!-- Favicon (RPE-99) — SVG mark: house + upward trend -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
     <!-- Theme bootstrap (RPE-69) — applied before first paint to avoid a
          flash of the wrong theme. Mirrors packages/ui resolveInitialTheme:
          stored choice (rpe_theme) -> OS preference -> dark. -->

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- RPE mark (RPE-99): house + upward trend on slate -->
+  <rect width="64" height="64" rx="14" fill="#0f172a"/>
+  <path d="M32 11 L55 30 H48 V53 H16 V30 H9 Z" fill="#f8fafc"/>
+  <path d="M21 45 L29 36 L35 41 L44 31" stroke="#10b981" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M44 31 H36 M44 31 V39" stroke="#10b981" stroke-width="5" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Implements [RPE-99](https://lowermedia.atlassian.net/browse/RPE-99): the SPA had no favicon at all. Adds an original SVG mark (house + emerald trend arrow on slate, legible at 16px) at apps/web/public/favicon.svg + the rel=icon link in index.html. Verified in the built dist (file copied, link present, head otherwise untouched). Gate green 958/959.

Self-review (Copilot unavailable): static asset + one head line — /favicon.svg falls through ingress to the web component correctly (no api prefix collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPE-99]: https://lowermedia.atlassian.net/browse/RPE-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ