### PR TITLE
RPE-108: feat: go/no-go verdict chip backed by an engine score single source of truth

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -28,6 +28,15 @@ export { calcProjection } from './projection';
 export { calcProForma } from './proforma';
 export { calcIRR, calcNPV } from './irr';
 export { SCREENER_METRIC_CONFIG } from './directions';
+export {
+  scoreVerdict,
+  SCORE_BAND_MIN,
+  SCORE_VERDICT_LABEL,
+  evalSignal,
+  SCORED_KEYS,
+  computeScreenerScore,
+} from './score';
+export type { ScoreVerdict, ScoreSignal, ScreenerScore } from './score';
 export { EXAMPLE_DEAL_INPUTS, EXAMPLE_DEAL_EXPECTED } from './exampleDeal';
 export type { MetricDirection, MetricConfig } from './directions';
 

--- a/packages/engine/src/score.ts
+++ b/packages/engine/src/score.ts
@@ -1,0 +1,90 @@
+/**
+ * Aggregate score calc + banding (RPE-108).
+ *
+ * Single source of truth for the screener score (passing ÷ scored metrics) and
+ * its go/no-go verdict band — consumed by the UI Score header + sticky bar
+ * (RPE-112), the CSV exports, and the PDF report header. evalSignal mirrors the
+ * per-metric pass/fail policy in SCREENER_METRIC_CONFIG; computeScreenerScore
+ * aggregates it; scoreVerdict bands the percentage.
+ */
+
+import { SCREENER_METRIC_CONFIG } from './directions';
+import type { ScreenerResults } from './types';
+
+export type ScoreVerdict = 'pass' | 'marginal' | 'fail';
+
+/** Per-metric signal. 'null' = no value; 'neutral' = informational (no threshold). */
+export type ScoreSignal = 'pass' | 'fail' | 'null' | 'neutral';
+
+/**
+ * Inclusive lower bounds (percent) for each band:
+ * ≥75 → pass, ≥50 → marginal, below 50 → fail.
+ */
+export const SCORE_BAND_MIN: { readonly pass: number; readonly marginal: number } = {
+  pass: 75,
+  marginal: 50,
+};
+
+/** Display label for each verdict. */
+export const SCORE_VERDICT_LABEL: Readonly<Record<ScoreVerdict, string>> = {
+  pass: 'Pass',
+  marginal: 'Marginal',
+  fail: 'Fail',
+};
+
+/**
+ * Map a score percentage (0–100, passing ÷ scored × 100) to a verdict.
+ * Non-finite or negative input is treated as 0 (fail).
+ */
+export function scoreVerdict(pct: number): ScoreVerdict {
+  const p = Number.isFinite(pct) ? pct : 0;
+  if (p >= SCORE_BAND_MIN.pass) return 'pass';
+  if (p >= SCORE_BAND_MIN.marginal) return 'marginal';
+  return 'fail';
+}
+
+/**
+ * Pass/fail/neutral for a single metric vs. its configured threshold.
+ * Mirrors the colouring policy in SCREENER_METRIC_CONFIG.
+ */
+export function evalSignal(key: keyof ScreenerResults, value: number | null): ScoreSignal {
+  if (value === null) return 'null';
+  const cfg = SCREENER_METRIC_CONFIG[key];
+  if (cfg.direction === 'none' || cfg.threshold === undefined) return 'neutral';
+  return cfg.direction === 'higher'
+    ? value >= cfg.threshold ? 'pass' : 'fail'
+    : value <= cfg.threshold ? 'pass' : 'fail';
+}
+
+/** Every metric key with a pass/fail threshold (direction !== 'none'). */
+export const SCORED_KEYS: (keyof ScreenerResults)[] = (
+  Object.entries(SCREENER_METRIC_CONFIG) as [
+    keyof ScreenerResults,
+    (typeof SCREENER_METRIC_CONFIG)[keyof ScreenerResults],
+  ][]
+)
+  .filter(([, cfg]) => cfg.direction !== 'none')
+  .map(([key]) => key);
+
+export interface ScreenerScore {
+  passing: number;
+  total: number;
+  /** passing / total × 100, 0 when nothing is scoreable. */
+  pct: number;
+  verdict: ScoreVerdict;
+}
+
+/**
+ * Aggregate the screener score over the given scored keys (defaults to all).
+ * `total` counts metrics with a non-null signal; `passing` counts 'pass'.
+ */
+export function computeScreenerScore(
+  results: ScreenerResults,
+  scoredKeys: readonly (keyof ScreenerResults)[] = SCORED_KEYS,
+): ScreenerScore {
+  const signals = scoredKeys.map((k) => evalSignal(k, results[k]));
+  const total = signals.filter((s) => s !== 'null').length;
+  const passing = signals.filter((s) => s === 'pass').length;
+  const pct = total > 0 ? (passing / total) * 100 : 0;
+  return { passing, total, pct, verdict: scoreVerdict(pct) };
+}

--- a/packages/engine/tests/score.test.ts
+++ b/packages/engine/tests/score.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Score calc + verdict bands — RPE-108.
+ *
+ * Asserts the go/no-go bands at the exact thresholds (49/50/74/75) and the
+ * per-metric signal + aggregation, so the verdict chip, sticky score bar, and
+ * report header never diverge.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  scoreVerdict,
+  evalSignal,
+  computeScreenerScore,
+  SCORED_KEYS,
+  SCORE_VERDICT_LABEL,
+  SCORE_BAND_MIN,
+} from '../src/score';
+import type { ScreenerResults } from '../src/types';
+
+describe('scoreVerdict band boundaries', () => {
+  it('fails below 50%', () => {
+    expect(scoreVerdict(0)).toBe('fail');
+    expect(scoreVerdict(49)).toBe('fail');
+    expect(scoreVerdict(49.999)).toBe('fail');
+  });
+
+  it('is marginal in [50, 75)', () => {
+    expect(scoreVerdict(50)).toBe('marginal');
+    expect(scoreVerdict(60)).toBe('marginal');
+    expect(scoreVerdict(74)).toBe('marginal');
+    expect(scoreVerdict(74.999)).toBe('marginal');
+  });
+
+  it('passes at or above 75%', () => {
+    expect(scoreVerdict(75)).toBe('pass');
+    expect(scoreVerdict(100)).toBe('pass');
+  });
+
+  it('treats non-finite or negative input as fail', () => {
+    expect(scoreVerdict(NaN)).toBe('fail');
+    expect(scoreVerdict(-10)).toBe('fail');
+  });
+
+  it('exposes labels and thresholds as the single source of truth', () => {
+    expect(SCORE_VERDICT_LABEL).toEqual({ pass: 'Pass', marginal: 'Marginal', fail: 'Fail' });
+    expect(SCORE_BAND_MIN).toEqual({ pass: 75, marginal: 50 });
+  });
+});
+
+describe('evalSignal', () => {
+  it('passes a "higher" metric at or above threshold (capRate ≥ 5)', () => {
+    expect(evalSignal('capRate', 5)).toBe('pass');
+    expect(evalSignal('capRate', 4.99)).toBe('fail');
+  });
+
+  it('passes a "lower" metric at or below threshold (grm ≤ 12)', () => {
+    expect(evalSignal('grm', 12)).toBe('pass');
+    expect(evalSignal('grm', 12.01)).toBe('fail');
+  });
+
+  it('returns neutral for informational metrics (direction none)', () => {
+    expect(evalSignal('loanAmount', 250_000)).toBe('neutral');
+  });
+
+  it('returns null for a null value', () => {
+    expect(evalSignal('capRate', null)).toBe('null');
+  });
+});
+
+describe('computeScreenerScore', () => {
+  it('aggregates passing/total/pct and bands the verdict', () => {
+    // capRate 6 ≥ 5 pass; dscr 1.0 < 1.25 fail; cocRoi 10 ≥ 8 pass → 2/3 ≈ 66.7% → marginal
+    const results = { capRate: 6, dscr: 1.0, cocRoi: 10 } as unknown as ScreenerResults;
+    const score = computeScreenerScore(results, ['capRate', 'dscr', 'cocRoi']);
+    expect(score.passing).toBe(2);
+    expect(score.total).toBe(3);
+    expect(score.pct).toBeCloseTo(66.6667, 2);
+    expect(score.verdict).toBe('marginal');
+  });
+
+  it('excludes null-valued metrics from the denominator', () => {
+    const results = { capRate: 6, dscr: null, cocRoi: 10 } as unknown as ScreenerResults;
+    const score = computeScreenerScore(results, ['capRate', 'dscr', 'cocRoi']);
+    expect(score.passing).toBe(2);
+    expect(score.total).toBe(2);
+    expect(score.pct).toBe(100);
+    expect(score.verdict).toBe('pass');
+  });
+
+  it('defaults to all scored keys and returns 0/0 fail when nothing is scoreable', () => {
+    expect(SCORED_KEYS.length).toBeGreaterThan(0);
+    const empty = Object.fromEntries(SCORED_KEYS.map((k) => [k, null])) as unknown as ScreenerResults;
+    const score = computeScreenerScore(empty);
+    expect(score.total).toBe(0);
+    expect(score.pct).toBe(0);
+    expect(score.verdict).toBe('fail');
+  });
+});

--- a/packages/report/src/csv.ts
+++ b/packages/report/src/csv.ts
@@ -4,7 +4,7 @@
  * The UI keeps only the browser download wrapper.
  */
 
-import { SCREENER_METRIC_CONFIG } from '@rpe/engine';
+import { SCREENER_METRIC_CONFIG, SCORE_VERDICT_LABEL, computeScreenerScore } from '@rpe/engine';
 import type { ScreenerResults } from '@rpe/engine';
 import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from './format';
 
@@ -102,6 +102,13 @@ export function buildCsvRows(
 ): string[][] {
   const header = ['Group', 'Metric', ...scenarios.map((s) => s.name)];
 
+  // Verdict row up top (RPE-108) — go/no-go per scenario from the full scored set.
+  const verdictRow = [
+    'Score',
+    'Verdict',
+    ...resultsList.map((r) => SCORE_VERDICT_LABEL[computeScreenerScore(r).verdict]),
+  ];
+
   const dataRows = CSV_ROWS.flatMap((row) => {
     const values = resultsList.map((r) => r[row.key]);
     // Skip rows where every scenario returned null
@@ -112,5 +119,5 @@ export function buildCsvRows(
     return [[row.group, label, ...cells]];
   });
 
-  return [header, ...dataRows];
+  return [header, verdictRow, ...dataRows];
 }

--- a/packages/report/src/pdf.ts
+++ b/packages/report/src/pdf.ts
@@ -16,6 +16,7 @@
 
 import { PDFDocument, StandardFonts, rgb, type PDFFont, type PDFPage } from 'pdf-lib';
 import { fmtCurrency, fmtMultiplier, fmtPercent } from './format';
+import { SCORE_VERDICT_LABEL } from '@rpe/engine';
 import type { DealReport } from './report';
 
 const PAGE = { width: 595.28, height: 841.89 } as const; // A4 portrait, points
@@ -25,6 +26,7 @@ const LINE = 16;
 const INK = rgb(0.07, 0.07, 0.07);
 const MID = rgb(0.4, 0.4, 0.4);
 const PASS = rgb(0.09, 0.4, 0.2);
+const WARN = rgb(0.72, 0.52, 0.04);
 const FAIL = rgb(0.6, 0.11, 0.11);
 
 interface Cursor {
@@ -101,10 +103,12 @@ export async function reportToPdf(report: DealReport): Promise<Uint8Array> {
   c.y -= 8;
 
   // ── Score ────────────────────────────────────────────────────────────
-  text(c, `Score: ${report.score.passing} / ${report.score.total} metrics passing (${report.score.pct.toFixed(0)}%)`, {
+  const verdictColor =
+    report.score.verdict === 'pass' ? PASS : report.score.verdict === 'marginal' ? WARN : FAIL;
+  text(c, `Verdict: ${SCORE_VERDICT_LABEL[report.score.verdict]} — ${report.score.passing} / ${report.score.total} metrics passing (${report.score.pct.toFixed(0)}%)`, {
     size: 12,
     bold: true,
-    color: report.score.pct >= 75 ? PASS : report.score.pct >= 50 ? MID : FAIL,
+    color: verdictColor,
   });
   c.y -= 24;
 

--- a/packages/report/src/report.ts
+++ b/packages/report/src/report.ts
@@ -10,10 +10,13 @@
 import {
   evaluate,
   SCREENER_METRIC_CONFIG,
+  scoreVerdict,
+  SCORE_VERDICT_LABEL,
   type DealInputs,
   type MetricDirection,
   type ProFormaResults,
   type ProjectionYear,
+  type ScoreVerdict,
   type ScreenerResults,
 } from '@rpe/engine';
 import { CSV_ROWS, buildCsvRows, fmtMetricRaw, rowsToCsv } from './csv';
@@ -46,6 +49,8 @@ export interface DealReport {
     total: number;
     /** passing / total × 100, 0 when nothing is scoreable. */
     pct: number;
+    /** Go/no-go band (RPE-108): pass ≥75% · marginal ≥50% · fail below. */
+    verdict: ScoreVerdict;
   };
   metrics: ReportMetric[];
   /** Present only in pro-forma mode. */
@@ -103,6 +108,7 @@ export function buildReport(inputs: DealInputs, options: BuildReportOptions = {}
 
   const scored = metrics.filter((m) => m.signal === 'pass' || m.signal === 'fail');
   const passing = scored.filter((m) => m.signal === 'pass').length;
+  const pct = scored.length > 0 ? (passing / scored.length) * 100 : 0;
 
   return {
     meta: {
@@ -115,7 +121,8 @@ export function buildReport(inputs: DealInputs, options: BuildReportOptions = {}
     score: {
       passing,
       total: scored.length,
-      pct: scored.length > 0 ? (passing / scored.length) * 100 : 0,
+      pct,
+      verdict: scoreVerdict(pct),
     },
     metrics,
     proForma: isProForma(results)
@@ -140,6 +147,14 @@ export function reportToCsvRows(report: DealReport): string[][] {
   ) as unknown as ScreenerResults;
 
   const rows = buildCsvRows([{ name: 'Value' }], [screenerLike]);
+
+  // Score summary up top (RPE-108) — verdict + passing count.
+  rows.splice(
+    1,
+    0,
+    ['Score', 'Verdict', SCORE_VERDICT_LABEL[report.score.verdict]],
+    ['Score', 'Passing', `${report.score.passing} of ${report.score.total} (${report.score.pct.toFixed(0)}%)`],
+  );
 
   if (report.proForma !== null && report.proForma.projection.length > 0) {
     rows.push([]);

--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback, useEffect } from 'react';
-import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount, normalizeInputs } from '@rpe/engine';
+import { evaluate, SCREENER_METRIC_CONFIG, calcLoanAmount, normalizeInputs, scoreVerdict, evalSignal, SCORED_KEYS, computeScreenerScore, type ScoreVerdict } from '@rpe/engine';
+import { VerdictChip } from './components/VerdictChip';
 import type { DealInputs, ScreenerResults, ProFormaResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
 import { useScenarios } from './hooks/useScenarios';
@@ -50,14 +51,7 @@ function fmtMetric(key: MetricKey, value: number | null): string {
   return fmtNumber(value, dec);
 }
 
-function evalSignal(key: MetricKey, value: number | null): 'pass' | 'fail' | 'null' | 'neutral' {
-  if (value === null) return 'null';
-  const cfg = SCREENER_METRIC_CONFIG[key];
-  if (cfg.direction === 'none' || cfg.threshold === undefined) return 'neutral';
-  return cfg.direction === 'higher'
-    ? value >= cfg.threshold ? 'pass' : 'fail'
-    : value <= cfg.threshold ? 'pass' : 'fail';
-}
+// evalSignal is imported from @rpe/engine (RPE-108) — single source of truth for per-metric pass/fail.
 
 const SIGNAL_CLASS: Record<ReturnType<typeof evalSignal>, string> = {
   pass: 'text-pass',
@@ -141,14 +135,7 @@ function ResultGroup({ title, children }: { title: string; children: React.React
   );
 }
 
-/**
- * All scored metric keys (direction !== 'none') — used by the full ScoreCard in complex mode.
- */
-const SCORED_KEYS: MetricKey[] = (
-  Object.entries(SCREENER_METRIC_CONFIG) as [MetricKey, (typeof SCREENER_METRIC_CONFIG)[MetricKey]][]
-)
-  .filter(([, cfg]) => cfg.direction !== 'none')
-  .map(([key]) => key);
+// SCORED_KEYS (all metrics with a pass/fail threshold) is imported from @rpe/engine (RPE-108).
 
 /**
  * Scored keys visible in simple mode — intersection of SCORED_KEYS and SIMPLE_RESULT_KEYS.
@@ -171,25 +158,27 @@ function fmtThreshold(cfg: (typeof SCREENER_METRIC_CONFIG)[MetricKey]): string {
 }
 
 /**
- * Score = passing ÷ scored metrics (the visible subset in simple mode).
- * Single source of truth for both the full ScoreCard and the mobile
- * StickyScoreBar (RPE-112).
+ * Score = passing ÷ scored metrics (the visible subset in simple mode), via the
+ * engine's computeScreenerScore (single source of truth, RPE-108). The UI only
+ * picks the mode-specific key set; aggregation + verdict band live in @rpe/engine.
  */
 function computeScore(result: ScreenerResults, uiMode: UiMode) {
   const scoredKeys = uiMode === 'simple' ? SIMPLE_SCORED_KEYS : SCORED_KEYS;
-  const signals = scoredKeys.map((k) => evalSignal(k, result[k]));
-  const total = signals.filter((s) => s !== 'null').length;
-  const passing = signals.filter((s) => s === 'pass').length;
-  const pct = total > 0 ? (passing / total) * 100 : 0;
+  const { passing, total, pct } = computeScreenerScore(result, scoredKeys);
   return { scoredKeys, total, passing, pct };
 }
 
-/** Score band → Tailwind tokens. ≥75% green, ≥50% amber, below red. */
-function scoreBand(pct: number): { text: string; bg: string } {
-  if (pct >= 75) return { text: 'text-pass', bg: 'bg-pass' };
-  if (pct >= 50) return { text: 'text-warn', bg: 'bg-warn' };
-  return { text: 'text-fail', bg: 'bg-fail' };
+/** Score band → Tailwind tokens, keyed off the engine verdict (single source of truth, RPE-108). */
+function scoreBand(pct: number): { verdict: ScoreVerdict; text: string; bg: string } {
+  const verdict = scoreVerdict(pct);
+  const tokens =
+    verdict === 'pass' ? { text: 'text-pass', bg: 'bg-pass' } :
+    verdict === 'marginal' ? { text: 'text-warn', bg: 'bg-warn' } :
+    { text: 'text-fail', bg: 'bg-fail' };
+  return { verdict, ...tokens };
 }
+
+// VerdictChip is in ./components/VerdictChip (RPE-108), shared with ProFormaPanel.
 
 function ScoreCard({ result, uiMode = 'complex' }: { result: ScreenerResults; uiMode?: UiMode }) {
   const [explainOpen, setExplainOpen] = useState(false);
@@ -198,8 +187,11 @@ function ScoreCard({ result, uiMode = 'complex' }: { result: ScreenerResults; ui
 
   return (
     <div className="rounded border border-border bg-surface p-4">
-      <div className="flex items-baseline justify-between mb-2">
-        <span className="section-title text-xs">Score</span>
+      <div className="flex items-center justify-between mb-2">
+        <span className="flex items-center gap-2">
+          <span className="section-title text-xs">Score</span>
+          <VerdictChip pct={pct} />
+        </span>
         <span className={`num text-lg font-mono ${scoreColor}`}>
           {passing}<span className="text-lo text-sm">/{total}</span>
         </span>
@@ -271,12 +263,13 @@ function StickyScoreBar({ result, uiMode }: { result: ScreenerResults; uiMode: U
       className="no-print lg:hidden sticky top-0 z-20 flex min-h-[44px] items-center justify-between gap-4 border-b border-border bg-base px-5 py-2"
       aria-label={`Score: ${passing} of ${total} metrics passing. Jump to results.`}
     >
-      <span className="flex items-baseline gap-2">
+      <span className="flex items-center gap-2">
         <span className="section-title text-xs">Score</span>
         <span className={`num font-mono text-base ${band.text}`}>
           {passing}
           <span className="text-lo text-xs">/{total}</span>
         </span>
+        <VerdictChip pct={pct} />
       </span>
       <span className="flex max-w-[45%] flex-1 items-center gap-2">
         <span className="h-1 flex-1 overflow-hidden rounded-full bg-raised">
@@ -932,7 +925,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
           className="lg:overflow-y-auto p-5"
         >
           {proFormaMode && proFormaResults ? (
-            <ProFormaPanel results={proFormaResults} purchasePrice={activeNormalized.purchasePrice} />
+            <ProFormaPanel results={proFormaResults} purchasePrice={activeNormalized.purchasePrice} screenerPct={computeScore(activeResults, uiMode).pct} />
           ) : isComparing ? (
             <ComparisonPanel scenarios={scenarios} resultsList={resultsList} />
           ) : (

--- a/packages/ui/src/components/ComparisonPanel.tsx
+++ b/packages/ui/src/components/ComparisonPanel.tsx
@@ -1,8 +1,9 @@
 import { Fragment } from 'react';
-import { SCREENER_METRIC_CONFIG } from '@rpe/engine';
+import { SCREENER_METRIC_CONFIG, evalSignal, computeScreenerScore } from '@rpe/engine';
 import type { ScreenerResults } from '@rpe/engine';
 import { fmtCurrency, fmtPercent, fmtNumber, fmtMultiplier, NULL_DISPLAY } from '../utils/format';
 import type { Scenario } from '../state/scenarios';
+import { VerdictChip } from './VerdictChip';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -23,17 +24,7 @@ function fmtMetric(key: MetricKey, value: number | null): string {
   return fmtNumber(value, dec);
 }
 
-function evalSignal(
-  key: MetricKey,
-  value: number | null,
-): 'pass' | 'fail' | 'null' | 'neutral' {
-  if (value === null) return 'null';
-  const cfg = SCREENER_METRIC_CONFIG[key];
-  if (cfg.direction === 'none' || cfg.threshold === undefined) return 'neutral';
-  return cfg.direction === 'higher'
-    ? value >= cfg.threshold ? 'pass' : 'fail'
-    : value <= cfg.threshold ? 'pass' : 'fail';
-}
+// evalSignal is imported from @rpe/engine (RPE-108) — single source of truth.
 
 // ─── Best-value indices ───────────────────────────────────────────────────────
 
@@ -60,18 +51,8 @@ function bestIndices(key: MetricKey, values: (number | null)[]): Set<number> {
 
 // ─── Score card row ───────────────────────────────────────────────────────────
 
-const SCORED_KEYS: MetricKey[] = (
-  Object.entries(SCREENER_METRIC_CONFIG) as [MetricKey, (typeof SCREENER_METRIC_CONFIG)[MetricKey]][]
-)
-  .filter(([, cfg]) => cfg.direction !== 'none')
-  .map(([key]) => key);
-
-function scoreFor(result: ScreenerResults): { passing: number; total: number; pct: number } {
-  const signals = SCORED_KEYS.map((k) => evalSignal(k, result[k]));
-  const total = signals.filter((s) => s !== 'null').length;
-  const passing = signals.filter((s) => s === 'pass').length;
-  return { passing, total, pct: total > 0 ? (passing / total) * 100 : 0 };
-}
+// Per-scenario score (passing/total/pct + verdict) comes from @rpe/engine
+// computeScreenerScore (RPE-108) — no local re-implementation or band thresholds.
 
 // ─── Layout constants ─────────────────────────────────────────────────────────
 
@@ -163,9 +144,11 @@ export function ComparisonPanel({ scenarios, resultsList }: ComparisonPanelProps
               {/* empty corner */}
             </th>
             {scenarios.map((scenario, si) => {
-              const score = scoreFor(resultsList[si] ?? {} as ScreenerResults);
+              const score = computeScreenerScore(resultsList[si] ?? {} as ScreenerResults);
               const color =
-                score.pct >= 75 ? 'text-pass' : score.pct >= 50 ? 'text-warn' : 'text-fail';
+                score.verdict === 'pass' ? 'text-pass' : score.verdict === 'marginal' ? 'text-warn' : 'text-fail';
+              const barColor =
+                score.verdict === 'pass' ? 'bg-pass' : score.verdict === 'marginal' ? 'bg-warn' : 'bg-fail';
               return (
                 <th
                   key={scenario.id}
@@ -176,10 +159,13 @@ export function ComparisonPanel({ scenarios, resultsList }: ComparisonPanelProps
                     {score.passing}
                     <span className="text-lo text-xs">/{score.total}</span>
                   </div>
+                  <div className="mt-1 flex justify-center">
+                    <VerdictChip pct={score.pct} />
+                  </div>
                   {/* Mini progress bar */}
                   <div className="mt-1.5 h-0.5 rounded-full bg-raised overflow-hidden mx-2">
                     <div
-                      className={`h-full rounded-full ${score.pct >= 75 ? 'bg-pass' : score.pct >= 50 ? 'bg-warn' : 'bg-fail'}`}
+                      className={`h-full rounded-full ${barColor}`}
                       style={{ width: `${score.pct}%` }}
                     />
                   </div>

--- a/packages/ui/src/components/ProFormaPanel.tsx
+++ b/packages/ui/src/components/ProFormaPanel.tsx
@@ -8,6 +8,7 @@
 import type { ProFormaResults, ProjectionYear } from '@rpe/engine';
 import { fmtCurrency, fmtPercent, fmtMultiplier, NULL_DISPLAY } from '../utils/format';
 import { CashFlowChart, EquityBuildChart } from './ProFormaCharts';
+import { VerdictChip } from './VerdictChip';
 
 // ─── KPI card ─────────────────────────────────────────────────────────────────
 
@@ -162,9 +163,11 @@ function EmptyProForma() {
 export interface ProFormaPanelProps {
   results: ProFormaResults;
   purchasePrice: number;
+  /** Screener score % for the go/no-go verdict chip (RPE-108). */
+  screenerPct: number;
 }
 
-export function ProFormaPanel({ results, purchasePrice }: ProFormaPanelProps) {
+export function ProFormaPanel({ results, purchasePrice, screenerPct }: ProFormaPanelProps) {
   const { projection, irr, npv, equityMultiple, netSaleProceeds, totalProfit,
           salePrice, sellingCosts } = results;
 
@@ -177,6 +180,12 @@ export function ProFormaPanel({ results, purchasePrice }: ProFormaPanelProps) {
 
   return (
     <div className="flex flex-col gap-4">
+
+      {/* ── Verdict (RPE-108) ──────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2">
+        <span className="section-title text-xs">Hold-Period Analysis</span>
+        <VerdictChip pct={screenerPct} />
+      </div>
 
       {/* ── KPI summary ──────────────────────────────────────────────────── */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">

--- a/packages/ui/src/components/VerdictChip.tsx
+++ b/packages/ui/src/components/VerdictChip.tsx
@@ -1,0 +1,20 @@
+/**
+ * Go/no-go verdict chip (RPE-108) — Pass / Marginal / Fail derived from the
+ * engine band thresholds (scoreVerdict, the single source of truth). Outlined
+ * pill in the verdict hue; theme-aware via the color tokens. Shared by the
+ * ScoreCard, the mobile sticky bar, and the Pro-Forma header.
+ */
+import { scoreVerdict, SCORE_VERDICT_LABEL } from '@rpe/engine';
+
+const VERDICT_TEXT = { pass: 'text-pass', marginal: 'text-warn', fail: 'text-fail' } as const;
+
+export function VerdictChip({ pct, className = '' }: { pct: number; className?: string }) {
+  const verdict = scoreVerdict(pct);
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border border-current px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${VERDICT_TEXT[verdict]} ${className}`}
+    >
+      {SCORE_VERDICT_LABEL[verdict]}
+    </span>
+  );
+}


### PR DESCRIPTION
## RPE-108 — go/no-go verdict chip

The headline score ("5/14") forced interpretation; this adds a **Pass / Marginal / Fail** verdict chip for at-a-glance triage, with the band logic as a single source of truth in `@rpe/engine`.

### Engine (SoT) — `packages/engine/src/score.ts`
- `scoreVerdict(pct)`: pass ≥75 · marginal ≥50 · fail below.
- Promoted `evalSignal` + `SCORED_KEYS` + `computeScreenerScore` from the UI so the score calc + bands live in one place.
- **12 unit tests** incl. the 49/50/74/75 band boundaries.

### UI
- Shared `VerdictChip` rendered in the **ScoreCard** (Simple + Complex screener), the **mobile sticky bar** (RPE-112), and the **Pro-Forma** header.
- `scoreBand` + `computeScore` now derive from the engine — no more hardcoded 75/50 or duplicated aggregation in the UI. Theme-aware tokens.

### Report — CSV / Print / PDF export header
- `DealReport.score` gains `verdict`; the canonical CSV and toolbar CSV get a verdict row; the PDF header shows the verdict and routes its band through the engine (removing a duplicated 75/50). Print is covered by the rendered chip.

### AC coverage
- ✅ Chip in Score header, Simple + Complex, Screener + Pro-Forma
- ✅ Bands reuse existing thresholds — single source of truth in `packages/engine`
- ✅ Theme-aware color tokens
- ✅ Included in CSV / Print / PDF export header
- ✅ Engine unit tests assert band boundaries (49/50/74/75)

### Verification (browser preview)
Chip shows **Fail** (5/14 = 36%) in the ScoreCard, sticky bar, and Pro-Forma header; correctly hidden per mode (exactly 1 chip in Pro-Forma; ScoreCard + sticky in Screener). Gate green: **977 tests / 1 skipped, all builds**.

Note: the canonical report/export verdict uses the full (complex) scored set, so a report exported while viewing Simple mode reflects the complete metric set.

Jira: https://lowermedia.atlassian.net/browse/RPE-108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
