### PR TITLE
RPE-102: a11y(ui): enlarge mobile toolbar tap targets to 44px minimum

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -411,7 +411,7 @@ function ModeToggle({ proFormaMode, onChange, disableProForma = false }: ModeTog
         <button
           type="button"
           onClick={() => onChange(false)}
-          className={`px-3 py-1.5 uppercase tracking-widest transition-colors ${
+          className={`px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 uppercase tracking-widest transition-colors ${
             !proFormaMode
               ? 'bg-accent text-base font-semibold'
               : 'text-lo hover:text-mid hover:bg-raised'
@@ -424,7 +424,7 @@ function ModeToggle({ proFormaMode, onChange, disableProForma = false }: ModeTog
           type="button"
           onClick={() => !disableProForma && onChange(true)}
           disabled={disableProForma}
-          className={`px-3 py-1.5 uppercase tracking-widest transition-colors border-l border-border ${
+          className={`px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 uppercase tracking-widest transition-colors border-l border-border ${
             disableProForma
               ? 'text-lo/40 cursor-not-allowed'
               : proFormaMode
@@ -462,7 +462,7 @@ function UiModeToggle({ uiMode, onChange }: UiModeToggleProps) {
       <button
         type="button"
         onClick={() => onChange('simple')}
-        className={`px-3 py-1.5 uppercase tracking-widest transition-colors ${
+        className={`px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 uppercase tracking-widest transition-colors ${
           uiMode === 'simple'
             ? 'bg-accent text-base font-semibold'
             : 'text-lo hover:text-mid hover:bg-raised'
@@ -474,7 +474,7 @@ function UiModeToggle({ uiMode, onChange }: UiModeToggleProps) {
       <button
         type="button"
         onClick={() => onChange('complex')}
-        className={`px-3 py-1.5 uppercase tracking-widest transition-colors border-l border-border ${
+        className={`px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 uppercase tracking-widest transition-colors border-l border-border ${
           uiMode === 'complex'
             ? 'bg-accent text-base font-semibold'
             : 'text-lo hover:text-mid hover:bg-raised'
@@ -510,7 +510,7 @@ function ShareButton({ inputs }: { inputs: DealInputs }) {
       type="button"
       onClick={() => void handleShare()}
       className="
-        rounded border border-border px-3 py-1.5
+        rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
         text-xs text-mid uppercase tracking-widest
         hover:border-accent hover:text-accent
         transition-colors
@@ -762,7 +762,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             type="button"
             onClick={() => setShowSettings(true)}
             className="
-              rounded border border-border px-3 py-1.5
+              rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
               text-xs text-mid uppercase tracking-widest
               hover:border-accent hover:text-accent
               transition-colors
@@ -791,7 +791,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             type="button"
             onClick={() => exportToCsv(scenarios, resultsList)}
             className="
-              rounded border border-border px-3 py-1.5
+              rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
               text-xs text-mid uppercase tracking-widest
               hover:border-accent hover:text-accent
               transition-colors
@@ -804,7 +804,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             type="button"
             onClick={() => window.print()}
             className="
-              rounded border border-border px-3 py-1.5
+              rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
               text-xs text-mid uppercase tracking-widest
               hover:border-accent hover:text-accent
               transition-colors
@@ -817,7 +817,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             type="button"
             onClick={() => dispatchToActive({ type: 'RESET' })}
             className="
-              rounded border border-border px-3 py-1.5
+              rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
               text-xs text-mid uppercase tracking-widest
               hover:border-accent hover:text-accent
               transition-colors

--- a/packages/ui/src/components/SavedDealsPanel.tsx
+++ b/packages/ui/src/components/SavedDealsPanel.tsx
@@ -167,7 +167,7 @@ export function SavedDealsPanel({
           type="button"
           onClick={handleOpenSave}
           className="
-            rounded border border-border px-3 py-1.5
+            rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
             text-xs text-mid uppercase tracking-widest
             hover:border-accent hover:text-accent
             transition-colors
@@ -186,7 +186,7 @@ export function SavedDealsPanel({
             setDealsOpen((o) => !o);
           }}
           className="
-            rounded border border-border px-3 py-1.5
+            rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
             text-xs text-mid uppercase tracking-widest
             hover:border-border-2 hover:text-hi
             transition-colors

--- a/packages/ui/src/components/ThemeToggle.tsx
+++ b/packages/ui/src/components/ThemeToggle.tsx
@@ -30,7 +30,7 @@ export function ThemeToggle() {
       aria-label={isLight ? 'Switch to dark mode' : 'Switch to light mode'}
       title={isLight ? 'Dark mode' : 'Light mode'}
       className="
-        rounded border border-border px-3 py-1.5
+        rounded border border-border px-3 py-1.5 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0
         text-xs text-mid
         hover:border-accent hover:text-accent
         transition-colors

--- a/packages/ui/src/components/auth/AccountMenu.tsx
+++ b/packages/ui/src/components/auth/AccountMenu.tsx
@@ -14,7 +14,7 @@ export function AccountMenu() {
     return (
       <a
         href="#/login"
-        className="rounded border border-border px-2.5 py-1 text-xs text-mid hover:text-hi"
+        className="rounded border border-border px-2.5 py-1 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 text-xs text-mid hover:text-hi"
       >
         Sign in
       </a>
@@ -23,7 +23,7 @@ export function AccountMenu() {
   return (
     <a
       href="#/account"
-      className="rounded border border-border px-2.5 py-1 text-xs text-accent"
+      className="rounded border border-border px-2.5 py-1 min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0 text-xs text-accent"
       aria-label={`Account: ${user?.name ?? ''}`}
     >
       {user?.name ?? 'Account'}


### PR DESCRIPTION
## RPE-102 — Mobile toolbar tap targets below 44px

Header toolbar controls rendered ~28px tall (`px-3 py-1.5 text-xs`), under the WCAG 2.5.5 / 44px touch-target guidance and hard to tap accurately on phones.

### Fix
Add a 44×44 minimum with centered content on mobile, reverting to compact desktop density at `sm`:
`min-h-[44px] min-w-[44px] inline-flex items-center justify-center sm:min-h-0 sm:min-w-0`

Applied across **all 13 toolbar controls** for visual + a11y consistency — the ticket's explicit list plus ThemeToggle, Save/Deals, and the account link, which share the same toolbar: theme toggle, account link, ⚙ settings, the Simple/Complex and Screener/Pro-Forma segmented toggles, Save, Deals, Share, CSV, Print, Reset.

- The account control is an `<a>` (inline) — `inline-flex` is required for `min-height` to apply.
- `min-w` is a no-op for the wide text buttons; it squares up the icon-only theme/⚙ buttons.

### Verification (browser preview)
- **390px:** all 13 controls measure ≥44×44 (icon buttons exactly 44×44, text buttons wider); centered labels; no console errors.
- **1280px:** all revert to ≤30px — desktop density unchanged.
- Gate green: lint + typecheck + 965 tests (964 pass / 1 skip) + all builds.

Files: `packages/ui/src/Evaluator.tsx`, `components/ThemeToggle.tsx`, `components/SavedDealsPanel.tsx`, `components/auth/AccountMenu.tsx`.

Jira: https://lowermedia.atlassian.net/browse/RPE-102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
