### PR TITLE
RPE-115: add .env.development to silence VITE_APP_ORIGIN dev warning

### DIFF
--- a/apps/web/.env.development
+++ b/apps/web/.env.development
@@ -1,0 +1,8 @@
+# Vite DEV-mode env (loaded by `pnpm dev`, mode=development).
+# Committed on purpose — no secrets — so %VITE_APP_ORIGIN% in index.html
+# resolves locally and dev doesn't warn "VITE_APP_ORIGIN is not defined"
+# (RPE-115). Production builds use .env.production instead.
+#
+# Per-developer overrides go in apps/web/.env.local (gitignored), e.g.
+# VITE_API_URL=http://localhost:3002 when the api runs on a non-default port.
+VITE_APP_ORIGIN=http://localhost:5173


### PR DESCRIPTION
Fixes [RPE-115](https://lowermedia.atlassian.net/browse/RPE-115): `pnpm dev` warned '%VITE_APP_ORIGIN% is not defined' (5 placeholders in index.html) because the var lives only in .env.production, which Vite doesn't load in dev mode. Adds a committed, no-secret apps/web/.env.development pinning the dev origin. Verified live: vite dev renders canonical=http://localhost:5173 with 0 warnings. Prod build path unchanged. Gate green 964/965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPE-115]: https://lowermedia.atlassian.net/browse/RPE-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ