### PR TITLE
RPE-118: keyboard-accessible metric tooltips (formula + definition)

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -108,7 +108,15 @@ function MetricRow({ metricKey, result, label }: MetricRowProps) {
     <div className="flex items-center gap-2 py-2 border-b border-border last:border-b-0">
       <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${DOT_CLASS[signal]}`} aria-hidden="true" />
       <div className="flex-1 min-w-0">
-        <span className="text-xs text-mid truncate block" title={cfg.description}>
+        {/* Keyboard-focusable + screen-reader-accessible metric tooltip (RPE-118):
+            cfg.description carries the formula + definition; tabIndex + aria-label
+            make it reachable without a mouse, focus-visible ring shows focus. */}
+        <span
+          className="block cursor-help truncate rounded-sm text-xs text-mid outline-none focus-visible:ring-1 focus-visible:ring-accent"
+          tabIndex={0}
+          title={cfg.description}
+          aria-label={`${displayLabel}: ${cfg.description}`}
+        >
           {displayLabel}
         </span>
         {note && (


### PR DESCRIPTION
Implements [RPE-118](https://lowermedia.atlassian.net/browse/RPE-118). The metric tooltips already carry the formula + plain definition (SCREENER_METRIC_CONFIG.description), but were hover-only via native `title`. Metric labels are now keyboard-focusable with an `aria-label` (label + formula/definition) and a focus-visible ring, so keyboard + screen-reader users reach the content. Low-risk: truncate layout preserved, content unchanged. Gate green 964/965.

Note: a visual focus-popover (vs the native title) is a possible follow-up enhancement; this ships the keyboard/SR accessibility now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RPE-118]: https://lowermedia.atlassian.net/browse/RPE-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ