### PR TITLE
RPE-101: fix(ui): gate viewport-locking to lg so mobile scrolls naturally

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -738,7 +738,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
   };
 
   return (
-    <div className="h-dvh bg-base text-hi flex flex-col">
+    <div className="min-h-dvh lg:h-dvh bg-base text-hi flex flex-col">
       {/* ── Skip navigation ── */}
       <a
         href="#results"
@@ -834,7 +834,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
         {/* Left — inputs (hidden in print) */}
         <aside
           aria-label="Deal inputs"
-          className="no-print flex flex-col overflow-hidden border-b border-border lg:border-b-0 lg:border-r lg:border-border"
+          className="no-print flex flex-col lg:overflow-hidden border-b border-border lg:border-b-0 lg:border-r lg:border-border"
         >
           <ScenarioTabs
             scenarios={scenarios}
@@ -845,7 +845,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             onRemove={removeScenario}
             onRename={renameScenario}
           />
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 lg:overflow-y-auto">
             <DealInputsForm
               state={activeInputs}
               dispatch={dispatchToActive}
@@ -870,7 +870,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
           aria-label="Evaluation results"
           aria-live="polite"
           aria-atomic="false"
-          className="overflow-y-auto p-5"
+          className="lg:overflow-y-auto p-5"
         >
           {proFormaMode && proFormaResults ? (
             <ProFormaPanel results={proFormaResults} purchasePrice={activeNormalized.purchasePrice} />


### PR DESCRIPTION
## RPE-101 — Mobile `h-dvh` + nested `overflow-y-auto` double-scroll trap

Root `h-dvh` plus the inputs `<aside>` (`overflow-hidden` → inner `flex-1 overflow-y-auto`) and the results `<section>` (`overflow-y-auto`) created competing inner scroll regions when the layout stacks on mobile, instead of natural page scroll.

### Fix — gate all viewport-locking to `lg` (`packages/ui/src/Evaluator.tsx`)
- root: `h-dvh` → `min-h-dvh lg:h-dvh`
- aside: `overflow-hidden` → `lg:overflow-hidden`
- inputs inner: `flex-1 overflow-y-auto` → `flex-1 lg:overflow-y-auto`
- results: `overflow-y-auto` → `lg:overflow-y-auto`

### Verification (browser preview)
- **390px (mobile):** page scrolls as one document (`scrollHeight 3933 > clientHeight 844`); aside / inputs-inner / `#results` all `overflow-y: visible` (no nested scrollers); no horizontal overflow; no console errors.
- **1280px (desktop):** root height = viewport (800px); aside `overflow-y: hidden`; both panes `overflow-y: auto`; no page scroll — two-pane independent scroll unchanged.
- Gate green: `pnpm lint && typecheck && test && build` → 68 files, 964 passed / 1 skipped (965), all packages built.

Jira: https://lowermedia.atlassian.net/browse/RPE-101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
