### PR TITLE
RPE-109: feat(ui): pin decision-driving metrics in a Key Metrics strip

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -135,6 +135,59 @@ function ResultGroup({ title, children }: { title: string; children: React.React
   );
 }
 
+/**
+ * RPE-109 — "Key metrics" strip. Pins the decision-driving metrics (Cash Flow,
+ * DSCR, Cash-on-Cash, Cap Rate) above the full grouped list so a buy/pass call
+ * doesn't require reading every row. Same pass/fail signals as the list; these
+ * metrics also remain in their groups below. Null metrics (e.g. a cash purchase
+ * has no DSCR) are dropped from the strip.
+ */
+const KEY_METRICS: { key: MetricKey; label?: string }[] = [
+  { key: 'cashFlowMonthly', label: 'Cash Flow / mo' },
+  { key: 'dscr' },
+  { key: 'cocRoi' },
+  { key: 'capRate' },
+];
+
+function KeyMetricCard({ metricKey, result, label }: { metricKey: MetricKey; result: ScreenerResults; label?: string }) {
+  const cfg = SCREENER_METRIC_CONFIG[metricKey];
+  const signal = evalSignal(metricKey, result[metricKey]);
+  return (
+    <div className="flex min-w-0 flex-col gap-1 rounded border border-border bg-surface px-3 py-2.5">
+      <span className="flex items-center gap-1.5">
+        <span className={`shrink-0 w-1.5 h-1.5 rounded-full ${DOT_CLASS[signal]}`} aria-hidden="true" />
+        <span
+          className="truncate rounded-sm text-[10px] uppercase tracking-widest text-lo outline-none focus-visible:ring-1 focus-visible:ring-accent"
+          tabIndex={0}
+          title={cfg.description}
+          aria-label={`${label ?? cfg.label}: ${cfg.description}`}
+        >
+          {label ?? cfg.label}
+        </span>
+      </span>
+      <span className={`num font-mono text-base tabular-nums ${SIGNAL_CLASS[signal]}`}>
+        {fmtMetric(metricKey, result[metricKey])}
+      </span>
+    </div>
+  );
+}
+
+/** Decision-driving metrics pinned above the full list (RPE-109). */
+function KeyMetrics({ result }: { result: ScreenerResults }) {
+  const shown = KEY_METRICS.filter(({ key }) => result[key] !== null);
+  if (shown.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="section-title text-xs">Key Metrics</h3>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {shown.map(({ key, label }) => (
+          <KeyMetricCard key={key} metricKey={key} result={result} label={label} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // SCORED_KEYS (all metrics with a pass/fail threshold) is imported from @rpe/engine (RPE-108).
 
 /**
@@ -363,6 +416,9 @@ function ResultsPanel({
   return (
     <div className="flex flex-col gap-4">
       <ScoreCard result={results} uiMode={uiMode} />
+
+      {/* ── Key metrics strip (RPE-109) ──────────────────────────────────────── */}
+      <KeyMetrics result={results} />
 
       {/* ── Assumptions accordion (simple mode, RPE-119) ─────────────────────── */}
       {simple && (


### PR DESCRIPTION
## RPE-109 — surface decision-driving metrics (lightweight)

The equal-weight pass/fail score buries the metrics that actually drive a buy/pass call. Per grooming, took the **lightweight surfacing** approach (weighted-score option deferred).

### Change
A **"Key Metrics" strip** above the full grouped list, surfacing the four decision-drivers — **Cash Flow / mo, DSCR, Cash-on-Cash, Cap Rate** — as prominent cards. Reuses the existing pass/fail signals (`evalSignal` + `SIGNAL_CLASS`/`DOT_CLASS`) — no scoring-logic change. Null metrics (e.g. cash purchase → no DSCR) drop out; the metrics also remain in their groups below.

### AC coverage
- ✅ Decision-driving metrics visually distinguished from the rest
- ✅ No regression to per-metric pass/fail display or thresholds (full list unchanged; gate green)
- ✅ Banding consistent with RPE-108 (same signals)
- ➖ Weighting ACs N/A (lightweight approach chosen in grooming)

### Verification (browser preview)
Complex + Simple screener: strip shows the 4 drivers with correct signal colors (default deal: all fail). Gate green: **977 tests**, all builds.

Jira: https://lowermedia.atlassian.net/browse/RPE-109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
