### PR TITLE
RPE-113: derive state from ZIP so location resolves without HUD

### DIFF
--- a/apps/api/src/routes/region.ts
+++ b/apps/api/src/routes/region.ts
@@ -41,7 +41,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { resolveRegionalRates } from '@rpe/region-defaults';
+import { resolveRegionalRates, stateForZip } from '@rpe/region-defaults';
 import { fetchHudSafmr } from '../services/hud.js';
 import type { HudSafmrResult } from '../services/hud.js';
 
@@ -98,9 +98,13 @@ export async function handleRegion(
       }
     }
 
-    // If HUD call failed or token absent, try to derive state from ZIP prefix
-    // This is a best-effort fallback — not all ZIP3 prefixes map to a unique state.
-    // For now, leave stateCode empty and serve national defaults.
+    // If HUD didn't resolve a state (no token / HUD failure / null / uncovered
+    // ZIP), derive it from the ZIP3 prefix so location still resolves to
+    // state-level defaults instead of hanging on "pending" (RPE-113). HUD,
+    // when present, stays authoritative for stateCode + town/county label + rent.
+    if (!stateCode) {
+      stateCode = stateForZip(zip);
+    }
 
     const rates = resolveRegionalRates(stateCode);
 

--- a/apps/api/tests/region.test.ts
+++ b/apps/api/tests/region.test.ts
@@ -86,7 +86,7 @@ describe('GET /region', () => {
 
   // ── Static-only (no HUD_TOKEN) ──────────────────────────────────────────────
 
-  it('returns national defaults when HUD_TOKEN is absent', async () => {
+  it('derives state from the ZIP and serves state-level rates when HUD_TOKEN is absent (RPE-113)', async () => {
     delete process.env['HUD_TOKEN'];
     // fetchHudSafmr should NOT be called when no token is set
 
@@ -94,12 +94,24 @@ describe('GET /region', () => {
     expect(r.status).toBe(200);
     const body = await r.json() as Record<string, unknown>;
     expect(body['zip']).toBe('78701');
-    expect(body['rent']).toBeNull();
-    // Should fall back to national (no stateCode resolved without HUD)
-    expect(body['resolvedLevel']).toBe('national');
+    expect(body['rent']).toBeNull(); // no rent without HUD
+    // ZIP3 787 → TX: state resolves from the ZIP even with no HUD token,
+    // so the UI no longer hangs on "pending".
+    expect(body['stateCode']).toBe('TX');
+    expect(body['label']).toBe('TX · 78701');
+    expect(body['resolvedLevel']).toBe('state');
     expect(typeof body['propertyTaxRate']).toBe('number');
     expect(typeof body['insuranceRate']).toBe('number');
     expect(mockFetchHudSafmr).not.toHaveBeenCalled();
+  });
+
+  it('resolves the reported-bug ZIP 52240 to IA without HUD (RPE-113)', async () => {
+    delete process.env['HUD_TOKEN'];
+    const r = await fetch(`${base}/region?zip=52240`);
+    expect(r.status).toBe(200);
+    const body = await r.json() as Record<string, unknown>;
+    expect(body['stateCode']).toBe('IA');
+    expect(body['resolvedLevel']).toBe('state');
   });
 
   // ── HUD SAFMR integration ───────────────────────────────────────────────────
@@ -155,15 +167,17 @@ describe('GET /region', () => {
     expect(body['rent']).toBeNull();
   });
 
-  it('falls back gracefully when HUD fetch rejects', async () => {
+  it('falls back to ZIP-derived state when HUD fetch rejects (RPE-113)', async () => {
     process.env['HUD_TOKEN'] = 'test-token';
     mockFetchHudSafmr.mockRejectedValueOnce(new Error('network error'));
 
     const r = await fetch(`${base}/region?zip=12345`);
     expect(r.status).toBe(200);
     const body = await r.json() as Record<string, unknown>;
-    expect(body['resolvedLevel']).toBe('national');
-    expect(body['rent']).toBeNull();
+    // ZIP3 123 → NY: HUD blew up, but the ZIP fallback still resolves state.
+    expect(body['stateCode']).toBe('NY');
+    expect(body['resolvedLevel']).toBe('state');
+    expect(body['rent']).toBeNull(); // no rent — HUD failed
   });
 
   it('includes correct label when HUD resolves town and state', async () => {

--- a/packages/region-defaults/src/index.ts
+++ b/packages/region-defaults/src/index.ts
@@ -21,6 +21,7 @@ import type { RegionalRates } from './types.js';
 
 export type { RegionalRates, RegionLevel } from './types.js';
 export { STATE_RATES, NATIONAL_RATES } from './stateRates.js';
+export { stateForZip } from './zipToState.js';
 
 /**
  * Resolve regional assumption rates for the given US state code.

--- a/packages/region-defaults/src/zipToState.ts
+++ b/packages/region-defaults/src/zipToState.ts
@@ -1,0 +1,92 @@
+/**
+ * ZIP3-prefix → US state derivation (RPE-113).
+ *
+ * The first three digits of a US ZIP (the SCF — Sectional Center Facility)
+ * map to a state via contiguous ranges. This is the static, no-I/O fallback
+ * the /region endpoint uses to resolve a state when HUD SAFMR is unavailable
+ * (no HUD_TOKEN, an uncovered ZIP, or a HUD outage), so location always
+ * resolves to state-level defaults instead of hanging on "pending".
+ *
+ * Coverage: the 50 states + DC + PR. Gaps (military APO/FPO bands such as
+ * 090-098 AE and 962-966 AP, and unassigned prefixes) fall through to '' →
+ * national defaults. DC/PR have no STATE_RATES entry and resolve to national
+ * rates, but still yield a non-empty stateCode so the UI resolves the chip.
+ *
+ * Source: standard USPS ZIP3 → state assignment (stable public data).
+ */
+
+/** Inclusive [lowPrefix, highPrefix, stateCode] ranges, ascending by prefix. */
+const ZIP3_RANGES: ReadonlyArray<readonly [number, number, string]> = [
+  [5, 5, 'NY'], // 005 Holtsville
+  [6, 9, 'PR'], // 006-009 Puerto Rico / USVI (territory → national rates)
+  [10, 27, 'MA'],
+  [28, 29, 'RI'],
+  [30, 38, 'NH'],
+  [39, 49, 'ME'],
+  [50, 59, 'VT'],
+  [60, 69, 'CT'],
+  [70, 89, 'NJ'],
+  [100, 149, 'NY'],
+  [150, 196, 'PA'],
+  [197, 199, 'DE'],
+  [200, 205, 'DC'], // territory → national rates
+  [206, 219, 'MD'],
+  [220, 246, 'VA'],
+  [247, 268, 'WV'],
+  [270, 289, 'NC'],
+  [290, 299, 'SC'],
+  [300, 319, 'GA'],
+  [320, 349, 'FL'],
+  [350, 369, 'AL'],
+  [370, 385, 'TN'],
+  [386, 397, 'MS'],
+  [398, 399, 'GA'],
+  [400, 427, 'KY'],
+  [430, 459, 'OH'],
+  [460, 479, 'IN'],
+  [480, 499, 'MI'],
+  [500, 528, 'IA'],
+  [530, 549, 'WI'],
+  [550, 567, 'MN'],
+  [570, 577, 'SD'],
+  [580, 588, 'ND'],
+  [590, 599, 'MT'],
+  [600, 629, 'IL'],
+  [630, 658, 'MO'],
+  [660, 679, 'KS'],
+  [680, 693, 'NE'],
+  [700, 714, 'LA'],
+  [716, 729, 'AR'],
+  [730, 749, 'OK'],
+  [750, 799, 'TX'],
+  [800, 816, 'CO'],
+  [820, 831, 'WY'],
+  [832, 838, 'ID'],
+  [840, 847, 'UT'],
+  [850, 865, 'AZ'],
+  [870, 884, 'NM'],
+  [885, 885, 'TX'], // El Paso special
+  [889, 898, 'NV'],
+  [900, 961, 'CA'],
+  [967, 968, 'HI'],
+  [970, 979, 'OR'],
+  [980, 994, 'WA'],
+  [995, 999, 'AK'],
+];
+
+/**
+ * Resolve the 2-letter US state code for a ZIP from its 3-digit prefix.
+ *
+ * @param zip  A ZIP string; only the leading 3 digits are used (ZIP+4 ok).
+ * @returns    2-letter code (e.g. 'IA'), or '' if the prefix maps to no
+ *             state (military band, unassigned, or malformed input).
+ */
+export function stateForZip(zip: string): string {
+  const match = /^\s*(\d{3})/.exec(zip);
+  if (!match) return '';
+  const prefix = Number(match[1]);
+  for (const [lo, hi, state] of ZIP3_RANGES) {
+    if (prefix >= lo && prefix <= hi) return state;
+  }
+  return '';
+}

--- a/packages/region-defaults/tests/zipToState.test.ts
+++ b/packages/region-defaults/tests/zipToState.test.ts
@@ -1,0 +1,60 @@
+/**
+ * RPE-113: ZIP3-prefix → state derivation.
+ *
+ * Verifies stateForZip across representative ZIPs (one per region band),
+ * the reported-bug ZIP (52240 → IA), and the unmappable/garbage cases that
+ * must return '' so the API degrades to national defaults.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stateForZip, STATE_RATES } from '../src/index';
+
+describe('stateForZip', () => {
+  it('resolves the reported-bug ZIP 52240 to IA (Iowa City)', () => {
+    expect(stateForZip('52240')).toBe('IA');
+  });
+
+  it('resolves representative ZIPs across the country', () => {
+    const cases: Array<[string, string]> = [
+      ['78701', 'TX'], // Austin
+      ['90001', 'CA'], // Los Angeles
+      ['10001', 'NY'], // Manhattan
+      ['33101', 'FL'], // Miami
+      ['60601', 'IL'], // Chicago
+      ['98101', 'WA'], // Seattle
+      ['02108', 'MA'], // Boston
+      ['80201', 'CO'], // Denver
+      ['99501', 'AK'], // Anchorage
+      ['96801', 'HI'], // Honolulu
+      ['97201', 'OR'], // Portland
+      ['85001', 'AZ'], // Phoenix
+      ['20001', 'DC'], // Washington DC
+      ['07001', 'NJ'], // New Jersey
+      ['00601', 'PR'], // Puerto Rico
+    ];
+    for (const [zip, state] of cases) {
+      expect(stateForZip(zip), `${zip} should be ${state}`).toBe(state);
+    }
+  });
+
+  it('uses only the first 3 digits (ZIP+4 and trailing chars ignored)', () => {
+    expect(stateForZip('52240-1234')).toBe('IA');
+    expect(stateForZip('522401234')).toBe('IA');
+  });
+
+  it("returns '' for unmappable or malformed input", () => {
+    expect(stateForZip('00000')).toBe(''); // prefix 000 — below the lowest range
+    expect(stateForZip('09001')).toBe(''); // 090 — AE military gap (070-089 NJ, 100+ NY)
+    expect(stateForZip('')).toBe('');
+    expect(stateForZip('abcde')).toBe('');
+    expect(stateForZip('12')).toBe(''); // fewer than 3 digits
+  });
+
+  it('every mapped state (except DC/PR territories) has rates in STATE_RATES', () => {
+    // Sanity: the codes stateForZip emits for the 50 states must be lookupable.
+    for (const zip of ['52240', '78701', '90001', '10001', '33101']) {
+      const st = stateForZip(zip);
+      expect(STATE_RATES[st]).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Fixes [RPE-113](https://lowermedia.atlassian.net/browse/RPE-113): the Location input sat on '{zip} pending' (yellow) forever. Root cause: /region only derived stateCode from HUD SAFMR (the ZIP->state fallback was an unimplemented TODO), so with no HUD_TOKEN every ZIP returned stateCode:'' and the UI's resolved-state guards never fired — even though the fetch succeeded and applied national rates.

Fix: implement the deferred ZIP3->state derivation in @rpe/region-defaults (stateForZip) and use it in region.ts when HUD doesn't resolve a state. Resolves for any valid US ZIP, HUD-independent, and upgrades rates national->state. HUD stays the source for rent + town/county label.

Verified at three levels: stateForZip unit tests, region handler integration tests (52240->IA & 78701->TX with no HUD; 00000->national; HUD-reject->ZIP fallback), and a built-bundle smoke (node dist + curl). Gate green 964/965.

Self-review (Copilot unavailable): ZIP3 ranges are the standard USPS SCF table; military/unassigned bands fall through to '' (national); DC/PR yield a non-empty stateCode (national rates) so the chip still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPE-113]: https://lowermedia.atlassian.net/browse/RPE-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ