### PR TITLE
RPE-105: feat: cap rate "all-in basis" toggle (price + rehab + out-of-pocket closing)

### DIFF
--- a/packages/engine/src/directions.ts
+++ b/packages/engine/src/directions.ts
@@ -112,7 +112,7 @@ export const SCREENER_METRIC_CONFIG: Readonly<
     direction: 'higher',
     threshold: 5,
     label: 'Cap Rate',
-    description: 'NOI ÷ purchase price. Market-dependent; 5% is a common minimum.',
+    description: 'NOI ÷ purchase price (or all-in cost — price + rehab + out-of-pocket closing — when the all-in basis toggle is on). Market-dependent; 5% is a common minimum.',
     unit: '%',
     decimals: 2,
   },

--- a/packages/engine/src/screener.ts
+++ b/packages/engine/src/screener.ts
@@ -120,9 +120,15 @@ export function calcScreener(inputs: DealInputs): ScreenerResults {
   const noiMonthly = egi - opExMonthly;
   const noiAnnual = noiMonthly * 12;
 
+  // ── Cost basis (shared by cap rate + total cash invested) ─────────────────
+  const closingCostsOut = inputs.rollClosingCostsIntoLoan ? 0 : inputs.closingCosts;
+  const rehab = inputs.rehab ?? 0;
+
   // ── Cap rate ──────────────────────────────────────────────────────────────
-  // NOI_annual / purchasePrice × 100
-  const capRate = (noiAnnual / purchasePrice) * 100;
+  // NOI_annual / basis × 100. Basis is purchasePrice by default, or the all-in
+  // cost (purchasePrice + rehab + out-of-pocket closing) when capRateAllIn (RPE-105).
+  const capRateBasis = inputs.capRateAllIn ? purchasePrice + rehab + closingCostsOut : purchasePrice;
+  const capRate = (noiAnnual / capRateBasis) * 100;
 
   // ── Cash flow ─────────────────────────────────────────────────────────────
   // Monthly: NOI_monthly − mortgagePayment (if no loan, CF = NOI)
@@ -133,8 +139,6 @@ export function calcScreener(inputs: DealInputs): ScreenerResults {
   // ── Total cash invested ───────────────────────────────────────────────────
   // downPayment + closingCosts (if not rolled into loan) + rehab
   const downPayment = purchasePrice * (inputs.percentDown / 100);
-  const closingCostsOut = inputs.rollClosingCostsIntoLoan ? 0 : inputs.closingCosts;
-  const rehab = inputs.rehab ?? 0;
   const totalCashInvested = downPayment + closingCostsOut + rehab;
 
   // ── CoC ROI ───────────────────────────────────────────────────────────────

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -48,6 +48,12 @@ export interface DealInputs {
   closingCosts: number;
   rollClosingCostsIntoLoan: boolean;
   rehab?: number;
+  /**
+   * RPE-105 — when true, cap rate divides NOI by the all-in cost
+   * (purchasePrice + rehab + out-of-pocket closing) instead of purchasePrice.
+   * Optional; defaults to false (purchase-price basis, unchanged).
+   */
+  capRateAllIn?: boolean;
 
   // ── Income ─────────────────────────────────────────────────────────────────
   /** Monthly gross rent (gross potential rent before vacancy). */

--- a/packages/engine/src/validate.ts
+++ b/packages/engine/src/validate.ts
@@ -72,6 +72,7 @@ export function normalizeInputs(raw: DealInputs): DealInputs {
     rollClosingCostsIntoLoan: Boolean(raw.rollClosingCostsIntoLoan),
 
     rehab: raw.rehab !== undefined ? clampNonNeg(safeNum(raw.rehab)) : undefined,
+    capRateAllIn: Boolean(raw.capRateAllIn),
 
     grossRent: clampNonNeg(safeNum(raw.grossRent)),
     otherIncome:

--- a/packages/engine/tests/screener.test.ts
+++ b/packages/engine/tests/screener.test.ts
@@ -64,6 +64,29 @@ function refDeal(overrides: Partial<DealInputs> = {}): DealInputs {
   };
 }
 
+// ─── Cap rate basis (RPE-105) ─────────────────────────────────────────────────
+
+describe('Cap rate all-in basis (RPE-105)', () => {
+  it('defaults to purchase-price basis (unchanged by rehab/closing)', () => {
+    expect(r(calcScreener(refDeal({ rehab: 20_000 })).capRate!)).toBe(6.27);
+  });
+
+  it('all-in basis includes rehab + out-of-pocket closing', () => {
+    // basis = 200,000 + 20,000 rehab + 4,000 closing (not rolled) = 224,000
+    expect(r(calcScreener(refDeal({ rehab: 20_000, capRateAllIn: true })).capRate!)).toBe(5.6);
+  });
+
+  it('all-in basis excludes closing when it is rolled into the loan', () => {
+    // basis = 200,000 + 20,000 rehab + 0 closing = 220,000
+    const res = calcScreener(refDeal({ rehab: 20_000, capRateAllIn: true, rollClosingCostsIntoLoan: true }));
+    expect(r(res.capRate!)).toBe(5.7);
+  });
+
+  it('all-in with no rehab and rolled closing equals the price basis', () => {
+    expect(r(calcScreener(refDeal({ capRateAllIn: true, rollClosingCostsIntoLoan: true })).capRate!)).toBe(6.27);
+  });
+});
+
 // ─── EGI ─────────────────────────────────────────────────────────────────────
 
 describe('EGI', () => {

--- a/packages/ui/src/components/inputs/DealInputsForm.tsx
+++ b/packages/ui/src/components/inputs/DealInputsForm.tsx
@@ -180,6 +180,11 @@ export function DealInputsForm({
               emptyZero
               hint="Added to total cash invested; not financed"
             />
+            <ToggleInput
+              label="Cap Rate on All-In Basis"
+              value={state.capRateAllIn ?? false}
+              onChange={(v) => dispatch({ type: 'SET_BOOL', field: 'capRateAllIn', value: v })}
+            />
           </>
         )}
       </InputSection>

--- a/packages/ui/src/state/dealReducer.ts
+++ b/packages/ui/src/state/dealReducer.ts
@@ -26,7 +26,7 @@ type NumericDealKey =
   | 'discountRatePct';
 
 /** All top-level DealInputs keys that hold a boolean (or undefined boolean). */
-type BooleanDealKey = 'rollClosingCostsIntoLoan' | 'capExInNOI';
+type BooleanDealKey = 'rollClosingCostsIntoLoan' | 'capExInNOI' | 'capRateAllIn';
 
 // ─── Actions ─────────────────────────────────────────────────────────────────
 

--- a/packages/ui/src/state/defaultInputs.ts
+++ b/packages/ui/src/state/defaultInputs.ts
@@ -13,6 +13,7 @@ export const DEFAULT_INPUTS: DealInputs = {
   closingCosts: 6_000,
   rollClosingCostsIntoLoan: false,
   rehab: 0,
+  capRateAllIn: false,
   grossRent: 2_200,
   otherIncome: 0,
   vacancyPct: 5,

--- a/packages/ui/src/state/uiMode.ts
+++ b/packages/ui/src/state/uiMode.ts
@@ -57,6 +57,7 @@ export const INPUT_TIER: Readonly<Record<InputFieldKey, ComplexityTier>> = {
   closingCosts: 'complex',
   rollClosingCostsIntoLoan: 'complex',
   rehab: 'complex',
+  capRateAllIn: 'complex',
   otherIncome: 'complex',
   capExInNOI: 'complex',
   // DealExpenses sub-fields:


### PR DESCRIPTION
## RPE-105 — cap rate "all-in basis" toggle

Cap rate divided NOI by `purchasePrice` only, overstating yield for BRRRR / heavy-rehab deals. Add an optional **all-in basis**: NOI ÷ (`purchasePrice` + `rehab` + closing costs not rolled into the loan). **Defaults to the purchase-price basis**, so existing results are unchanged until the toggle is flipped.

### Engine
- `DealInputs.capRateAllIn` (optional, normalized to `false`); `screener.ts` computes `capRateBasis` and divides NOI by it.
- 4 tests: default unchanged by rehab/closing; all-in includes rehab + out-of-pocket closing; rolled closing excluded; no-cost all-in equals the price basis.
- The cap-rate metric description documents both bases (the in-app calc spec — there's no separate calc doc).

### UI
- "Cap Rate on All-In Basis" toggle in the complex Acquisition section (`BooleanDealKey` + `DEFAULT_INPUTS` + `INPUT_TIER` wiring). Complex-only; simple mode stays on the price basis (`applySimpleBaselines` drops the flag).

### AC coverage
- ✅ Optional toggle; default = current (purchase-price) behavior
- ✅ Basis = price + rehab + out-of-pocket closing
- ✅ Surfaced in the metric tooltip
- ✅ Engine tests
- ✅ Documented in the calc spec (metric description)

### Verification (browser preview)
Toggling moves the default deal **4.40% → 4.31%** (300k → 306k basis with $6k closing not rolled); tooltip reflects the all-in basis. Gate green: **981 tests**, all builds.

Jira: https://lowermedia.atlassian.net/browse/RPE-105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
