### PR TITLE
RPE-110: feat(ui): default first-run to Simple + persist last-used mode

### DIFF
--- a/packages/ui/src/Evaluator.tsx
+++ b/packages/ui/src/Evaluator.tsx
@@ -4,7 +4,8 @@ import { VerdictChip } from './components/VerdictChip';
 import type { DealInputs, ScreenerResults, ProFormaResults } from '@rpe/engine';
 import { useSavedDeals } from './hooks/useSavedDeals';
 import { useScenarios } from './hooks/useScenarios';
-import { buildShareUrl } from './utils/shareUrl';
+import { buildShareUrl, parseShareParam, parseShareMode } from './utils/shareUrl';
+import { resolveInitialMode, persistMode, type ModePreference } from './state/modePreference';
 import { exportToCsv } from './utils/exportCsv';
 import { AdSlot } from './components/AdSlot';
 import { DealInputsForm } from './components/inputs/DealInputsForm';
@@ -590,11 +591,11 @@ function UiModeToggle({ uiMode, onChange }: UiModeToggleProps) {
 
 // ─── Share button ─────────────────────────────────────────────────────────────
 
-function ShareButton({ inputs }: { inputs: DealInputs }) {
+function ShareButton({ inputs, uiMode, proFormaMode }: { inputs: DealInputs; uiMode: UiMode; proFormaMode: boolean }) {
   const [copied, setCopied] = useState(false);
 
   const handleShare = useCallback(async () => {
-    const url = buildShareUrl(inputs);
+    const url = buildShareUrl(inputs, undefined, { uiMode, proFormaMode });
     try {
       await navigator.clipboard.writeText(url);
     } catch {
@@ -604,7 +605,7 @@ function ShareButton({ inputs }: { inputs: DealInputs }) {
     }
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
-  }, [inputs]);
+  }, [inputs, uiMode, proFormaMode]);
 
   return (
     <button
@@ -678,7 +679,16 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
 
   const { deals, save, rename, remove } = useSavedDeals();
 
-  const [proFormaMode, setProFormaMode] = useState(false);
+  /**
+   * Initial view mode (RPE-110): first-run defaults to Simple / Screener (the
+   * fast triage path); thereafter the last-used mode is restored from
+   * localStorage. A shared-scenario link (?s=) may carry its own mode (?m=)
+   * that overrides this.
+   */
+  const [initialMode] = useState<ModePreference>(() =>
+    resolveInitialMode(parseShareParam() !== null ? parseShareMode() : null),
+  );
+  const [proFormaMode, setProFormaMode] = useState(initialMode.proFormaMode);
 
   /**
    * UI complexity mode — 'simple' hides advanced inputs and results and
@@ -686,7 +696,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
    * ComparisonPanel and ProFormaPanel are not uiMode-aware (E8 does not
    * require them to be).
    */
-  const [uiMode, setUiMode] = useState<UiMode>('complex');
+  const [uiMode, setUiMode] = useState<UiMode>(initialMode.uiMode);
 
   /**
    * Switch UI mode. Switching to simple also forces screener mode because
@@ -694,9 +704,10 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
    */
   const handleSetUiMode = useCallback((mode: UiMode) => {
     setUiMode(mode);
-    if (mode === 'simple' && proFormaMode) {
-      setProFormaMode(false);
-    }
+    // Pro-forma requires complex inputs; switching to simple forces screener.
+    const nextProForma = mode === 'simple' ? false : proFormaMode;
+    if (nextProForma !== proFormaMode) setProFormaMode(nextProForma);
+    persistMode({ uiMode: mode, proFormaMode: nextProForma }); // RPE-110
   }, [proFormaMode]);
 
   const [showSettings, setShowSettings] = useState(false);
@@ -768,6 +779,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
   /** Seed pro-forma defaults into state the first time the user enters pro-forma mode. */
   const handleSetProFormaMode = useCallback((pf: boolean) => {
     setProFormaMode(pf);
+    persistMode({ uiMode, proFormaMode: pf }); // RPE-110
     if (pf) {
       // Only dispatch defaults for fields that are currently undefined/absent so we
       // don't overwrite values the user has already entered.
@@ -782,7 +794,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
       if (activeInputs.sellingCostsPct === undefined)
         dispatchToActive({ type: 'SET_NUMBER', field: 'sellingCostsPct', value: 6 });
     }
-  }, [activeInputs, dispatchToActive]);
+  }, [activeInputs, dispatchToActive, uiMode]);
 
   /**
    * Evaluate all scenarios. In simple mode each scenario's inputs are run
@@ -887,7 +899,7 @@ function EvaluatorInner({ adConfig, authEnabled }: { adConfig?: AdConfig; authEn
             onDelete={remove}
             onRename={rename}
           />
-          <ShareButton inputs={activeInputs} />
+          <ShareButton inputs={activeInputs} uiMode={uiMode} proFormaMode={proFormaMode} />
           <button
             type="button"
             onClick={() => exportToCsv(scenarios, resultsList)}

--- a/packages/ui/src/state/modePreference.ts
+++ b/packages/ui/src/state/modePreference.ts
@@ -1,0 +1,59 @@
+/**
+ * RPE-110 — last-used view mode (uiMode + proFormaMode) persistence.
+ *
+ * First-run default is Simple / Screener (the fast triage path); thereafter the
+ * last-used mode is restored. Persisted to localStorage, so it survives across
+ * sessions for both anonymous and signed-in users on the same browser. (Account-
+ * scoped cross-device sync would need a server-side preference store — follow-up.)
+ *
+ * A shared-scenario link (?s=) may carry its own mode (?m=) which overrides the
+ * persisted default at the call site — see resolveInitialMode().
+ */
+
+import type { UiMode } from './uiMode';
+
+export const MODE_STORAGE_KEY = 'rpe_mode';
+
+export interface ModePreference {
+  uiMode: UiMode;
+  proFormaMode: boolean;
+}
+
+const FIRST_RUN_DEFAULT: ModePreference = { uiMode: 'simple', proFormaMode: false };
+
+function isUiMode(value: unknown): value is UiMode {
+  return value === 'simple' || value === 'complex';
+}
+
+/** Stored last-used mode, or null when the user never set one. */
+export function getStoredMode(): ModePreference | null {
+  try {
+    const raw = localStorage.getItem(MODE_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<ModePreference>;
+    if (!isUiMode(parsed.uiMode)) return null;
+    // Pro-forma requires complex inputs; never restore simple + pro-forma.
+    const proFormaMode = parsed.uiMode === 'complex' && Boolean(parsed.proFormaMode);
+    return { uiMode: parsed.uiMode, proFormaMode };
+  } catch {
+    return null; // private browsing / SSR
+  }
+}
+
+/**
+ * Initial mode for a fresh load. A shared-link mode (when present) overrides the
+ * persisted default; otherwise the stored mode, falling back to first-run Simple.
+ */
+export function resolveInitialMode(sharedMode?: ModePreference | null): ModePreference {
+  if (sharedMode) return sharedMode;
+  return getStoredMode() ?? FIRST_RUN_DEFAULT;
+}
+
+/** Persist the last-used mode. */
+export function persistMode(pref: ModePreference): void {
+  try {
+    localStorage.setItem(MODE_STORAGE_KEY, JSON.stringify(pref));
+  } catch {
+    // storage unavailable — mode still applies for this session
+  }
+}

--- a/packages/ui/src/utils/shareUrl.ts
+++ b/packages/ui/src/utils/shareUrl.ts
@@ -5,6 +5,28 @@ import type { DealInputs } from '@rpe/engine';
 /** URL query-param key used for the encoded share payload. */
 export const SHARE_PARAM = 's';
 
+/** URL query-param key for the encoded view mode (RPE-110). */
+export const MODE_PARAM = 'm';
+
+/** View mode carried by a share link: uiMode + pro-forma flag. */
+export type ShareMode = { uiMode: 'simple' | 'complex'; proFormaMode: boolean };
+
+/** Encode a view mode as a 2-char code: [s|c][s|p]. */
+function encodeMode(mode: ShareMode): string {
+  return `${mode.uiMode === 'simple' ? 's' : 'c'}${mode.proFormaMode ? 'p' : 's'}`;
+}
+
+/**
+ * Parse the view mode from the `?m=` param of a shared link (RPE-110).
+ * Returns null when absent or malformed. Pro-forma is only valid in complex mode.
+ */
+export function parseShareMode(search?: string): ShareMode | null {
+  const qs = search ?? (typeof window !== 'undefined' ? window.location.search : '');
+  const code = new URLSearchParams(qs).get(MODE_PARAM);
+  if (code !== 'ss' && code !== 'cs' && code !== 'cp') return null;
+  return { uiMode: code[0] === 's' ? 'simple' : 'complex', proFormaMode: code === 'cp' };
+}
+
 // ─── Encode / decode ──────────────────────────────────────────────────────────
 
 /**
@@ -58,7 +80,7 @@ export function parseShareParam(search?: string): DealInputs | null {
  *
  * Returns `''` if no URL can be constructed (e.g. SSR without `base`).
  */
-export function buildShareUrl(inputs: DealInputs, base?: string): string {
+export function buildShareUrl(inputs: DealInputs, base?: string, mode?: ShareMode): string {
   let url: URL;
   try {
     url = new URL(base ?? (typeof window !== 'undefined' ? window.location.href : ''));
@@ -66,5 +88,6 @@ export function buildShareUrl(inputs: DealInputs, base?: string): string {
     return '';
   }
   url.searchParams.set(SHARE_PARAM, encodeInputs(inputs));
+  if (mode) url.searchParams.set(MODE_PARAM, encodeMode(mode));
   return url.toString();
 }

--- a/packages/ui/tests/modePreference.test.ts
+++ b/packages/ui/tests/modePreference.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+/**
+ * RPE-110 — last-used view mode persistence + first-run Simple default.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getStoredMode,
+  resolveInitialMode,
+  persistMode,
+  MODE_STORAGE_KEY,
+} from '../src/state/modePreference';
+
+beforeEach(() => localStorage.clear());
+
+describe('modePreference (RPE-110)', () => {
+  it('first run (no stored, no shared) defaults to Simple / Screener', () => {
+    expect(getStoredMode()).toBeNull();
+    expect(resolveInitialMode()).toEqual({ uiMode: 'simple', proFormaMode: false });
+  });
+
+  it('persist + restore round-trips the last-used mode', () => {
+    persistMode({ uiMode: 'complex', proFormaMode: true });
+    expect(getStoredMode()).toEqual({ uiMode: 'complex', proFormaMode: true });
+    expect(resolveInitialMode()).toEqual({ uiMode: 'complex', proFormaMode: true });
+  });
+
+  it('never restores simple + pro-forma (pro-forma needs complex inputs)', () => {
+    localStorage.setItem(MODE_STORAGE_KEY, JSON.stringify({ uiMode: 'simple', proFormaMode: true }));
+    expect(getStoredMode()).toEqual({ uiMode: 'simple', proFormaMode: false });
+  });
+
+  it('ignores malformed stored values', () => {
+    localStorage.setItem(MODE_STORAGE_KEY, 'not json');
+    expect(getStoredMode()).toBeNull();
+    localStorage.setItem(MODE_STORAGE_KEY, JSON.stringify({ uiMode: 'banana' }));
+    expect(getStoredMode()).toBeNull();
+  });
+
+  it('a shared-link mode overrides the persisted default', () => {
+    persistMode({ uiMode: 'complex', proFormaMode: false });
+    expect(resolveInitialMode({ uiMode: 'simple', proFormaMode: false })).toEqual({
+      uiMode: 'simple',
+      proFormaMode: false,
+    });
+  });
+});

--- a/packages/ui/tests/scoreExplanation.test.tsx
+++ b/packages/ui/tests/scoreExplanation.test.tsx
@@ -22,6 +22,9 @@ describe('ScoreCard explanation disclosure (RPE-70)', () => {
   });
 
   function openDisclosure() {
+    // RPE-110: first-run default is now Simple; this suite asserts the full
+    // complex-mode scored-metric list, so pin complex mode before rendering.
+    localStorage.setItem('rpe_mode', JSON.stringify({ uiMode: 'complex', proFormaMode: false }));
     render(<Evaluator />);
     const toggle = screen.getAllByRole('button', { name: /How is this scored/ })[0];
     expect(toggle.getAttribute('aria-expanded')).toBe('false');

--- a/packages/ui/tests/shareUrl.test.ts
+++ b/packages/ui/tests/shareUrl.test.ts
@@ -3,11 +3,45 @@ import {
   encodeInputs,
   decodeInputs,
   parseShareParam,
+  parseShareMode,
   buildShareUrl,
   SHARE_PARAM,
 } from '../src/utils/shareUrl';
 import { DEFAULT_INPUTS } from '../src/state/defaultInputs';
 import type { DealInputs } from '@rpe/engine';
+
+// ─── view mode (RPE-110) ──────────────────────────────────────────────────────
+
+describe('parseShareMode / buildShareUrl mode (RPE-110)', () => {
+  const B = 'https://x.test/';
+
+  it('encodes the view mode in the m param', () => {
+    expect(buildShareUrl(DEFAULT_INPUTS, B, { uiMode: 'simple', proFormaMode: false })).toContain('m=ss');
+    expect(buildShareUrl(DEFAULT_INPUTS, B, { uiMode: 'complex', proFormaMode: false })).toContain('m=cs');
+    expect(buildShareUrl(DEFAULT_INPUTS, B, { uiMode: 'complex', proFormaMode: true })).toContain('m=cp');
+  });
+
+  it('omits the m param when no mode is given', () => {
+    expect(buildShareUrl(DEFAULT_INPUTS, B)).not.toContain('m=');
+  });
+
+  it('parses the mode codes', () => {
+    expect(parseShareMode('?m=ss')).toEqual({ uiMode: 'simple', proFormaMode: false });
+    expect(parseShareMode('?m=cs')).toEqual({ uiMode: 'complex', proFormaMode: false });
+    expect(parseShareMode('?m=cp')).toEqual({ uiMode: 'complex', proFormaMode: true });
+  });
+
+  it('returns null for an absent or malformed mode', () => {
+    expect(parseShareMode('?s=abc')).toBeNull();
+    expect(parseShareMode('?m=zz')).toBeNull();
+    expect(parseShareMode('?m=sp')).toBeNull();
+  });
+
+  it('round-trips through buildShareUrl', () => {
+    const url = buildShareUrl(DEFAULT_INPUTS, B, { uiMode: 'complex', proFormaMode: true });
+    expect(parseShareMode(new URL(url).search)).toEqual({ uiMode: 'complex', proFormaMode: true });
+  });
+});
 
 // ─── encodeInputs / decodeInputs ──────────────────────────────────────────────
 


### PR DESCRIPTION
## RPE-110 — default Simple + persist last-used mode

First load dropped users into Complex (14 metrics). For a triage tool the fast path (Simple) should be the default; returning users also lost their mode between sessions.

### Change
- **`modePreference` state** (new): first-run defaults to **Simple / Screener**; the last-used mode (`uiMode` + `proFormaMode`) is persisted to localStorage and restored on load. Pro-forma is never restored in simple mode (it needs complex inputs).
- **Share links encode the mode** (`?m=ss|cs|cp`); a scenario opened via a shared link uses that mode, overriding the persisted default.
- `Evaluator` initializes from `resolveInitialMode(shared ?? stored ?? Simple)` and persists on every mode change.
- Tests: `modePreference` (5) + `shareUrl` mode (5); updated the `scoreExplanation` suite to pin complex (it asserts the full 14-metric list, no longer the default).

### AC coverage
- ✅ First-run (no saved pref, no shared param) defaults to **Simple**
- ✅ Last-used mode (Simple/Complex, Screener/Pro-Forma) persisted + restored
- ✅ Shared link respects the mode encoded in the link, overriding the persisted default
- ⚠️ Persistence works for anonymous + signed-in (localStorage, **per-browser**). **Account-scoped cross-device sync is deferred** — it needs a server-side preference store (new `/v1` endpoint + DB); flagged as a follow-up. localStorage covers signed-in users on the same browser.

### Verification (browser preview)
First-run with no stored mode → Simple active. Toggle Complex → `rpe_mode` persisted → reload → Complex restored. Gate green: **991 tests**, all builds.

Jira: https://lowermedia.atlassian.net/browse/RPE-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
